### PR TITLE
fix: build universal app for Mac

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+	    <release version="1.4.29" date="2024-04-22">
+			<description>
+				<ul>
+					<li>Build universal app for Mac, to support Apple Silicon as well as Intel Macs</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.28" date="2024-04-17">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -31,7 +31,7 @@
     "dist:linux:appimage": "electron-builder --x64 --armv7l --arm64 -l AppImage",
     "dist:linux:snap": "electron-builder -l snap",
     "dist:linux:snap:armv7l": "electron-builder --armv7l -l snap",
-    "dist:mac": "electron-builder --mac",
+    "dist:mac": "electron-builder --mac --universal",
     "dist:windows": "electron-builder --windows --x64",
     "dist:linux:x64": "electron-builder --x64 -l tar.gz deb rpm AppImage",
     "dist:linux:arm64": "electron-builder --arm64 -l tar.gz deb rpm AppImage",


### PR DESCRIPTION
Fixes #684

Electron builder now simply has `--universal` option. Tested on M1 mac.