### PR TITLE
updating default user agent string per issue 204

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -21,7 +21,7 @@ Here is the list of available arguments and its usage:
 | minimized | Start the application minimized | false |
 | url | url to open | https://teams.microsoft.com/ |
 | config | config file location | ~/.config/teams-for-linux/config.json |
-| chromeUserAgent | user agent string for chrome | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36 |
+| chromeUserAgent | user agent string for chrome | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3831.6 Safari/537.36 |
 | ntlmV2enabled | set enable-ntlm-v2 value | true |
 | authServerWhitelist | set auth-server-whitelist value | * |
 | customCSSName | Custom CSS name for the packaged available css files. Currently those are: "compactDark", "compactLight", "tweaks", "condensedDark" and "condensedLight" | |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -53,7 +53,7 @@ function argv(configPath) {
 				describe: 'Google Chrome User Agent',
 				type: 'string',
 				default:
-					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3835.0 Safari/537.36',
+					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3831.6 Safari/537.36',
 			},
 			ntlmV2enabled: {
 				default: 'true',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Hey, here is the pull request for the default user agent string update, as per https://github.com/IsmaelMartinez/teams-for-linux/issues/204#issuecomment-520179006

Let me know if there's anything else we might need to tweak here, but a quick few tests with find and grep show no other instances of "Windows NT" in the project.