### PR TITLE
Wayland: Fix the Wayland specific runtime flags. Fixes #455.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,8 +15,7 @@ app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
 app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
-	app.commandLine.appendSwitch('ozone-platform', 'wayland');
-	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer;UseOzonePlatform');
+	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
 }
 
 const protocolClient = 'msteams';


### PR DESCRIPTION
The Wayland specific runtime flags are separated by a semicolon rather than the required comma. This PR fixes that. Furthermore, fixing the feature flags also resulted in the Wayland/Ozone backend actually being picked up. However, for me Teams would remain completely blank, and for another user (https://github.com/IsmaelMartinez/teams-for-linux/issues/455#issuecomment-1007458946) the title bar was gone preventing you from resizing or moving the window. Removing those flags for now.