### PR TITLE
Add electron spell checker option

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -30,6 +30,7 @@ Here is the list of available arguments and its usage:
 | customCSSLocation | Location for custom CSS styles | |
 | customCACertsFingerprints | custom CA Certs Fingerprints to allow SSL unrecognized signer or self signed certificate (see below) | [] |
 | appIcon | 'Teams app icon to show in the tray' | ../assets/icons/icon-16x16.png if Mac or ../assets/icons/icon-96x96.png otherwise|  
+| spellCheckerLanguages | Language codes to use with Electron\'s spell checker (experimental) | [] |
 
 As an example, to disable the persitence, you can run the following command:
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -118,6 +118,11 @@ function argv(configPath) {
 				default: path.join(__dirname, '..', 'assets', 'icons', isMac ? 'icon-16x16.png' : 'icon-96x96.png'),
 				describe: 'Teams app icon to show in the tray',
 				type: 'string'
+			},
+			spellCheckerLanguages: {
+				default: [],
+				describe: 'Array of languages to use with Electron\'s spell checker (experimental)',
+				type: 'array',
 			}
 		})
 		.parse(process.argv.slice(1));

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -41,6 +41,15 @@ exports.onAppReady = async function onAppReady(mainConfig) {
 		notifications.addDesktopNotificationHack(iconPath);
 	}
 
+	if (config.spellCheckerLanguages) {
+		try {
+			window.webContents.session.setSpellCheckerLanguages(config.spellCheckerLanguages);
+		} catch {
+			logger.warn('Specified languages are not correct. Falling back to en-US');
+			window.webContents.session.setSpellCheckerLanguages(['en-US']);
+		}
+	}
+
 	window.webContents.on('new-window', onNewWindow);
 
 	window.webContents.session.webRequest.onBeforeRequest({ urls: ['https://*/*'] }, onBeforeRequestHandler);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/IsmaelMartinez/teams-for-linux/issues/385#issuecomment-1378521745), I've added a new flag/option named `spellCheckerLanguages` with type array. This array will contain the language codes that we want to use for the spell checking offered by Electron. This is enabled only if the option is passed when running teams-for-linux.