### PR TITLE
Replacing depShield for snyk to check vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/IsmaelMartinez/teams-for-linux.svg?branch=develop)](https://travis-ci.org/IsmaelMartinez/teams-for-linux)
 [![dependencies Status](https://david-dm.org/IsmaelMartinez/teams-for-linux/status.svg)](https://david-dm.org/IsmaelMartinez/teams-for-linux)
 [![devDependencies Status](https://david-dm.org/IsmaelMartinez/teams-for-linux/dev-status.svg)](https://david-dm.org/IsmaelMartinez/teams-for-linux?type=dev)
-[![DepShield Badge](https://depshield.sonatype.org/badges/IsmaelMartinez/teams-for-linux/depshield.svg)](https://depshield.github.io)
+[![Known Vulnerabilities](https://snyk.io//test/github/IsmaelMartinez/teams-for-linux/badge.svg?targetFile=package.json)](https://snyk.io//test/github/IsmaelMartinez/teams-for-linux?targetFile=package.json)
 
 Unofficial Microsoft Teams client for Linux using [Electron](https://electronjs.org/).
 It uses the Web App and wraps it as a standalone application using Electron.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "release": "electron-builder"
   },
   "dependencies": {
-    "electron-editor-context-menu": "https://github.com/IsmaelMartinez/electron-editor-context-menu",
+    "electron-editor-context-menu": "1.1.1",
     "electron-native-notification": "1.2.1",
     "electron-window-state": "5.0.3",
     "spellchecker": "3.7.0",


### PR DESCRIPTION
depshild did more anoyance than help. Replacinf for snyk as part of #251 