### PR TITLE
Fixes issue 220. Electron's getLocale, and Chromium's l10n_util, can …

### DIFF
--- a/app/browser/rightClickMenuWithSpellcheck.js
+++ b/app/browser/rightClickMenuWithSpellcheck.js
@@ -6,7 +6,7 @@
 const { remote, webFrame } = require('electron');
 const buildEditorContextMenu = remote.require('electron-editor-context-menu');
 const spellchecker = require('spellchecker');
-const appLocale = remote.app.getLocale();
+const appLocale = remote.app.getLocale().replace('-', '_');
 var EN_VARIANT = /^en/;
 
 // Prevent the spellchecker from showing contractions as errors.


### PR DESCRIPTION
Fixes issue 220. Electron's getLocale, and Chromium's l10n_util, can return the language code in the IETF BCP 47 format (en-US) instead of the ISO 15897 format (en_US). Hunspell, the dictionaries included with this project, and the JavaScript code here assumes the ISO 15897 format, so this hotfix converts what getLocale returns.