### PR TITLE
Feature 322 fix meetings links issue

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -15,10 +15,10 @@ Switching the userAgent with the persistence turn on sometimes have the side eff
 The following is a list of locations depending on your type installation:
 
 | Type of install | Location | Clean-up command |
-|:-------------:|:-------------:|:-----:|  
+|:-------------:|:-------------:|:-----:|
 | Vanilla install | `~/.config/teams-for-linux` | `rm -rf ~/.config/teams-for-linux` |
 | snap | `~/snap/teams-for-linux/current/.config/teams-for-linux/` |  `rm -rf ~/snap/teams-for-linux/current/.config/teams-for-linux/` |
-| --user installed flatpak | `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux` | `rm -rf ~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux` | 
+| --user installed flatpak | `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux` | `rm -rf ~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux` |
 | From source | `~/.config/Electron/` | `rm -rf ~/.config/Electron/` |
 
 ## Spellchecker not working
@@ -57,15 +57,15 @@ Some users have reported a blank page on login (with the title `Microsoft Teams 
 
 The following workarounds tend to solve the issue:
 
-* Right click on the Microsoft Teams icon tray and click on Refresh. (Ctrl+R)
+*  Right click on the Microsoft Teams icon tray and click on Refresh. (Ctrl+R)
 
 If the above doesn't work:
 
-* Close the application and delete the application cache folder
-  * `.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`
-  * for Snap installation, `snap/teams-for-linux/current/.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`.
-  * for flatpack, `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux/Partitions/teams-4-linux/Application\ Cache/`
-  > Check the config locations to find other installations location
+*  Close the application and delete the application cache folder
+  *  `.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`
+  *  for Snap installation, `snap/teams-for-linux/current/.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`.
+  *  for flatpack, `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux/Partitions/teams-4-linux/Application\ Cache/`
+  >  Check the config locations to find other installations location
 
 Refer to [#171](https://github.com/IsmaelMartinez/teams-for-linux/issues/171) for more info
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -62,9 +62,13 @@ The following workarounds tend to solve the issue:
 If the above doesn't work:
 
 *  Close the application and delete the application cache folder
+
   *  `.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`
+
   *  for Snap installation, `snap/teams-for-linux/current/.config/teams-for-linux/Partitions/teams-4-linux/Application Cache`.
+
   *  for flatpack, `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux/Partitions/teams-4-linux/Application\ Cache/`
+
   >  Check the config locations to find other installations location
 
 Refer to [#171](https://github.com/IsmaelMartinez/teams-for-linux/issues/171) for more info

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![dependencies Status](https://david-dm.org/IsmaelMartinez/teams-for-linux/status.svg)](https://david-dm.org/IsmaelMartinez/teams-for-linux)
 [![devDependencies Status](https://david-dm.org/IsmaelMartinez/teams-for-linux/dev-status.svg)](https://david-dm.org/IsmaelMartinez/teams-for-linux?type=dev)
 [![Known Vulnerabilities](https://snyk.io//test/github/IsmaelMartinez/teams-for-linux/badge.svg?targetFile=package.json)](https://snyk.io//test/github/IsmaelMartinez/teams-for-linux?targetFile=package.json)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/8954c6c7e85c4ab9b92aef9f54f22eab)](https://www.codacy.com/manual/IsmaelMartinez/teams-for-linux?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=IsmaelMartinez/teams-for-linux&amp;utm_campaign=Badge_Grade)
 
 Unofficial Microsoft Teams client for Linux using [Electron](https://electronjs.org/).
 It uses the Web App and wraps it as a standalone application using Electron.

--- a/app/browser/README.md
+++ b/app/browser/README.md
@@ -12,9 +12,9 @@ The [rightClickMenuWithSpellcheck.js](rightClickMenuWithSpellcheck.js) handles t
 
 The notifications folder contains:
 
-* [pageTitleNotifications.js](notifications/pageTitleNotifications.js) file handles the emitting of an event when the page-title changes and indicates that there is an unread message.
-* [activityManager.js](notifications/activityManager.js) listens for changes in the chatListService and bellNotificationsService to update the unread count.
-* [trayIconRenderer.js](notifications/trayIconRenderer.js) renders a new icon with the number of unread messages.
+*  [pageTitleNotifications.js](notifications/pageTitleNotifications.js) file handles the emitting of an event when the page-title changes and indicates that there is an unread message.
+*  [activityManager.js](notifications/activityManager.js) listens for changes in the chatListService and bellNotificationsService to update the unread count.
+*  [trayIconRenderer.js](notifications/trayIconRenderer.js) renders a new icon with the number of unread messages.
 
 The desktopShare folder contains the logic to add basic destop sharing capabilities to the app.
 

--- a/app/browser/index.js
+++ b/app/browser/index.js
@@ -28,23 +28,11 @@
 		modifyAngularSettingsWithTimeot();
 	});
 
-	function modifyAngularSettingsWithTimeot() {
-		setTimeout(() => {
-			try {
-				let injector = angular.element(document).injector();
-
-				if(injector) {
-					enableChromeVideoAudioMeetings(injector);
-					disablePromoteStuff(injector);
-
-					injector.get('settingsService').settingsService.refreshSettings();
-				}
-			} catch (error) {
-				if (error instanceof ReferenceError) {
-					modifyAngularSettingsWithTimeot();
-				}
-			}
-		}, 4000);
+	function disablePromoteStuff(injector) {
+		injector.get('settingsService').appConfig.promoteMobile = false;
+		injector.get('settingsService').appConfig.promoteDesktop = false;
+		injector.get('settingsService').appConfig.hideGetAppButton = true;
+		injector.get('settingsService').appConfig.enableMobileDownloadMailDialog = false;
 	}
 
 	function enableChromeVideoAudioMeetings(injector) {
@@ -82,12 +70,25 @@
 		injector.get('settingsService').appConfig.disableCallingOnlineCheck = false;
 	}
 
-	function disablePromoteStuff(injector) {
-		injector.get('settingsService').appConfig.promoteMobile = false;
-		injector.get('settingsService').appConfig.promoteDesktop = false;
-		injector.get('settingsService').appConfig.hideGetAppButton = true;
-		injector.get('settingsService').appConfig.enableMobileDownloadMailDialog = false;
+	function modifyAngularSettingsWithTimeot() {
+		setTimeout(() => {
+			try {
+				let injector = angular.element(document).injector();
+
+				if(injector) {
+					enableChromeVideoAudioMeetings(injector);
+					disablePromoteStuff(injector);
+
+					injector.get('settingsService').settingsService.refreshSettings();
+				}
+			} catch (error) {
+				if (error instanceof ReferenceError) {
+					modifyAngularSettingsWithTimeot();
+				}
+			}
+		}, 4000);
 	}
+
 	Object.defineProperty(navigator.serviceWorker, 'register', {
 		value: () => {
 			return Promise.reject()

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -13,14 +13,14 @@ Here is the list of available arguments and its usage:
 | help  | show the available commands | false |
 | version | show the version number | false |
 | onlineOfflineReload | Reload page when going from offline to online | true |
-| rightClickWithSpellcheck | Enable/Disable the right click menu with spellchecker| true |
+| rightClickWithSpellcheck | Enable/Disable the right click menu with spellchecker | true |
 | enableDesktopNotificationsHack | Enable electron-desktop-notifications extension hack | false |
 | closeAppOnCross | Close the app when clicking the close (X) cross | false |
 | partition | [BrowserWindow](https://electronjs.org/docs/api/browser-window) webpreferences partition | persist:teams-4-linux |
 | webDebug | Start with the browser developer tools open  |  false |
 | minimized | Start the application minimized | false |
-| url | url to open | https://teams.microsoft.com/ |
-| proxyServer | Proxy Server with format address:port| None |
+| url | url to open | [https://teams.microsoft.com/](https://teams.microsoft.com/) |
+| proxyServer | Proxy Server with format address:port | None |
 | useElectronDl | Use Electron dl to automatically download files to the download folder | false |
 | config | config file location | ~/.config/teams-for-linux/config.json |
 | chromeUserAgent | user agent string for chrome | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3831.6 Safari/537.36 |
@@ -40,7 +40,7 @@ Alternatively, you can use a file called `config.json` with the configuration op
 
 [yargs](https://www.npmjs.com/package/yargs) allows for extra modes of configuration. Refer to their documentation if you prefer to use a configuration file instead of arguments.
 
-Example: 
+Example:
 
 ```json
 {

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -1,6 +1,15 @@
 const yargs = require('yargs');
 const path = require('path');
 
+function getConfigFile(configPath) {
+	try {
+		return require(path.join(configPath, 'config.json'));
+	} catch (e){
+		console.info('Failed to get the config file, using default values');
+		return {};
+	}
+}
+
 function argv(configPath) {
 	console.log('configPath =', configPath);
 	let configFile = getConfigFile(configPath);
@@ -92,15 +101,6 @@ function argv(configPath) {
 			}
 		})
 		.parse(process.argv.slice(1));
-}
-
-function getConfigFile(configPath) {
-	try {
-		return require(path.join(configPath, 'config.json'));
-	} catch (e){
-		console.info('Failed to get the config file, using default values');
-		return {};
-	}
 }
 
 exports = module.exports = argv;

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -41,6 +41,15 @@ exports.onAppReady = function onAppReady() {
 	}
 
 	window.webContents.on('did-finish-load', () => {
+		console.log('did-finish-load');
+		window.webContents.executeJavaScript(`
+			openBrowserButton = document.getElementById('openTeamsClientInBrowser');
+			openBrowserButton && openBrowserButton.click();
+		`);
+		window.webContents.executeJavaScript(`
+			tryAgainLink = document.getElementById('try-again-link');
+			tryAgainLink && tryAgainLink.click()
+		`);
 		customCSS.onDidFinishLoad(window.webContents);
 	});
 
@@ -53,7 +62,7 @@ exports.onAppReady = function onAppReady() {
 		window = null;
 	});
 
-	url = processArgs(process.argv)
+	const url = processArgs(process.argv)
 	window.loadURL( url ? url:config.url);
 
 	if (config.webDebug) {
@@ -63,11 +72,13 @@ exports.onAppReady = function onAppReady() {
 
 exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
 	console.log('second-instance started');
+	let allowFurtherRequests = true;
 	if (window) {
 		event.preventDefault();
-		url = processArgs(args)
-		if (url) {
-			window.loadURL(url)
+		const url = processArgs(args)
+		if (url && allowFurtherRequests)  {
+			allowFurtherRequests = false;
+			setTimeout(() => { allowFurtherRequests = true}, 10000);
 		} else {
 			if (window.isMinimized()) window.restore();
 			window.focus();

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -62,7 +62,7 @@ exports.onAppReady = function onAppReady() {
 		window = null;
 	});
 
-	const url = processArgs(process.argv)
+	const url = processArgs(process.argv);
 	window.loadURL( url ? url:config.url);
 
 	if (config.webDebug) {
@@ -75,7 +75,7 @@ exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
 	let allowFurtherRequests = true;
 	if (window) {
 		event.preventDefault();
-		const url = processArgs(args)
+		const url = processArgs(args);
 		if (url && allowFurtherRequests)  {
 			allowFurtherRequests = false;
 			setTimeout(() => { allowFurtherRequests = true}, 10000);
@@ -91,15 +91,13 @@ function processArgs(args) {
 	for (const arg of args) {
 		if (arg.startsWith('https://teams.microsoft.com/l/meetup-join/')) {
 			console.log('meetup-join argument received with https protocol');
-			window.show()
-			return arg
+			window.show();
+			return arg;
 		}
 		if (arg.startsWith('msteams:/l/meetup-join/')) {
 			console.log('meetup-join argument received with msteams protocol');
-			window.show()
-			pathMeetup = arg.substring(8, arg.length)
-			url = config.url + pathMeetup
-			return url
+			window.show();
+			return config.url + arg.substring(8, arg.length);
 		}
 	}
 }

--- a/app/menus/README.md
+++ b/app/menus/README.md
@@ -6,10 +6,10 @@ To access the main menu, press the 'Alt' key while the application is selected.
 
 [index.js](index.js) is the entry point. That loads the different files in this folder that define each menu and submenu items.
 
-* Application: The [application.js](application.js) file contains the submenu for the application tab. This submenu definition is also in use for the tray menu.
+*  Application: The [application.js](application.js) file contains the submenu for the application tab. This submenu definition is also in use for the tray menu.
 
-* Help: The help menu is defined in the [help.js](help.js) file.
+*  Help: The help menu is defined in the [help.js](help.js) file.
 
-* Preferences: The preferences submenu gets defined in the [preferences.js](preferences.js) file.
+*  Preferences: The preferences submenu gets defined in the [preferences.js](preferences.js) file.
 
-* Tray: [tray.js](tray.js) contains the tray menu and its implementation.
+*  Tray: [tray.js](tray.js) contains the tray menu and its implementation.

--- a/app/menus/README.md
+++ b/app/menus/README.md
@@ -7,9 +7,6 @@ To access the main menu, press the 'Alt' key while the application is selected.
 [index.js](index.js) is the entry point. That loads the different files in this folder that define each menu and submenu items.
 
 *  Application: The [application.js](application.js) file contains the submenu for the application tab. This submenu definition is also in use for the tray menu.
-
 *  Help: The help menu is defined in the [help.js](help.js) file.
-
 *  Preferences: The preferences submenu gets defined in the [preferences.js](preferences.js) file.
-
 *  Tray: [tray.js](tray.js) contains the tray menu and its implementation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Stopping multiple requests from piling up.
Adding a wee javascript that clicks the "try again" or "open in browser" buttons if present. 

This should fix #322, #318 and #341 (once released in flatpak - not done by me)

Notice that if you are running this from the yarn command you will get a pop-up saying "could not find application for handler msteams" 