### PR TITLE
prevent arbitrary command execution via URL when using --defaultURLHandler

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -10,7 +10,7 @@ const { StreamSelector } = require('../streamSelector');
 const { LucidLog } = require('lucid-log');
 const { SpellCheckProvider } = require('../spellCheckProvider');
 const { httpHelper } = require('../helpers');
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const TrayIconChooser = require('../browser/tools/trayIconChooser');
 // eslint-disable-next-line no-unused-vars
 const { AppConfiguration } = require('../appConfiguration');
@@ -360,7 +360,7 @@ function secureOpenLink(details) {
 
 function openInBrowser(details) {
 	if (config.defaultURLHandler.trim() !== '') {
-		exec(`${config.defaultURLHandler.trim()} "${details.url}"`, openInBrowserErrorHandler);
+		execFile(config.defaultURLHandler.trim(), [details.url], openInBrowserErrorHandler);
 	} else {
 		shell.openExternal(details.url);
 	}

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.3.17" date="2023-10-30">
+			<description>
+				<ul>
+					<li>Fix: Avoid calling child_process.exec with untrusted string</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.3.16" date="2023-10-30">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
I've just seen changes in 1.3.16, and I think #996 points to a security flaw (which was there already, just happened to see it because of this change). In this version, when using `--defaultURLHandler favorite-browser`, opening an URL will execute a shell process ([`child_process.exec(...)`](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback)) to run the following command:
```sh
favorite-browser "THE_URL"
```
Although `THE_URL` has some URL-encoded characters, this still leaves plenty of potential for arbitrary command execution via a malicious URL in a Teams message. In particular, the following characters are not encoded in the path of an URL: `$`, `(`, `)`. 

Here is a way to exploit that: `https://google.com/$(sudo$IFS$(true)shutdown$IFS$(true)-h$IFS$(true)now)`
  - `$IFS` is substituted with some space characters
  - `$(true)` is substituted with empty string, it's used here to separate `$IFS` and whatever follows
  - `sudo shutdown -h now` is the resulting command...
  - `$(...)` executes this command in a sub-shell, and is substituted with its standard output (which is empty here)
  - `favorite-browser` will simply open `https://google.com/` (while the computer starts shutting down if `sudo` expects no password)

In this PR, I propose to use [`child_process.execFile(...)`](https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback) as a safer replacement for `exec(...)`. No shell involved, just a command name (`favorite-browser`) and its unaltered string argument (the URL string, as-is).

The drawback is that maybe someone somewhere has been successfully using something like `--defaultURLHandler "favorite-browser --some-browser-option"`, and this will not work anymore. IMHO, it's an acceptable trade-off. If you think it's not, then some alternative fixes could be:
- with `execFile(...)`: split `defaultURLHandler`, use first word as command and remaining ones as additional arguments before the URL
- with `exec(...)`: properly shell-escape the `details.url` string in the command (I _think_ escaping `$` as `\$`, plus the double-quotes which has already been added around the string, might be enough, thanks to the limited set of chars we get in URLs, but not 100% sure)