### PR TITLE
- changed kill singal for "incomingCallCommand" from SIGKILL to SIGTE…

### DIFF
--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -77,8 +77,8 @@ function updateActivityCountHandler(self) {
  * @param {ActivityManager} self 
  */
 function incomingCallCreatedHandler(self) {
-	return async () => {
-		self.ipcRenderer.invoke('incoming-call-created');
+	return async (data) => {
+		self.ipcRenderer.invoke('incoming-call-created', data);
 	};
 }
 

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -223,7 +223,7 @@ function assignIncomingCallCreatedHandler(controller) {
 		controller.constants.events.calling.callCreated,
 		(e, data) => {
 			if (data.signalingSession.isIncomingCall) {
-				onIncomingCallCreated();
+				onIncomingCallCreated({ caller: data.signalingSession.remoteCaller.displayName });
 			}
 		});
 }
@@ -286,10 +286,10 @@ async function onActivitiesCountUpdated(controller) {
 	}
 }
 
-async function onIncomingCallCreated() {
+async function onIncomingCallCreated(data) {
 	const handlers = getEventHandlers('incoming-call-created');
 	for (const handler of handlers) {
-		handler.handler({});
+		handler.handler(data);
 	}
 }
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -222,6 +222,10 @@ function argv(configPath) {
 			incomingCallCommand: {
 				default: null,
 				describe: 'Command to execute on an incoming call.'
+			},
+			incomingCallCommandArgs: {
+				default: [],
+				describe: 'Arguments for the incomming call command.'
 			}
 		})
 		.parse(process.argv.slice(1));

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -510,7 +510,8 @@ function assignSelectSourceHandler() {
 }
 
 async function handleOnIncomingCallCreated(e, data) {
-	if (!incomingCallCommandProcess && config.incomingCallCommand) {
+	if (config.incomingCallCommand) {
+		incomingCallCommandTerminate();
 		const commandArgs = [...config.incomingCallCommandArgs, data.caller];
 		incomingCallCommandProcess = spawn(config.incomingCallCommand, commandArgs);
 	}

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -516,7 +516,7 @@ async function handleOnIncomingCallCreated(e, data) {
 	}
 }
 
-async function incomingCallCommandKill() {
+async function incomingCallCommandTerminate() {
 	if (incomingCallCommandProcess) {
 		incomingCallCommandProcess.kill('SIGTERM');
 		incomingCallCommandProcess = null;

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -16,8 +16,6 @@ const TrayIconChooser = require('../browser/tools/trayIconChooser');
 const { AppConfiguration } = require('../appConfiguration');
 const connMgr =  require('../connectionManager');
 
-const commandSplitRegex = /"(\\"|[^"])*?"|(\\ |[^\s])*/gm;
-
 /**
  * @type {TrayIconChooser}
  */
@@ -511,16 +509,16 @@ function assignSelectSourceHandler() {
 	};
 }
 
-async function handleOnIncomingCallCreated() {
+async function handleOnIncomingCallCreated(e, data) {
 	if (!incomingCallCommandProcess && config.incomingCallCommand) {
-		let commandParts = config.incomingCallCommand.match(commandSplitRegex);
-		incomingCallCommandProcess = spawn(commandParts.shift(), commandParts);
+		const commandArgs = [...config.incomingCallCommandArgs, data.caller];
+		incomingCallCommandProcess = spawn(config.incomingCallCommand, commandArgs);
 	}
 }
 
 async function incomingCallCommandKill() {
 	if (incomingCallCommandProcess) {
-		incomingCallCommandProcess.kill('SIGKILL');
+		incomingCallCommandProcess.kill('SIGTERM');
 		incomingCallCommandProcess = null;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.25",
+  "version": "1.3.26",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
- changed kill singal for "incomingCallCommand" from SIGKILL to SIGTERM to get access to the trap functionality in scripts

- added a new argument "incomingCallCommandArgs" to increase argument compatibility and get rid of the regex. "incomingCallCommand" does only contain the executeable from now on.

- if the incomingCallCommand is executed the callers name is now  given as the last argument