### PR TITLE
update selector to automatically open video calls within app

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -92,7 +92,7 @@ exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
 function onDidFinishLoad() {
 	logger.debug('did-finish-load');
 	window.webContents.executeJavaScript(`
-			openBrowserButton = document.getElementById('openTeamsClientInBrowser');
+			openBrowserButton = document.querySelector('[data-tid=joinOnWeb]');
 			openBrowserButton && openBrowserButton.click();
 		`);
 	window.webContents.executeJavaScript(`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
The selector for this field changed, a while ago already. This change makes it so that the interstitial page of "Open Teams in Browser" / "Download Linux Client" / "Open in Teams App" is automatically clicked away again. It selects "Open Teams in Browser" which opens the video call pre-screen directly within the Electron app window.