### PR TITLE
rework wayland screenshare source selection

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -18,7 +18,6 @@ Here is the list of available arguments and its usage:
 | appLogLevels | Comma separated list of log levels (error,warn,info,debug) | error,warn |
 | appTitle |  A text to be suffixed with page title | Microsoft Teams |
 | authServerWhitelist | set auth-server-whitelist value | * |
-| bypassWaylandSourceSelection | A flag indicates whether to bypass wayland source selection dialog when screen a share request is received | false |
 | chromeUserAgent | user agent string for chrome | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3831.6 Safari/537.36 |
 | customBGServiceBaseUrl | Base URL of the server which provides custom background images | http://localhost |
 | customBGServiceConfigFetchInterval | A numeric value in seconds as poll interval to download custom background service configuration. If 0, it will be downloaded only at application start | 0 |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -62,11 +62,6 @@ function argv(configPath, appVersion) {
 				describe: 'Set auth-server-whitelist value',
 				type: 'string'
 			},
-			bypassWaylandSourceSelection: {
-				default: false,
-				describe: 'A flag indicates whether to bypass wayland source selection dialog when screen a share request is received',
-				type: 'boolean'
-			},
 			chromeUserAgent: {
 				default: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${process.versions.chrome} Safari/537.36`,
 				describe: 'Google Chrome User Agent',

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -445,7 +445,6 @@ async function createWindow() {
 
 function assignEventHandlers(newWindow) {
 	ipcMain.on('select-source', assignSelectSourceHandler());
-	ipcMain.handle('select-source-wayland', assignSelectSourceHandlerWayland());
 	ipcMain.handle('incoming-call-created', handleOnIncomingCallCreated);
 	ipcMain.handle('incoming-call-connecting', incomingCallCommandTerminate);
 	ipcMain.handle('incoming-call-disconnecting', incomingCallCommandTerminate);
@@ -481,25 +480,6 @@ function createNewBrowserWindow(windowState) {
 	});
 }
 
-function assignSelectSourceHandlerWayland() {
-	return async () => {
-		if (config.bypassWaylandSourceSelection) {
-			return 'default';
-		}
-
-		const actionValues = ['monitor', 'window', 'none'];
-		const action = await dialog.showMessageBox(window, {
-			type: 'question',
-			buttons: ['Monitor', 'Window', 'Cancel'],
-			title: 'Type of source',
-			normalizeAccessKeys: true,
-			defaultId: 0,
-			cancelId: 2,
-			message: 'Please choose the type of source (Monitor/Window)'
-		});
-		return actionValues[action.response];
-	};
-}
 function assignSelectSourceHandler() {
 	return event => {
 		const streamSelector = new StreamSelector(window);

--- a/app/streamSelector/browser.js
+++ b/app/streamSelector/browser.js
@@ -3,35 +3,12 @@ window.addEventListener('DOMContentLoaded', init());
 
 function init() {
 	return () => {
-		if (process.env['XDG_SESSION_TYPE'] === 'wayland') {
-			//Pipewire dialog already allows user to select screen/window so request directly to avoid prompting user multiple times to select screen
-			initRequestSource(requestSingleScreenOrWindow);
-		} else {
-			initRequestSource(createPreviewScreen);
-		}
+		ipcRenderer.once('get-screensizes-response', (event, screens) => {
+			createPreviewScreen(screens);
+		});
+		ipcRenderer.send('get-screensizes-request');
 	};
 }
-
-function initRequestSource(callback) {
-	ipcRenderer.once('get-screensizes-response', (event, screens) => {
-		callback(screens);
-	});
-	ipcRenderer.send('get-screensizes-request');
-}
-
-function requestSingleScreenOrWindow(screens) {
-	ipcRenderer.invoke('desktopCapturerGetSources', { types: ['screen'] }).then(async (sources) => {
-		if (sources.length === 0)
-			return;
-
-		const properties = {
-			id: sources[0].id,
-			screen: screens.find(s => s.default)
-		};
-		ipcRenderer.send('selected-source', properties);
-	});
-}
-
 
 function createPreviewScreen(screens) {
 	let windowsIndex = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
I've been experiencing the issue described in #912 and did a bit of investigation. It seems that the issue can be resolved by calling the electron desktopCapturer getSources method rather than navigator.mediaDevices.getDisplayMedia directly as the app is currently doing. 

This pull request makes the following changes:
- Amend chromeApi.js to call desktopCapturerGetSources rather than navigator.mediaDevices.getDisplayMedia on wayland and hence fix #912
- Remove the bypassWaylandSourceSelection parameter since you can now request screen or window on desktopCapturerGetSources (the portal dialogue has a tab for screens and another for windows, see screenshots which removed the need for the current separate selection dialogue)
- Removed unused wayland handling code from streamSelector/browser.js (this is only used for X11 now).

Tested on KDE Wayland, Gnome Wayland and  Hyprland

KDE desktop portal
![teams-for-linux-kde](https://github.com/IsmaelMartinez/teams-for-linux/assets/56479007/66a1127c-0aac-47c1-8e59-13c66ec1dff0)

Gnome desktop portal
![teams-for-linux-gnome](https://github.com/IsmaelMartinez/teams-for-linux/assets/56479007/772b6add-9878-4de5-b861-87c80e4fead5)

