### PR TITLE
Adding the 'try-supported-channel-layouts' to the appendSwitch to not…

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,7 +8,7 @@ global.config = config;
 
 app.commandLine.appendSwitch('auth-server-whitelist', config.authServerWhitelist);
 app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
-app.commandLine.appendSwitch('--try-supported-channel-layouts');
+app.commandLine.appendSwitch('try-supported-channel-layouts');
 app.setAsDefaultProtocolClient('msteams');
 
 if (!gotTheLock) {

--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,7 @@ global.config = config;
 
 app.commandLine.appendSwitch('auth-server-whitelist', config.authServerWhitelist);
 app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
+app.commandLine.appendSwitch('--try-supported-channel-layouts');
 app.setAsDefaultProtocolClient('msteams');
 
 if (!gotTheLock) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
… lock the audio on the 1st instance of the app.

Fixes #275 