### PR TITLE
#591 Add forceBackground Option to use a custom meeting background

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -42,7 +42,7 @@ Here is the list of available arguments and its usage:
 | appIdleTimeoutCheckInterval | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | 10 |
 | appActiveCheckInterval | A numeric value in seconds as poll interval to check if the system is active from being idle | 2 |
 | screenLockInhibitionMethod | Screen lock inhibition method to be used (Electron/WakeLockSentinel) | Electron |
-
+| forceBackground | Provide a local path to a meeting background (select any background image then) - experimental | empty |
 
 
 As an example, to disable the persitence, you can run the following command:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.0.83",
+  "version": "1.1.0",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
See #591 

How to use

* supply the `--forceBackground /path/to/your/jpeg/our/png/file.png` option
* when starting a meeting, choose any background image

The previews are not replaced, but the meeting background is working

Thanks to @jijojosephk