### PR TITLE
Fixed a problem where out of focus window wouldn't show when open button is clicked in a tray #81

### DIFF
--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -19,7 +19,11 @@ class Menus {
 	}
 
 	open() {
-		this.window.show();
+		if (!this.window.isVisible()) {
+			this.window.show();
+		}
+
+		this.window.focus();
 	}
 
 	reload() {


### PR DESCRIPTION
This PR addresses a problem where the application wouldn't restore from taskbar on linux 18.04 and 16.04.