### PR TITLE
fix getting version from cli arg with yargs after the Electron 28 bump

### DIFF
--- a/app/appConfiguration/index.js
+++ b/app/appConfiguration/index.js
@@ -9,9 +9,9 @@ class AppConfiguration {
 	/**
 	 * @param {string} configPath 
 	 */
-	constructor(configPath) {
+	constructor(configPath, appVersion) {
 		_AppConfiguration_configPath.set(this, configPath);
-		_AppConfiguration_startupConfig.set(this, require('../config')(configPath));
+		_AppConfiguration_startupConfig.set(this, require('../config')(configPath, appVersion));
 		_AppConfiguration_legacyConfigStore.set(this, new Store({
 			name: 'config'
 		}));

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -12,13 +12,14 @@ function getConfigFile(configPath) {
 	}
 }
 
-function argv(configPath) {
+function argv(configPath, appVersion) {
 	let configFile = getConfigFile(configPath);
 	const missingConfig = configFile == null;
 	configFile = configFile || {};
 	let config = yargs
 		.env(true)
 		.config(configFile)
+		.version(appVersion)
 		.options({
 			appActiveCheckInterval: {
 				default: 2,

--- a/app/index.js
+++ b/app/index.js
@@ -12,7 +12,7 @@ if (app.commandLine.hasSwitch('customUserDir')) {
 }
 
 const { AppConfiguration } = require('./appConfiguration');
-const appConfig = new AppConfiguration(app.getPath('userData'));
+const appConfig = new AppConfiguration(app.getPath('userData'), app.getVersion());
 
 const config = appConfig.startupConfig;
 config.appPath = path.join(__dirname, isDev ? '' : '../../');


### PR DESCRIPTION
After the Electron 28 bump, `teams-for-linux --version` is not working for us (nixpkgs) when packaged as ASAR and using our own build of Electron (it gives an `unknown` output)

This seems to be because yargs expects `require.main.filename` to exist (see [here](https://github.com/yargs/yargs/blob/e517318cea0087b813f5de414b3cdec7b70efe33/lib/yargs-factory.ts#L1617) and [here](https://github.com/yargs/yargs/blob/e517318cea0087b813f5de414b3cdec7b70efe33/lib/platform-shims/cjs.ts#L23)), but that is no longer the case with Electron 28 and is a more-or-less intended change by Electron upstream: electron/electron#40501

I'm not sure if this PR is the best solution (I'm not too familiar with the codebase), but more or less this PR propagates `app.getVersion()` to the yargs call and manually tells it what version number to use, since the `package.json` finding now fails for yargs, but Electron does know the correct app version number

Let me know if you would like the implementation tweaked. Also thank you for your work on teams-for-linux!

Side note: Switching from CJS entrypoint to ESM entrypoints would probably also fix the issue, but that would be a much more involved change to teams-for-linux than I am comfortable with doing myself, so I opted for a simple fix we can apply now