### PR TITLE
Adding the option to open the url links in a popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Here is the list of available arguments and its usage:
 | help  | show the available commands  |  false |
 | version  | show the version number  |  false |
 | disableDesktopNotifications | disable electron-desktop-notifications extension | false |
+| openLinksInExternalBrowser | open links in external browser | true |
 | partition | [BrowserWindow](https://electronjs.org/docs/api/browser-window) webpreferences partition  | persist:teams-4-linux |
 | webDebug  | start with the browser developer tools open  |  false |
 | url  | url to open |  https://teams.microsoft.com/ |

--- a/app/lib/config/index.js
+++ b/app/lib/config/index.js
@@ -12,6 +12,11 @@ function argv(configPath) {
         describe: 'disable electron-native-notifications',
         type: 'boolean'
       },
+      openLinksInExternalBrowser: {
+        default: true,
+        describe: 'open links in external browser',
+        type: 'boolean'
+      },
       url: {
         default: 'https://teams.microsoft.com/',
         describe: 'Microsoft Teams URL',

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -83,10 +83,12 @@ app.on('ready', () => {
     });
   }
   
-  window.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
-    shell.openExternal(url);
-  });
+  if (config.openLinksInExternalBrowser) {
+    window.webContents.on('new-window', (event, url) => {
+      event.preventDefault();
+      shell.openExternal(url);
+    });
+  }
 
   window.webContents.on('login', (event, request, authInfo, callback) => {
     event.preventDefault();

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Microsoft Teams for Linux",
   "main": "lib/index.js",
   "author": "Ivelin Velkov <ivelin.velkov@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
   "keywords": [


### PR DESCRIPTION
Adding the option to open the url links in a popup instead of a new browser window as this affects oauth. 

Defaulting to opening to the external browser as the solution is not fully reliable (you still need to close the popup window after authentication)

This release is to try to fix issue #23 but might also address #4 

`teams --openLinksInExternalBrowser=false`