### PR TITLE
Wayland flags, bypass streamSelector on wayland

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -16,8 +16,6 @@ app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
 	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
-	//Ozone-platform wayland seems to lead to window with no title bar or blank window
-	//app.commandLine.appendSwitch('ozone-platform', 'wayland');
 }
 
 const protocolClient = 'msteams';

--- a/app/index.js
+++ b/app/index.js
@@ -15,8 +15,9 @@ app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
 app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
-	app.commandLine.appendSwitch('ozone-platform', 'wayland');
-	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer;UseOzonePlatform');
+	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
+	//Ozone-platform wayland seems to lead to window with no title bar or blank window
+	//app.commandLine.appendSwitch('ozone-platform', 'wayland');
 }
 
 const protocolClient = 'msteams';

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -1,28 +1,41 @@
 const { desktopCapturer, ipcRenderer } = require('electron');
-window.addEventListener('DOMContentLoaded', createSourceSelector());
+window.addEventListener('DOMContentLoaded', init());
 
-function createSourceSelector() {
+function init() {
 	return () => {
-		ipcRenderer.once('get-screensizes-response', (event, screens) => {
-			//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
-			if (process.env["XDG_SESSION_TYPE"] === "wayland")
-				requestSingleScreenOrWindow(screens);
-			else
-				createPreviewScreen(screens);
-		});
-		ipcRenderer.send('get-screensizes-request');
-	};
+		if (process.env["XDG_SESSION_TYPE"] === "wayland")
+			initRequestSource();
+		else
+			createSourceSelector();
+	}
+}
+
+function initRequestSource() {
+	//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+	ipcRenderer.once('get-screensizes-response', (event, screens) => {
+		requestSingleScreenOrWindow(screens);
+	});
+	ipcRenderer.send('get-screensizes-request');
 }
 
 function requestSingleScreenOrWindow(screens) {
 	desktopCapturer.getSources({ types: ['screen'] }).then(async (sources) => {
-		if (sources.length !== 0) {
-			ipcRenderer.send('selected-source', {
-				id: sources[0].id,
-				screen: screens.find(s => s.default)
-			});
-		}
+		if (sources.length === 0)
+			return;
+
+		const properties = {
+			id: sources[0].id,
+			screen: screens.find(s => s.default)
+		};
+		ipcRenderer.send('selected-source', properties);
 	});
+}
+
+function createSourceSelector() {
+	ipcRenderer.once('get-screensizes-response', (event, screens) => {
+		createPreviewScreen(screens);
+	});
+	ipcRenderer.send('get-screensizes-request');
 }
 
 function createPreviewScreen(screens) {

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -7,7 +7,7 @@ function init() {
                          //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
 			initRequestSource(requestSingleScreenOrWindow);
 		else
-			createSourceSelector();
+			createSourceSelector(createPreviewScreen);
 	}
 }
 

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -3,11 +3,12 @@ window.addEventListener('DOMContentLoaded', init());
 
 function init() {
 	return () => {
-		if (process.env["XDG_SESSION_TYPE"] === "wayland")
-                         //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+		if (process.env["XDG_SESSION_TYPE"] === "wayland") {
+			//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
 			initRequestSource(requestSingleScreenOrWindow);
-		else
-			createSourceSelector(createPreviewScreen);
+		} else {
+			initRequestSource(createPreviewScreen);
+		}
 	}
 }
 

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -10,10 +10,9 @@ function init() {
 	}
 }
 
-function initRequestSource() {
-	//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+function initRequestSource(callback) {
 	ipcRenderer.once('get-screensizes-response', (event, screens) => {
-		requestSingleScreenOrWindow(screens);
+		callback(screens);
 	});
 	ipcRenderer.send('get-screensizes-request');
 }

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -4,7 +4,8 @@ window.addEventListener('DOMContentLoaded', init());
 function init() {
 	return () => {
 		if (process.env["XDG_SESSION_TYPE"] === "wayland")
-			initRequestSource();
+                         //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+			initRequestSource(requestSingleScreenOrWindow);
 		else
 			createSourceSelector();
 	}

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -31,12 +31,6 @@ function requestSingleScreenOrWindow(screens) {
 	});
 }
 
-function createSourceSelector() {
-	ipcRenderer.once('get-screensizes-response', (event, screens) => {
-		createPreviewScreen(screens);
-	});
-	ipcRenderer.send('get-screensizes-request');
-}
 
 function createPreviewScreen(screens) {
 	let windowsIndex = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Fix Wayland flags to allow pipewire capture.

Bypass streamSelector on wayland to avoid spamming user with multiple requests to select a source stream (native pipewire dialog already allows for stream selection).