### PR TITLE
Fix default url handler

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -360,7 +360,7 @@ function secureOpenLink(details) {
 
 function openInBrowser(details) {
 	if (config.defaultURLHandler.trim() !== '') {
-		exec(`${config.defaultURLHandler.trim()} ${details.url}`, openInBrowserErrorHandler);
+		exec(`${config.defaultURLHandler.trim()} "${details.url}"`, openInBrowserErrorHandler);
 	} else {
 		shell.openExternal(details.url);
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
URL is not passed correctly to handler if it contains special chars.
    
Example failing url: `https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fstatics.teams.cdn.office.net.mcas.ms...`
    
In the case above the url handler only receives `https://mcas-proxyweb.mcas.ms/certificate-checker?login=false` (the url is cut after "&").