### PR TITLE
Navigation on Mac with Command instead of Option

### DIFF
--- a/app/browser/tools/shortcuts.js
+++ b/app/browser/tools/shortcuts.js
@@ -25,14 +25,17 @@ class Shortcuts {
 	}
 }
 
+const isMac = os.platform() === 'darwin';
+const navigationModifiedKey = isMac ? 'META' : 'ALT';
+
 const KEY_MAPS = {
 	'CTRL_+': () => zoom.increaseZoomLevel(),
 	'CTRL_=': () => zoom.increaseZoomLevel(),
 	'CTRL_-': () => zoom.decreaseZoomLevel(),
 	'CTRL__': () => zoom.decreaseZoomLevel(),
 	'CTRL_0': () => zoom.resetZoomLevel(),
-	'ALT_ArrowLeft': () => window.history.back(),
-	'ALT_ArrowRight': () => window.history.forward()
+	[`${navigationModifiedKey}_ArrowLeft`]: () => window.history.back(),
+	[`${navigationModifiedKey}_ArrowRight`]: () => window.history.forward()
 };
 
 function initInternal() {
@@ -70,7 +73,7 @@ function whenIframeReady(callback) {
 
 function keyDownEventHandler(event) {
 	const keyName = event.key;
-	if (keyName === 'Control' || keyName === 'Alt') {
+	if (keyName === 'Control' || keyName === 'Alt' || keyName === 'Meta') {
 		return;
 	}
 
@@ -89,7 +92,7 @@ function wheelEventHandler(event) {
 }
 
 function getKeyName(event, keyName) {
-	return `${event.ctrlKey ? 'CTRL_' : ''}${event.altKey ? 'ALT_' : ''}${keyName}`;
+	return `${event.ctrlKey ? 'CTRL_' : ''}${event.altKey ? 'ALT_' : ''}${event.metaKey ? 'META_': ''}${keyName}`;
 }
 
 function fireEvent(event, keyName) {

--- a/app/browser/tools/shortcuts.js
+++ b/app/browser/tools/shortcuts.js
@@ -26,7 +26,6 @@ class Shortcuts {
 }
 
 const isMac = os.platform() === 'darwin';
-const navigationModifiedKey = isMac ? 'META' : 'ALT';
 
 const KEY_MAPS = {
 	'CTRL_+': () => zoom.increaseZoomLevel(),
@@ -34,8 +33,14 @@ const KEY_MAPS = {
 	'CTRL_-': () => zoom.decreaseZoomLevel(),
 	'CTRL__': () => zoom.decreaseZoomLevel(),
 	'CTRL_0': () => zoom.resetZoomLevel(),
-	[`${navigationModifiedKey}_ArrowLeft`]: () => window.history.back(),
-	[`${navigationModifiedKey}_ArrowRight`]: () => window.history.forward()
+	// Alt (Option) Left / Right is used to jump words in Mac, so diabling the history navigation for Mac here
+	...(!isMac ? 
+		{ 
+			'ALT_ArrowLeft': () => window.history.back(),
+		    'ALT_ArrowRight': () => window.history.forward()
+		} 
+		: {}
+		)
 };
 
 function initInternal() {
@@ -73,7 +78,7 @@ function whenIframeReady(callback) {
 
 function keyDownEventHandler(event) {
 	const keyName = event.key;
-	if (keyName === 'Control' || keyName === 'Alt' || keyName === 'Meta') {
+	if (keyName === 'Control' || keyName === 'Alt') {
 		return;
 	}
 
@@ -92,7 +97,7 @@ function wheelEventHandler(event) {
 }
 
 function getKeyName(event, keyName) {
-	return `${event.ctrlKey ? 'CTRL_' : ''}${event.altKey ? 'ALT_' : ''}${event.metaKey ? 'META_': ''}${keyName}`;
+	return `${event.ctrlKey ? 'CTRL_' : ''}${event.altKey ? 'ALT_' : ''}${keyName}`;
 }
 
 function fireEvent(event, keyName) {

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.11" date="2024-02-14">
+			<description>
+				<ul>
+					<li>Fix: MacOS - Disable Option + Left / Right keyboard shortcuts for history navigation (it is used for word jumping on MacOS)</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.10" date="2024-02-04">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Fixes https://github.com/IsmaelMartinez/teams-for-linux/issues/1101

I first wanted to replace the problematic `Option + Left` with `Command + Left` for history navigation, but it did not work for some reason, so I ended up removing the history navigation shortcuts completely for Mac.