### PR TITLE
Electron16 update

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -72,7 +72,7 @@ function argv(configPath) {
 				describe: 'Google Chrome User Agent',
 				type: 'string',
 				default:
-					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36',
+					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36'
 			},
 			ntlmV2enabled: {
 				default: 'true',

--- a/app/index.js
+++ b/app/index.js
@@ -16,8 +16,6 @@ app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
 	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
-	//Ozone-platform wayland seems to lead to window with no title bar or blank window
-	//app.commandLine.appendSwitch('ozone-platform', 'wayland');
 }
 
 const protocolClient = 'msteams';

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-const { app, ipcMain } = require('electron');
+const { app, ipcMain, desktopCapturer } = require('electron');
 const config = require('./config')(app.getPath('userData'));
 const Store = require('electron-store');
 const store = new Store({
@@ -16,6 +16,7 @@ app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
 	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
+	app.commandLine.appendSwitch('use-fake-ui-for-media-stream');
 }
 
 const protocolClient = 'msteams';
@@ -39,6 +40,7 @@ if (!gotTheLock) {
 	ipcMain.handle('getConfig', handleGetConfig);
 	ipcMain.handle('getZoomLevel', handleGetZoomLevel);
 	ipcMain.handle('saveZoomLevel', handleSaveZoomLevel);
+	ipcMain.handle('desktopCaturerGetSources', (event, opts) => desktopCapturer.getSources(opts));
 }
 
 function handleAppReady() {

--- a/app/index.js
+++ b/app/index.js
@@ -15,8 +15,9 @@ app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
 app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
-	app.commandLine.appendSwitch('ozone-platform', 'wayland');
-	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer;UseOzonePlatform');
+	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
+	//Ozone-platform wayland seems to lead to window with no title bar or blank window
+	//app.commandLine.appendSwitch('ozone-platform', 'wayland');
 }
 
 const protocolClient = 'msteams';

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -1,28 +1,41 @@
 const { desktopCapturer, ipcRenderer } = require('electron');
-window.addEventListener('DOMContentLoaded', createSourceSelector());
+window.addEventListener('DOMContentLoaded', init());
 
-function createSourceSelector() {
+function init() {
 	return () => {
-		ipcRenderer.once('get-screensizes-response', (event, screens) => {
-			//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
-			if (process.env["XDG_SESSION_TYPE"] === "wayland")
-				requestSingleScreenOrWindow(screens);
-			else
-				createPreviewScreen(screens);
-		});
-		ipcRenderer.send('get-screensizes-request');
-	};
+		if (process.env["XDG_SESSION_TYPE"] === "wayland")
+			initRequestSource();
+		else
+			createSourceSelector();
+	}
+}
+
+function initRequestSource() {
+	//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+	ipcRenderer.once('get-screensizes-response', (event, screens) => {
+		requestSingleScreenOrWindow(screens);
+	});
+	ipcRenderer.send('get-screensizes-request');
 }
 
 function requestSingleScreenOrWindow(screens) {
 	desktopCapturer.getSources({ types: ['screen'] }).then(async (sources) => {
-		if (sources.length !== 0) {
-			ipcRenderer.send('selected-source', {
-				id: sources[0].id,
-				screen: screens.find(s => s.default)
-			});
-		}
+		if (sources.length === 0)
+			return;
+
+		const properties = {
+			id: sources[0].id,
+			screen: screens.find(s => s.default)
+		};
+		ipcRenderer.send('selected-source', properties);
 	});
+}
+
+function createSourceSelector() {
+	ipcRenderer.once('get-screensizes-response', (event, screens) => {
+		createPreviewScreen(screens);
+	});
+	ipcRenderer.send('get-screensizes-request');
 }
 
 function createPreviewScreen(screens) {

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -7,7 +7,7 @@ function init() {
                          //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
 			initRequestSource(requestSingleScreenOrWindow);
 		else
-			createSourceSelector();
+			createSourceSelector(createPreviewScreen);
 	}
 }
 

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -3,11 +3,12 @@ window.addEventListener('DOMContentLoaded', init());
 
 function init() {
 	return () => {
-		if (process.env["XDG_SESSION_TYPE"] === "wayland")
-                         //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+		if (process.env["XDG_SESSION_TYPE"] === "wayland") {
+			//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
 			initRequestSource(requestSingleScreenOrWindow);
-		else
-			createSourceSelector(createPreviewScreen);
+		} else {
+			initRequestSource(createPreviewScreen);
+		}
 	}
 }
 

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -10,10 +10,9 @@ function init() {
 	}
 }
 
-function initRequestSource() {
-	//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+function initRequestSource(callback) {
 	ipcRenderer.once('get-screensizes-response', (event, screens) => {
-		requestSingleScreenOrWindow(screens);
+		callback(screens);
 	});
 	ipcRenderer.send('get-screensizes-request');
 }

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -4,7 +4,8 @@ window.addEventListener('DOMContentLoaded', init());
 function init() {
 	return () => {
 		if (process.env["XDG_SESSION_TYPE"] === "wayland")
-			initRequestSource();
+                         //Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
+			initRequestSource(requestSingleScreenOrWindow);
 		else
 			createSourceSelector();
 	}

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -1,4 +1,4 @@
-const { desktopCapturer, ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron');
 window.addEventListener('DOMContentLoaded', init());
 
 function init() {
@@ -20,7 +20,7 @@ function initRequestSource(callback) {
 }
 
 function requestSingleScreenOrWindow(screens) {
-	desktopCapturer.getSources({ types: ['screen'] }).then(async (sources) => {
+	ipcRenderer.invoke('desktopCaturerGetSources', { types: ['screen'] }).then(async (sources) => {
 		if (sources.length === 0)
 			return;
 
@@ -37,7 +37,7 @@ function createPreviewScreen(screens) {
 	let windowsIndex = 0;
 	const sscontainer = document.getElementById('screen-size');
 	createEventHandlers({ screens, sscontainer });
-	desktopCapturer.getSources({ types: ['window', 'screen'] }).then(async (sources) => {
+	ipcRenderer.invoke('desktopCaturerGetSources', { types: ['window', 'screen'] }).then(async (sources) => {
 		const rowElement = document.querySelector('.container-fluid .row');
 		ipcRenderer.once('disable-blur-response', async () => {
 			for (const source of sources) {

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -31,12 +31,6 @@ function requestSingleScreenOrWindow(screens) {
 	});
 }
 
-function createSourceSelector() {
-	ipcRenderer.once('get-screensizes-response', (event, screens) => {
-		createPreviewScreen(screens);
-	});
-	ipcRenderer.send('get-screensizes-request');
-}
 
 function createPreviewScreen(screens) {
 	let windowsIndex = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -44,7 +44,7 @@
     "yargs": "17.2.1"
   },
   "devDependencies": {
-    "electron": "15.3.0",
+    "electron": "^16.0.6",
     "electron-builder": "22.13.1",
     "eslint": "8.1.0",
     "yarn": "1.22.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Bump electron to v16
- Refactor calls to desktopCapturer.getSources since this is now [deprecated in the renderer](https://www.electronjs.org/docs/latest/breaking-changes#deprecated-desktopcapturergetsources-in-the-renderer) and will be removed in v17
- Bumped user agent to chrome 96 to match electron version.
- Added use-fake-ui-for-media-stream flag on wayland to fix permission error I was getting during screen share (didn't seem to be an issue until v16).

For me this seems to enable virtual/blured background support which is nice to have. It may just be the user agent bump that did this.

Also this partially resolves bug #504. With electron v16 you can launch with --ozone-platform=wayland and the main windows loads  but you end up with no titlebar/decorations. This seems to be an outstanding [electron issue](https://github.com/electron/electron/issues/27016). A work around would be to implement server side decorations similar to the official teams app (#441).