### PR TITLE
Force fallback to XWayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
       "summary": "Teams for Linux",
       "confinement": "strict",
       "grade": "stable",
+      "environment": {
+        "DISABLE_WAYLAND": 1
+      },
       "plugs": [
         "default",
         "camera",


### PR DESCRIPTION
Perhaps electron cannot use native wayland, so disabling it in the snap
causes it to fall back to XWayland which makes it work.

Tested by building snap locally on my machine.