### PR TITLE
Better handle external requests in new windows

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -9,6 +9,7 @@ const Menus = require('../menus');
 const notifications = require('../notifications');
 const onlineOffline = require('../onlineOffline');
 
+let aboutBlankRequestCount = 0;
 let window = null;
 
 exports.onAppReady = function onAppReady() {
@@ -24,6 +25,8 @@ exports.onAppReady = function onAppReady() {
 	}
 
 	window.webContents.on('new-window', onNewWindow);
+
+	window.webContents.session.webRequest.onBeforeRequest(['http*'], onBeforeRequestHandler);
 
 	login.handleLoginDialogTry(window);
 	if (config.onlineOfflineReload) {
@@ -59,11 +62,41 @@ exports.onAppSecondInstance = function onAppSecondInstance(args) {
 	}
 }
 
-function onNewWindow(event, url, frame, disposition) {
+function onBeforeRequestHandler(details, callback) {
+	// Check if the counter was incremented
+	if (aboutBlankRequestCount < 1) {
+		// Proceed normally
+		callback({});
+	} else {
+		// Open the request externally
+		console.debug('DEBUG - webRequest to  ' + details.url + ' intercepted!');
+		shell.openExternal(details.url);
+		// decrement the counter
+		aboutBlankRequestCount -= 1;
+		callback({ cancel: true });
+	}
+}
+
+function onNewWindow(event, url, frame, disposition, options) {
 	if (url.startsWith('https://teams.microsoft.com/l/meetup-join')) {
 		event.preventDefault();
 		window.loadURL(url);
-	} else if ((disposition !== 'background-tab') && (url !== 'about:blank')) {
+	} else if (url === 'about:blank') {
+		event.preventDefault();
+		// Increment the counter
+		aboutBlankRequestCount += 1;
+		// Create a new hidden window to load the request in the background
+		console.debug('DEBUG - captured about:blank');
+		const win = new BrowserWindow({
+			webContents: options.webContents, // use existing webContents if provided
+			show: false
+		})
+
+		// Close the new window once it is done loading.
+		win.once('ready-to-show', () => win.close())
+
+		event.newGuest = win
+	} else if (disposition !== 'background-tab') {
 		event.preventDefault();
 		shell.openExternal(url);
 	}


### PR DESCRIPTION
Here we use a counter to track the requests that are slated to open in a new window and have a URL of `about:blank`. We then filter all requests and proceed normally when the counter is less than 1.

Closes #182 