### PR TITLE
Changing user agent to a lower version and removing now redundant browser settings

### DIFF
--- a/app/browser/index.js
+++ b/app/browser/index.js
@@ -35,48 +35,12 @@
 		injector.get('settingsService').appConfig.enableMobileDownloadMailDialog = false;
 	}
 
-	function enableChromeVideoAudioMeetings(injector) {
-		injector.get('callingSupportService').oneOnOneCallingEnabled = true;
-		injector.get('callingSupportService').isDesktopApp = true;
-		injector.get('callingSupportService').isChromeMeetingSingleVideoEnabled = true;
-		injector.get('callingSupportService').isChromeVideoOneOnOneEnabled = true;
-		injector.get('callingSupportService').isChromeVideoMultipartyEnabled = true;
-		injector.get('settingsService').appConfig.angularDebugInfoEnabled = true;
-		injector.get('settingsService').appConfig.enableCallingChromeOneOnOne = true;
-		injector.get('settingsService').appConfig.callingEnableChromeMeetingSingleVideo = true;
-		injector.get('settingsService').appConfig.callingEnableChromeMultipartyVideo = true;
-		injector.get('settingsService').appConfig.callingEnabledLinux = true;
-		injector.get('settingsService').appConfig.enableChromeScreenSharing = true;
-		injector.get('settingsService').appConfig.enableAddToChatButtonForMeetings = true;
-		injector.get('settingsService').appConfig.enableSharingOnlyCallChrome = true;
-		injector.get('settingsService').appConfig.enableScreenSharingToolbar = true;
-		injector.get('settingsService').appConfig.enableCallingScreenPreviewLabel = true;
-		injector.get('settingsService').appConfig.callingEnableChromeOneToOneVideo = true;
-		injector.get('settingsService').appConfig.enableMeetingStartedNotificationWeb = true;
-		injector.get('settingsService').appConfig.enableMicOSUnmuteOnUnmute = true;
-		injector.get('settingsService').appConfig.enableModeratorsSupport = true;
-		injector.get('settingsService').appConfig.enableRecordPPTSharing = true;
-		injector.get('settingsService').appConfig.enable3x3VideoLayout = true;
-		injector.get('settingsService').appConfig.enableCallTranscript = true;
-		injector.get('settingsService').appConfig.enableCallTransferredScreen = true;
-		injector.get('settingsService').appConfig.enableCameraSharing = true;
-		injector.get('settingsService').appConfig.enableEdgeScreenSharing = true;
-		injector.get('settingsService').appConfig.enableSeeMyScreenshare = true;
-		injector.get('settingsService').appConfig.enableSmartReplies = true;
-		injector.get('settingsService').appConfig.enableSms = true;
-		injector.get('settingsService').appConfig.enableTestCallForAll = true;
-		injector.get('settingsService').appConfig.enableUnreadMessagesButton = true;
-		injector.get('settingsService').appConfig.enableVideoBackground = true;
-		injector.get('settingsService').appConfig.disableCallingOnlineCheck = false;
-	}
-
 	function modifyAngularSettingsWithTimeot() {
 		setTimeout(() => {
 			try {
 				let injector = angular.element(document).injector();
 
 				if (injector) {
-					enableChromeVideoAudioMeetings(injector);
 					disablePromoteStuff(injector);
 
 					injector.get('settingsService').settingsService.refreshSettings();

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 function getConfigFile(configPath) {
 	try {
 		return require(path.join(configPath, 'config.json'));
-	} catch (e){
+	} catch (e) {
 		console.info('Failed to get the config file, using default values');
 		return {};
 	}
@@ -72,7 +72,7 @@ function argv(configPath) {
 				describe: 'Google Chrome User Agent',
 				type: 'string',
 				default:
-					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3831.6 Safari/537.36',
+					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3202.75 Safari/537.36',
 			},
 			ntlmV2enabled: {
 				default: 'true',


### PR DESCRIPTION
# What

Reducing the browser user agent to version 71 from 77. Also removed some redundant overwrite of settings.

# Why

Because MS did include screensharing support from version 72, but is now breaking our workaround for screensharing, and the settings that we use to overwrite, aren't needed anymore.

This fixes/closes #406 