### PR TITLE
enable useMutationTitleLogic by default

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -52,7 +52,7 @@ Here is the list of available arguments and its usage:
 | screenLockInhibitionMethod      | Screen lock inhibition method to be used (`Electron`/`WakeLockSentinel`)                      | Electron                |
 | spellCheckerLanguages           | Array of languages to use with Electron's spell checker                    | []                 |
 | url                             | Microsoft Teams URL                                                                      | string                |
-| useMutationTitleLogic         | Use MutationObserver to update counter from title                                          | false               |
+| useMutationTitleLogic         | Use MutationObserver to update counter from title                                          | true               |
 | version                         | Show the version number                                                                  | false                 |
 | webDebug                        | Enable web debugging                                                                     | false               |
 | electronCLIFlags | Electron CLI flags to be added when the app starts | [] |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -234,7 +234,7 @@ function argv(configPath, appVersion) {
 				type: 'string'
 			},
 			useMutationTitleLogic: {
-				default: false,
+				default: true,
 				describe: 'Use MutationObserver to update counter from title',
 				type: 'boolean'
 			},

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.30" date="2024-04-24">
+			<description>
+				<ul>
+					<li>Enable useMutationTitleLogic by default</li>
+				</ul>
+			</description>
+		</release>
 	    <release version="1.4.29" date="2024-04-22">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.29",
+  "version": "1.4.30",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Enabling the useMutationTitleLogic by default to on the back of https://github.com/IsmaelMartinez/teams-for-linux/issues/1218 and https://github.com/IsmaelMartinez/teams-for-linux/issues/1207