### PR TITLE
Implemented reliable tray updates

### DIFF
--- a/app/browser/activityManager.js
+++ b/app/browser/activityManager.js
@@ -1,0 +1,68 @@
+/* global angular, teamspace */
+const TrayIconRenderer = require('./trayIconRenderer');
+
+class ActivityManager {
+
+	constructor(ipc, baseIconPath) {
+		this.ipc = ipc;
+		this.subscribed = false;
+		this.iconRenderer = new TrayIconRenderer(baseIconPath);
+	}
+
+	handleNewActivityCountUpdate(count) {
+		this.iconRenderer.render(count).then(icon => {
+			this.ipc.send('tray-update', {
+				icon: icon,
+				flash: (count > 0)
+			});
+		});
+	}
+
+	subscribeToNewActivitiyCountUpdate(callback) {
+		if (this.subscribed) {
+			return;
+		}
+	
+		if (typeof angular === 'undefined') {
+			return;
+		}
+	
+		const controller = angular.element(document.documentElement).controller();
+		
+		if (!controller) {
+			return;
+		}
+
+		const onChange = () => {
+			const count = 
+				controller.bellNotificationsService.getNewActivitiesCount() +
+				controller.chatListService.getUnreadCountFromChatList();
+
+			callback(count);
+		};
+	
+		controller.eventingService.$on(
+			controller.$scope, 
+			controller.constants.events.notifications.bellCountUpdated, 
+			onChange);
+	
+		controller.chatListService.safeSubscribe(
+			controller.$scope, 
+			onChange, 
+			teamspace.services.ChatListServiceEvents.EventType_UnreadCount);
+	
+		this.subscribed = true;
+
+		onChange();
+	}
+
+	start() {
+		this.ipc.on('page-title', () => {
+			this.subscribeToNewActivitiyCountUpdate(count => {
+				this.handleNewActivityCountUpdate(count);
+			});
+		});
+	}
+}
+
+module.exports = exports = ActivityManager;

--- a/app/browser/index.js
+++ b/app/browser/index.js
@@ -3,6 +3,8 @@
 	const path = require('path');
 	const { ipcRenderer } = require('electron');
 	const pageTitleNotifications = require('./pageTitleNotifications');
+	const ActivityManager = require('./activityManager');
+	
 	require('./onlineOfflineListener')();
 	require('./rightClickMenuWithSpellcheck');
 	require('./zoom')();
@@ -10,10 +12,9 @@
 
 	const iconPath = path.join(__dirname, '../assets/icons/icon-96x96.png');
 
-	pageTitleNotifications({
-		ipc: ipcRenderer,
-		iconPath,
-	});
+	new ActivityManager(ipcRenderer, iconPath).start();
+
+	pageTitleNotifications(ipcRenderer);
 
 	// HACK: changing the userAgent to chrome after 5 seconds to fix the issue of notifications disapearing.
 	document.addEventListener(

--- a/app/browser/pageTitleNotifications.js
+++ b/app/browser/pageTitleNotifications.js
@@ -1,43 +1,8 @@
-/* global angular, Image */
-const { nativeImage } = require('electron');
+/* global angular */
 
-/**
- * Build an app icon with a notifications count overlay.
- */
-function buildIcon({ count, icon }) {
-	return new Promise((resolve) => {
-		const canvas = document.createElement('canvas');
-		canvas.height = 140;
-		canvas.width = 140;
-		const image = new Image();
-		image.src = icon.toDataURL('image/png');
-
-		// Create the red circle for notifications
-		image.onload = () => {
-			const ctx = canvas.getContext('2d');
-			ctx.drawImage(image, 0, 0, 140, 140);
-			if (count > 0) {
-				ctx.fillStyle = 'red';
-				ctx.beginPath();
-				ctx.ellipse(105, 35, 35, 35, 35, 0, 2 * Math.PI);
-				ctx.fill();
-				ctx.textAlign = 'center';
-				ctx.fillStyle = 'white';
-
-				ctx.font = 'bold 70px "Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif';
-				if (count > 9) {
-					ctx.fillText('9+', 105, 60);
-				} else {
-					ctx.fillText(count.toString(), 105, 60);
-				}
-			}
-			resolve(canvas.toDataURL());
-		};
-	});
-}
-
-exports = module.exports = ({ ipc, iconPath }) => {
+exports = module.exports = (ipc) => {
 	let lastCount = 0;
+
 	ipc.on('page-title', () => {
 		if (typeof angular === 'undefined') {
 			return;
@@ -54,15 +19,10 @@ exports = module.exports = ({ ipc, iconPath }) => {
 			const toast = document.getElementById('toast-container');
 			const innerText = (toast) ? toast.innerText.replace(/(\r\n|\n|\r)/gm, ' ') : '';
 
-			buildIcon({ count, icon: nativeImage.createFromPath(iconPath) }).then(
-				(icon) => {
-					ipc.send('notifications', {
-						count,
-						icon,
-						text: innerText,
-					});
-				},
-			);
+			ipc.send('notifications', {
+				count,
+				text: innerText,
+			});
 		}
 	});
 };

--- a/app/browser/trayIconRenderer.js
+++ b/app/browser/trayIconRenderer.js
@@ -1,0 +1,47 @@
+const { nativeImage } = require('electron');
+
+class TrayIconRenderer {
+
+	constructor(baseIconPath) {
+		this.baseIconPath = baseIconPath;
+	}
+
+	render(newActivityCount) {
+		const baseIcon = nativeImage.createFromPath(this.baseIconPath);
+
+		return new Promise(resolve => {
+			const canvas = document.createElement('canvas');
+			canvas.height = 140;
+			canvas.width = 140;
+			const image = new Image();
+			image.src = baseIcon.toDataURL('image/png');
+
+			// Create the red circle for notifications
+			image.onload = () => {
+				const ctx = canvas.getContext('2d');
+				ctx.drawImage(image, 0, 0, 140, 140);
+				if (newActivityCount > 0) {
+					ctx.fillStyle = 'red';
+					ctx.beginPath();
+					ctx.ellipse(105, 35, 35, 35, 35, 0, 2 * Math.PI);
+					ctx.fill();
+					ctx.textAlign = 'center';
+					ctx.fillStyle = 'white';
+
+					ctx.font = 'bold 70px "Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif';
+					if (newActivityCount > 9) {
+						ctx.fillText('9+', 105, 60);
+					} else {
+						ctx.fillText(newActivityCount.toString(), 105, 60);
+					}
+				}
+
+				const iconUrl = canvas.toDataURL();
+
+				resolve(iconUrl);
+			};
+		});
+	}
+}
+
+module.exports = exports = TrayIconRenderer;

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -14,17 +14,19 @@ class ApplicationTray {
 		this.tray.on('click', () => this.showAndFocusWindow());
 		this.tray.setContextMenu(Menu.buildFromTemplate(this.appMenu));
 
-		ipcMain.on('notifications', (event, {count, icon}) => this.updateTrayImage(count, icon));
+		ipcMain.on('tray-update', (event, {icon, flash}) => this.updateTrayImage(icon, flash));
 	}
 
-	showAndFocusWindow (){
+	showAndFocusWindow() {
 		this.window.show();
 		this.window.focus();
 	}
 
-	updateTrayImage (count, icon) {
-		this.tray.setImage(nativeImage.createFromDataURL(icon));
-		this.window.flashFrame(count > 0);
+	updateTrayImage(iconUrl, flash) {
+		const image = nativeImage.createFromDataURL(iconUrl);
+
+		this.tray.setImage(image);
+		this.window.flashFrame(flash);
 	}
 }
 exports = module.exports = ApplicationTray;


### PR DESCRIPTION
Hey @IsmaelMartinez this pull request addresses the problem that I observed on Ubuntu 16.04.5 where a tray icon wouldn't update on unread messages. This implementation relies on Teams API to get notified instead of obtaining unread notification based on page title change.

I tested it on Ubuntu 16.04.5 and Ubuntu 18.04.2.