### PR TITLE
fix: enable meetups join also for https protocol links

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -78,8 +78,13 @@ exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
 function processArgs(args) {
 	console.debug("processArgs", args);
 	for (const arg of args) {
+		if (arg.startsWith('https://teams.microsoft.com/l/meetup-join/')) {
+			console.log('meetup-join argument received with https protocol');
+			window.show()
+			return arg
+		}
 		if (arg.startsWith('msteams:/l/meetup-join/')) {
-			console.log('meetup-join argument received');
+			console.log('meetup-join argument received with msteams protocol');
 			window.show()
 			pathMeetup = arg.substring(8, arg.length)
 			url = config.url + pathMeetup


### PR DESCRIPTION
This is small update/fix to issue #253 by Emanuel Batista.
He provides solution to join teams meetups specified with msteams protocol. I added option to use also links defined by https protocol.