### PR TITLE
Allow enable-features on commandline

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,7 +18,12 @@ app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
 app.commandLine.appendSwitch('try-supported-channel-layouts');
 if (process.env.XDG_SESSION_TYPE == 'wayland') {
 	console.log('INFO: Running under Wayland, switching to PipeWire...');
-	app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,UseOzonePlatform');
+	
+	const features = app.commandLine.hasSwitch('enable-features') ? app.commandLine.getSwitchValue("enable-features").split(',') : [];
+	if (!features.includes("WebRTCPipeWireCapturer"))
+		features.push("WebRTCPipeWireCapturer");
+
+	app.commandLine.appendSwitch("enable-features", features.join(','));
 	app.commandLine.appendSwitch('use-fake-ui-for-media-stream');
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Electron 20 seems to work quite well in native wayland mode. Unfortunately the electron process only allows the enable-features switch to be supplied once and since the app is appending this switch itself (when running on wayland) it overrides the switch the user has specified on the command line. This change allows any user specified features to be appended with those added by the app.

With this patch I can run with "--ozone-platform=wayland --enable-features=WaylandWindowDecorations" to run in native wayland mode and it seems to work pretty well for me (on Fedora/Gnome).