### PR TITLE
Patch: Support for multiple Teams Accounts at the same time

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -31,6 +31,8 @@ Here is the list of available arguments and its usage:
 | customCACertsFingerprints | custom CA Certs Fingerprints to allow SSL unrecognized signer or self signed certificate (see below) | [] |
 | appIcon | 'Teams app icon to show in the tray' | ../assets/icons/icon-16x16.png if Mac or ../assets/icons/icon-96x96.png otherwise|  
 | spellCheckerLanguages | Language codes to use with Electron\'s spell checker (experimental) | [] |
+| customUserDir | Custom User Directory so that you can have multiple profiles | |
+
 
 As an example, to disable the persitence, you can run the following command:
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -48,6 +48,11 @@ function argv(configPath) {
 				describe: 'Proxy Server with format address:port',
 				type: 'string',
 			},
+			customUserDir: {
+				default: null,
+				describe: 'Custom User Directory so that you can have multiple profiles',
+				type: 'string',
+			},
 			useElectronDl: {
 				default: false,
 				describe: 'Use Electron dl to automatically download files to the download folder',

--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,9 @@ const { LucidLog } = require('lucid-log');
 const isDev = require('electron-is-dev');
 const os = require('os');
 const isMac = os.platform() === 'darwin';
+if (app.commandLine.hasSwitch('customUserDir')) {
+	app.setPath('userData', app.commandLine.getSwitchValue('customUserDir'));
+}
 const config = require('./config')(app.getPath('userData'));
 const logger = new LucidLog({
 	levels: config.appLogLevels.split(',')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
I'm always frustrated when I have to use my three different Teams Instances and managing them is quite difficult.
I usually have my team instances managed via teams-for-linux, one with my browser, and one with the incognito tab of my browser.
With the provided code one can run multiple teams-for-linux Instances at the same time and only has to create a different .desktop file for each of them.

