### PR TITLE
Add option to load client certificates for corporate auth

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -29,6 +29,7 @@ Here is the list of available arguments and its usage:
 | customCSSName | Custom CSS name for the packaged available css files. Currently those are: "compactDark", "compactLight", "tweaks", "condensedDark" and "condensedLight" | |
 | customCSSLocation | Location for custom CSS styles | |
 | customCACertsFingerprints | custom CA Certs Fingerprints to allow SSL unrecognized signer or self signed certificate (see below) | [] |
+| clientCertPath clientCertPassword | custom Client Certs for corporate authentication (certificate must be in pkcs12 format) | [] |
 | appIcon | 'Teams app icon to show in the tray' | ../assets/icons/icon-16x16.png if Mac or ../assets/icons/icon-96x96.png otherwise|  
 | spellCheckerLanguages | Language codes to use with Electron\'s spell checker (experimental) | [] |
 

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -91,7 +91,7 @@ function applyAppConfiguration(config, window) {
 		onlineOffline.reloadPageWhenOfflineToOnline(window, config);
 	}
 
-	if (typeof config.clientCertPath === 'undefined') {
+	if (typeof config.clientCertPath !== 'undefined') {
 		app.importCertificate({ certificate: config.clientCertPath, password: config.clientCertPassword }, (result) => {
 			logger.info('Loaded certificate: ' + config.clientCertPath + ', result: ' + result);
 		});

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -91,6 +91,12 @@ function applyAppConfiguration(config, window) {
 		onlineOffline.reloadPageWhenOfflineToOnline(window, config);
 	}
 
+	if (typeof config.clientCertPath === 'undefined') {
+		app.importCertificate({ certificate: config.clientCertPath, password: config.clientCertPassword }, (result) => {
+			logger.info('Loaded certificate: ' + config.clientCertPath + ', result: ' + result);
+		});
+	}
+
 	window.webContents.setUserAgent(config.chromeUserAgent);
 
 	if (!config.minimized) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Example in `~/.config/teams-for-linux/config.json`:

```
{
    "clientCertPath": "/path/to/my-certificate.p12",
    "clientCertPassword": "my-password"
}
```

This will use `my-certificate.p12` for corporate authentication, allowing copy/paste, attachments management and possibly other blocked features.
