### PR TITLE
add os-locale package to dependencies to fix spellchecker

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "electron-native-notification": "^1.2.1",
     "electron-window-state": "^5.0.3",
     "spellchecker": "^3.6.0",
-    "yargs": "^13.3.0"
+    "yargs": "^13.3.0",
+    "os-locale": "^3.1.0"
   },
   "devDependencies": {
     "electron": "^4.2.0",


### PR DESCRIPTION
I'm running Teams from develop branch by building a deb package first. After https://github.com/IsmaelMartinez/teams-for-linux/pull/152 got merged, spellchecker stopped working. This PR fixes the issue.