### PR TITLE
add support for changing idle (away) state in Teams2

### DIFF
--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -56,15 +56,31 @@ class ActivityHub {
 	 * @param {number} state 
 	 */
 	setMachineState(state) {
-		instance.whenReady().then((inst) => {
-			if (state === 1) {
-				this.refreshAppState(inst.controller, state);
-			} else {
-				inst.controller.appStateService.setMachineState(state);
+		const teams2IdleTracker = instance.getTeams2IdleTracker();
+		if (teams2IdleTracker) {
+			try {
+				console.log(`setMachineState teams2 state=${state}`);
+				if (state === 1) {
+					// ALTERNATIVE: teams2IdleTracker._idleStateBehaviorSubject.next('Active');
+					teams2IdleTracker.handleMonitoredWindowEvent();
+				} else {
+					// ALTERNATIVE: teams2IdleTracker._idleStateBehaviorSubject.next('Inactive');
+					teams2IdleTracker.transitionToIdle();
+				}
+			} catch(e) {
+				console.error('Failed to set teams2 Machine State', e);
 			}
-		}).catch(() => {
-			console.error('Failed to set Machine State');
-		});
+		} else {
+			instance.whenReady().then((inst) => {
+				if (state === 1) {
+					this.refreshAppState(inst.controller, state);
+				} else {
+					inst.controller.appStateService.setMachineState(state);
+				}
+			}).catch(() => {
+				console.error('Failed to set Machine State');
+			});
+		}
 	}
 
 	/**

--- a/app/browser/tools/instance.js
+++ b/app/browser/tools/instance.js
@@ -15,6 +15,18 @@ class Instance {
 			return await this.whenReady(tries + 1);
 		}
 	}
+
+	getTeams2ReactElement() {
+		return document.getElementById('app');
+	}
+
+	getTeams2CoreServices() {
+		return this.getTeams2ReactElement()?._reactRootContainer?._internalRoot?.current?.updateQueue?.baseState?.element?.props?.coreServices;
+	}
+
+	getTeams2IdleTracker() {
+		return this.getTeams2CoreServices()?.clientState?._idleTracker;
+	}
 }
 
 function getAppObjects() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
My state in Teams2.0 always went to "absent" when I did not move my mouse over the teams window at least once every 5 minutes (some users reported this in #1006). This PR interacts with the Teams2.0 core service via the react root element to change the idle state.
