### PR TITLE
Added three new events to activityHub.js (incoming-call-created,incom…

### DIFF
--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -47,6 +47,9 @@ class ActivityManager {
  */
 function setActivityHandlers(self) {
 	activityHub.on('activities-count-updated', updateActivityCountHandler(self));
+	activityHub.on('incoming-call-created', incomingCallCreatedHandler(self));
+	activityHub.on('incoming-call-connecting', incomingCallConnectingHandler(self));
+	activityHub.on('incoming-call-disconnecting', incomingCallDisconnectingHandler(self));
 	activityHub.on('call-connected', callConnectedHandler(self));
 	activityHub.on('call-disconnected', callDisconnectedHandler(self));
 	activityHub.on('meeting-started', meetingStartNotifyHandler(self));
@@ -67,6 +70,33 @@ function setEventHandlers(self) {
 function updateActivityCountHandler(self) {
 	return async (data) => {
 		self.updateActivityCount(data.count);
+	};
+}
+
+/**
+ * @param {ActivityManager} self 
+ */
+function incomingCallCreatedHandler(self) {
+	return async () => {
+		self.ipcRenderer.invoke('incoming-call-created');
+	};
+}
+
+/**
+ * @param {ActivityManager} self 
+ */
+function incomingCallConnectingHandler(self) {
+	return async () => {
+		self.ipcRenderer.invoke('incoming-call-connecting');
+	};
+}
+
+/**
+ * @param {ActivityManager} self 
+ */
+function incomingCallDisconnectingHandler(self) {
+	return async () => {
+		self.ipcRenderer.invoke('incoming-call-disconnecting');
 	};
 }
 

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -6,6 +6,9 @@ const eventHandlers = [];
 
 // Supported events
 const supportedEvents = [
+	'incoming-call-created',
+	'incoming-call-connecting',
+	'incoming-call-disconnecting',
 	'call-connected',
 	'call-disconnected',
 	'activities-count-updated',
@@ -18,7 +21,7 @@ class ActivityHub {
 	}
 
 	/**
-	 * @param {'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
+	 * @param {'incoming-call-created'|'incoming-call-connecting'|'incoming-call-disconnecting'|'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
 	 * @param {(data)=>void} handler
 	 * @returns {number} handle 
 	 */
@@ -27,7 +30,7 @@ class ActivityHub {
 	}
 
 	/**
-	 * @param {'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
+	 * @param {'incoming-call-created'|'incoming-call-connecting'|'incoming-call-disconnecting'|'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
 	 * @param {number} handle
 	 * @returns {number} handle 
 	 */
@@ -110,7 +113,7 @@ function removeEventHandler(event, handle) {
 
 /**
  * 
- * @param {'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
+ * @param {'incoming-call-created'|'incoming-call-connecting'|'incoming-call-disconnecting'|'call-connected'|'call-disconnected'|'activities-count-updated'|'meeting-started'|'my-status-changed'} event 
  * @returns {Array<{handler:(data)=>void,event:string,handle:number}>} handlers
  */
 function getEventHandlers(event) {
@@ -124,6 +127,9 @@ function getEventHandlers(event) {
  */
 function assignEventHandlers(inst) {
 	assignActivitiesCountUpdateHandler(inst.controller);
+	assignIncomingCallCreatedHandler(inst.controller);
+	assignIncomingCallConnectingHandler(inst.controller);
+	assignIncomingCallDisconnectingHandler(inst.controller);
 	assignCallConnectedHandler(inst.controller);
 	assignCallDisconnectedHandler(inst.controller);
 	assignWorkerMessagingUpdatesHandler(inst.controller);
@@ -211,6 +217,39 @@ function assignActivitiesCountUpdateHandler(controller) {
 	onActivitiesCountUpdated(controller);
 }
 
+function assignIncomingCallCreatedHandler(controller) {
+	controller.eventingService.$on(
+		controller.$scope,
+		controller.constants.events.calling.callCreated,
+		(e, data) => {
+			if (data.signalingSession.isIncomingCall) {
+				onIncomingCallCreated();
+			}
+		});
+}
+
+function assignIncomingCallConnectingHandler(controller) {
+	controller.eventingService.$on(
+		controller.$scope,
+		controller.constants.events.calling.callConnecting,
+		(e, data) => {
+			if (data.signalingSession.isIncomingCall) {
+				onIncomingCallConnecting();
+			}
+		});
+}
+
+function assignIncomingCallDisconnectingHandler(controller) {
+	controller.eventingService.$on(
+		controller.$scope,
+		controller.constants.events.calling.callDisconnecting,
+		(e, data) => {
+			if (data.signalingSession.isIncomingCall) {
+				onIncomingCallDisconnecting();
+			}
+		});
+}
+
 function assignCallConnectedHandler(controller) {
 	controller.eventingService.$on(
 		controller.$scope,
@@ -244,6 +283,27 @@ async function onActivitiesCountUpdated(controller) {
 	const handlers = getEventHandlers('activities-count-updated');
 	for (const handler of handlers) {
 		handler.handler({ count: count });
+	}
+}
+
+async function onIncomingCallCreated() {
+	const handlers = getEventHandlers('incoming-call-created');
+	for (const handler of handlers) {
+		handler.handler({});
+	}
+}
+
+async function onIncomingCallConnecting() {
+	const handlers = getEventHandlers('incoming-call-connecting');
+	for (const handler of handlers) {
+		handler.handler({});
+	}
+}
+
+async function onIncomingCallDisconnecting() {
+	const handlers = getEventHandlers('incoming-call-disconnecting');
+	for (const handler of handlers) {
+		handler.handler({});
 	}
 }
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -51,6 +51,7 @@ Here is the list of available arguments and its usage:
 | url | url to open | [https://teams.microsoft.com/](https://teams.microsoft.com/) |
 | version | show the version number | false |
 | webDebug | Start with the browser developer tools open  |  false |
+| incomingCallCommand | Command to execute on an incoming call | |
 
 
 As an example, to disable the persistence, you can run the following command:

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -218,6 +218,10 @@ function argv(configPath) {
 				describe: 'Type of network test for checking online status.',
 				type: 'string',
 				choices: ['https', 'dns', 'native', 'none']
+			},
+			incomingCallCommand: {
+				default: null,
+				describe: 'Command to execute on an incoming call.'
 			}
 		})
 		.parse(process.argv.slice(1));

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -10,11 +10,13 @@ const { StreamSelector } = require('../streamSelector');
 const { LucidLog } = require('lucid-log');
 const { SpellCheckProvider } = require('../spellCheckProvider');
 const { httpHelper } = require('../helpers');
-const execFile = require('child_process').execFile;
+const { execFile, spawn } = require('child_process');
 const TrayIconChooser = require('../browser/tools/trayIconChooser');
 // eslint-disable-next-line no-unused-vars
 const { AppConfiguration } = require('../appConfiguration');
 const connMgr =  require('../connectionManager');
+
+const commandSplitRegex = /"(\\"|[^"])*?"|(\\ |[^\s])*/gm;
 
 /**
  * @type {TrayIconChooser}
@@ -26,6 +28,8 @@ let blockerId = null;
 let isOnCall = false;
 
 let isControlPressed = false;
+
+let incomingCallCommandProcess = null;
 
 /**
  * @type {URL}
@@ -432,6 +436,9 @@ async function createWindow() {
 function assignEventHandlers(newWindow) {
 	ipcMain.on('select-source', assignSelectSourceHandler());
 	ipcMain.handle('select-source-wayland', assignSelectSourceHandlerWayland());
+	ipcMain.handle('incoming-call-created', handleOnIncomingCallCreated);
+	ipcMain.handle('incoming-call-connecting', incomingCallCommandKill);
+	ipcMain.handle('incoming-call-disconnecting', incomingCallCommandKill);
 	ipcMain.handle('call-connected', handleOnCallConnected);
 	ipcMain.handle('call-disconnected', handleOnCallDisconnected);
 	if (config.screenLockInhibitionMethod === 'WakeLockSentinel') {
@@ -490,6 +497,20 @@ function assignSelectSourceHandler() {
 			event.reply('select-source', source);
 		});
 	};
+}
+
+async function handleOnIncomingCallCreated() {
+	if (!incomingCallCommandProcess && config.incomingCallCommand) {
+		let commandParts = config.incomingCallCommand.match(commandSplitRegex);
+		incomingCallCommandProcess = spawn(commandParts.shift(), commandParts);
+	}
+}
+
+async function incomingCallCommandKill() {
+	if (incomingCallCommandProcess) {
+		incomingCallCommandProcess.kill('SIGKILL');
+		incomingCallCommandProcess = null;
+	}
 }
 
 async function handleOnCallConnected() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
…ing-call-connecting,incoming-call-disconnecting).

These three events are handled inside the index.js of minAppWindow to run a command on an incoming call. The command can be specified as cli argument or inside a config.json as incomingCallCommand parameter. As an example this can be used to play a sound on a second speaker to simulate a second ringer.

Like so:

teams-for-linux --incomingCallCommand second_ringer.sh

second_ringer.sh:
#!/bin/bash
export PULSE_SINK=0
vlc -aout pulse -I dummy ring.mp3