### PR TITLE
Add extraResources property to include node-spellchecker dictionaries when packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,13 @@
         "Comment": "Unofficial client for Microsoft Teams for Linux",
         "StartupWMClass": "teams-for-linux"
       },
+      "extraResources": [
+        {
+          "from": "node_modules/spellchecker/vendor",
+          "to": "app.asar.unpacked/node_modules/spellchecker/vendor",
+          "filter": "**/*"
+        }
+      ],
       "target": [
         "rpm",
         "deb",


### PR DESCRIPTION
Adds extraResources key to electron-builder configuration to include node-spellchecker's dictionaries when application is packaged.