### PR TITLE
Feature: Disable Notification Sound if not Available

### DIFF
--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -109,7 +109,7 @@ function meetingStartNotifyHandler(self) {
 function myStatusChangedHandler(self) {
 	// eslint-disable-next-line no-unused-vars
 	return async (event) => {
-		// To do: self.ipcRenderer.send('user-status-changed', { data: event.data })
+		self.ipcRenderer.send('user-status-changed', { data: event.data })
 	};
 }
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -37,6 +37,7 @@ Here is the list of available arguments and its usage:
 | clearStorage | Whether to clear the storage before creating the window or not | false |
 | disableMeetingNotifications | Whether to disable meeting notifications or not | false |
 | disableNotificationSound | Disable chat/meeting start notification sound | false |
+| disableNotificationSoundIfNotAvailable | Disable chat/meeting start notification sound if status is not Available (e.g. busy, in a call) | true |
 | appIdleTimeout | A numeric value in seconds as duration before app considers the system as idle | 300 |
 | appIdleTimeoutCheckInterval | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | 10 |
 | appActiveCheckInterval | A numeric value in seconds as poll interval to check if the system is active from being idle | 2 |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -124,6 +124,11 @@ function argv(configPath) {
 				describe: 'Disable chat/meeting start notification sound',
 				type: 'boolean'
 			},
+			disableNotificationSoundIfNotAvailable: {
+				default: true,
+				describe: 'Disables notification sound unless status is Available (e.g. while in a call, busy, etc.)',
+				type: 'boolean'
+			},
 			appIcon: {
 				default: path.join(__dirname, '..', 'assets', 'icons', isMac ? 'icon-16x16.png' : 'icon-96x96.png'),
 				describe: 'Teams app icon to show in the tray',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
This adds functionality to disable notification sounds if status is not "Available".

If the user is in a meeting/call, or has set their status to "Busy", "Away", etc. - basically anything other than "Available" - then notification sounds won't be played.