### PR TITLE
Make sure executable is writable before running fuses in afterpack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.25",
+  "version": "1.3.26",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -1,4 +1,5 @@
 const {flipFuses, FuseVersion, FuseV1Options} = require('@electron/fuses');
+const {chmod} = require('fs/promises');
 
 function getAppFileName(context) {
 	const productFileName = context.packager.appInfo.productFilename
@@ -19,8 +20,10 @@ function getAppFileName(context) {
 
 exports.default = async function afterPack(context) {
 	try {
+		const path = `${context.appOutDir}/${getAppFileName(context)}`;
+		await chmod(path, 0o755);
 		await flipFuses(
-			`${context.appOutDir}/${getAppFileName(context)}`,
+			path,
 			{
 			  version: FuseVersion.V1,
 			  [FuseV1Options.EnableCookieEncryption]: true,


### PR DESCRIPTION
When the electron binary that is used to create the `teams-for-linux` binary isn't writable, the `teams-for-linux` binary isn't either. This results in errors when running the afterpack script. This PR makes sure that the binary is writable before running the fuses.