### PR TITLE
Electron v16 update

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -72,7 +72,7 @@ function argv(configPath) {
 				describe: 'Google Chrome User Agent',
 				type: 'string',
 				default:
-					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36',
+					'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36'
 			},
 			ntlmV2enabled: {
 				default: 'true',

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-const { app, ipcMain } = require('electron');
+const { app, ipcMain, desktopCapturer } = require('electron');
 const config = require('./config')(app.getPath('userData'));
 const Store = require('electron-store');
 const store = new Store({
@@ -16,6 +16,7 @@ app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
 	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
+	app.commandLine.appendSwitch('use-fake-ui-for-media-stream');
 }
 
 const protocolClient = 'msteams';
@@ -39,6 +40,7 @@ if (!gotTheLock) {
 	ipcMain.handle('getConfig', handleGetConfig);
 	ipcMain.handle('getZoomLevel', handleGetZoomLevel);
 	ipcMain.handle('saveZoomLevel', handleSaveZoomLevel);
+	ipcMain.handle('desktopCaturerGetSources', (event, opts) => desktopCapturer.getSources(opts));
 }
 
 function handleAppReady() {

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -1,4 +1,4 @@
-const { desktopCapturer, ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron');
 window.addEventListener('DOMContentLoaded', init());
 
 function init() {
@@ -20,7 +20,7 @@ function initRequestSource(callback) {
 }
 
 function requestSingleScreenOrWindow(screens) {
-	desktopCapturer.getSources({ types: ['screen'] }).then(async (sources) => {
+	ipcRenderer.invoke('desktopCaturerGetSources', { types: ['screen'] }).then(async (sources) => {
 		if (sources.length === 0)
 			return;
 
@@ -37,7 +37,7 @@ function createPreviewScreen(screens) {
 	let windowsIndex = 0;
 	const sscontainer = document.getElementById('screen-size');
 	createEventHandlers({ screens, sscontainer });
-	desktopCapturer.getSources({ types: ['window', 'screen'] }).then(async (sources) => {
+	ipcRenderer.invoke('desktopCaturerGetSources', { types: ['window', 'screen'] }).then(async (sources) => {
 		const rowElement = document.querySelector('.container-fluid .row');
 		ipcRenderer.once('disable-blur-response', async () => {
 			for (const source of sources) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -44,7 +44,7 @@
     "yargs": "17.2.1"
   },
   "devDependencies": {
-    "electron": "15.3.0",
+    "electron": "^16.0.6",
     "electron-builder": "22.13.1",
     "eslint": "8.1.0",
     "yarn": "1.22.17"


### PR DESCRIPTION
Bump electron to v16
- Refactor calls to desktopCapturer.getSources since this is now [deprecated in the renderer](https://www.electronjs.org/docs/latest/breaking-changes#deprecated-desktopcapturergetsources-in-the-renderer) and will be removed in v17
- Bumped user agent to chrome 96 to match electron version.
- Added use-fake-ui-for-media-stream flag on wayland to fix permission error I was getting during screen share (didn't seem to be an issue until v16).

For me this seems to enable virtual/blured background support which is nice to have. It may just be the user agent bump that did this.

Also this partially resolves bug #504. With electron v16 you can launch with --ozone-platform=wayland and the main window loads  but you end up with no titlebar/decorations. This seems to be an outstanding [electron issue](https://github.com/electron/electron/issues/27016). A work around would be to implement server side decorations similar to the official teams app (#441).