### PR TITLE
Unpack hunspell dictionaries during the build

### DIFF
--- a/app/browser/rightClickMenuWithSpellcheck.js
+++ b/app/browser/rightClickMenuWithSpellcheck.js
@@ -6,8 +6,19 @@
 const { remote, webFrame } = require('electron');
 const SpellCheckProvider = require('electron-spell-check-provider');
 const buildEditorContextMenu = remote.require('electron-editor-context-menu');
+const fs = require('fs');
+const spellchecker = require('spellchecker');
 const appLocale = remote.app.getLocale();
 let selection;
+
+const sysDictPath = '/usr/share/hunspell';
+
+try {
+	if (fs.statSync(sysDictPath)) {
+		spellchecker.setDictionary(appLocale, sysDictPath);
+	}
+} catch (error) {
+}
 
 function resetSelection() {
 	selection = {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "build": {
     "appId": "teams-for-linux",
+    "asarUnpack": ["node_modules/spellchecker/vendor/hunspell_dictionaries"],
     "linux": {
       "category": "Network;Chat",
       "packageCategory": "net",


### PR DESCRIPTION
It will keep `hunspell_dictionaries` in `app.asar.unpacked` directory which allows spell checking to work correctly.

Fixes #118 