### PR TITLE
Fix: import empty certificate path

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -106,7 +106,7 @@ exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
 function applyAppConfiguration(config, window) {
 	applySpellCheckerConfiguration(config.spellCheckerLanguages, window);
 
-	if (typeof config.clientCertPath !== 'undefined') {
+	if (typeof config.clientCertPath !== 'undefined' && config.clientCertPath !== '') {
 		app.importCertificate({ certificate: config.clientCertPath, password: config.clientCertPassword }, (result) => {
 			logger.info('Loaded certificate: ' + config.clientCertPath + ', result: ' + result);
 		});

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.3.12" date="2023-09-28">
+			<description>
+				<ul>
+					<li>Fix: Import empty certificate path. The default config.clientCertPath is an empty string</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.3.11" date="2023-09-18">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Hello,

The default config.clientCertPath is an empty string. I added this check for this.

Thanks