### PR TITLE
Custom backgrounds in Teams V2

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -112,6 +112,7 @@ We added a feature to load custom background images during a video call. This is
 2. 3 new command-line parameters `customBGServiceBaseUrl`, `customBGServiceIgnoreMSDefaults` and `customBGServiceConfigFetchInterval` are introduced. See above for details.
 3. Custom images are always loaded with `<customBGServiceBaseUrl>/<image-path>`. So, you have to make sure the web server is running and `<customBGServiceBaseUrl>` responds to the request.
 4. You can choose any web server of your choice but make sure `Access-Control-Allow-Origin` is set to `*` in response headers from web server.
+5. In Teams version 2, this will replace Microsoft's default images.
 
 For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
 ```xml
@@ -126,8 +127,8 @@ For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
 ### Configuring list of images
 
 1. List of images are to be stored in `<customBGServiceBaseUrl>/config.json`.
-2. It would look like this:
-```js
+2. In Teams V1, it would look like this:
+```json
 [
 	{
 		"filetype": "jpg",
@@ -137,8 +138,22 @@ For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
 		"thumb_src": "/<path-to-thumb-image>"
 	}
 ]
-
 ```
+3. In Teams V2, it would look like this:
+```json
+{
+	"videoBackgroundImages": [
+		{
+			"filetype": "png",
+			"id": "Custom_bg01",
+			"name": "Custom bg",
+			"src": "/evergreen-assets/backgroundimages/<path-to-image>",
+			"thumb_src": "/evergreen-assets/backgroundimages/<path-to-thumb-image>"
+		}
+	]
+}
+```
+
 As you can see from the above example, it's a JSON array so you can configure any number of images of your choice.
 
 ### About the entries
@@ -146,6 +161,6 @@ As you can see from the above example, it's a JSON array so you can configure an
 - `id`: Id of the image. Give a unique name without spaces.
 - `name`: Name of your image.
 - `src`: Path to the image to be loaded when selected from the preview. Provide a picture with resolution 1920x1080 (Based on Microsoft CDN) though any resolution would work. This is to avoid unnecessary traffic by loading large size images.
-- `thumb_src`: Path to the image to be shown on the preview screen. Provide a low resolution picture (280x158 based on Microsoft CDN) as it's shown on the preview page. The smaller the image the quicker the preview will be. 
+- `thumb_src`: Path to the image to be shown on the preview screen. Provide a low resolution picture (280x158 based on Microsoft CDN) as it's shown on the preview page. The smaller the image the quicker the preview will be.
 
 Image paths are relative to `customBGServiceBaseUrl`. If your image is at `https://example.com/images/sample.jpg`, then `src` would be `/images/sample.jpg`.

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -112,7 +112,7 @@ We added a feature to load custom background images during a video call. This is
 2. 3 new command-line parameters `customBGServiceBaseUrl`, `customBGServiceIgnoreMSDefaults` and `customBGServiceConfigFetchInterval` are introduced. See above for details.
 3. Custom images are always loaded with `<customBGServiceBaseUrl>/<image-path>`. So, you have to make sure the web server is running and `<customBGServiceBaseUrl>` responds to the request.
 4. You can choose any web server of your choice but make sure `Access-Control-Allow-Origin` is set to `*` in response headers from web server.
-5. In Teams version 2, this will replace Microsoft's default images.
+5. In Teams version 2, this will replace Microsoft's default images. To use standard Microsoft images, you must activate the flag --isCustomBackgroundEnabled=false
 
 For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
 ```xml

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -44,7 +44,7 @@ Here is the list of available arguments and its usage:
 | electronCLIFlags | Electron CLI flags to be added when the app starts | [] |
 | incomingCallCommand             | Command to execute on an incoming call.                                                   |                       |
 | incomingCallCommandArgs         | Arguments for the incomming call command.                                                 |                       |
-| isCustomBackgroundEnabled	   | A flag indicates whether to enable custom background images or not                       | true               |
+| isCustomBackgroundEnabled	   | A flag indicates whether to enable custom background images or not                       | false              |
 | menubar                         | A value controls the menu bar behaviour                                                   | string                |
 | minimized                       | Start the application minimized                                                          | false               |
 | notificationMethod | Notification method to be used by the application (`web`/`electron`) | web |

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -112,7 +112,8 @@ We added a feature to load custom background images during a video call. This is
 2. 3 new command-line parameters `customBGServiceBaseUrl`, `customBGServiceIgnoreMSDefaults` and `customBGServiceConfigFetchInterval` are introduced. See above for details.
 3. Custom images are always loaded with `<customBGServiceBaseUrl>/<image-path>`. So, you have to make sure the web server is running and `<customBGServiceBaseUrl>` responds to the request.
 4. You can choose any web server of your choice but make sure `Access-Control-Allow-Origin` is set to `*` in response headers from web server.
-5. In Teams version 2, this will replace Microsoft's default images. To use standard Microsoft images, you must activate the flag --isCustomBackgroundEnabled=false
+5. In Teams version 2, this will replace Microsoft's default images.
+6. To use you must activate the flag `--isCustomBackgroundEnabled=true`. From version 1.4.36 this flag is change default to `false`.
 
 For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
 ```xml

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -192,7 +192,7 @@ function argv(configPath, appVersion) {
 				describe: 'Arguments for the incomming call command.'
 			},
 			isCustomBackgroundEnabled: {
-				default: true,
+				default: false,
 				describe: 'A flag indicates whether to enable custom background or not',
 				type: 'boolean'
 			},

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -253,7 +253,7 @@ function onBeforeRequestHandler(details, callback) {
 		callback({ redirectURL: imgUrl });
 	}
 	// Custom background replace for teams v2
-	else if (details.url.startsWith('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/')) {
+	else if (details.url.startsWith('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/' && config.isCustomBackgroundEnabled)) {
 		const reqUrl = details.url.replace('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/', '');
 		const imgUrl = getBGRedirectUrl(reqUrl);
 		logger.debug(`Forwarding '${details.url}' to '${imgUrl}'`);

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -56,7 +56,7 @@ let window = null;
 let appConfig = null;
 
 /**
- * @param {AppConfiguration} configGroup 
+ * @param {AppConfiguration} configGroup
  */
 exports.onAppReady = async function onAppReady(configGroup) {
 	appConfig = configGroup;
@@ -242,12 +242,19 @@ function processArgs(args) {
 }
 
 /**
- * @param {Electron.OnBeforeRequestListenerDetails} details 
- * @param {Electron.CallbackResponse} callback 
+ * @param {Electron.OnBeforeRequestListenerDetails} details
+ * @param {Electron.CallbackResponse} callback
  */
 function onBeforeRequestHandler(details, callback) {
 	if (details.url.startsWith('https://statics.teams.cdn.office.net/teams-for-linux/custom-bg/')) {
 		const reqUrl = details.url.replace('https://statics.teams.cdn.office.net/teams-for-linux/custom-bg/', '');
+		const imgUrl = getBGRedirectUrl(reqUrl);
+		logger.debug(`Forwarding '${details.url}' to '${imgUrl}'`);
+		callback({ redirectURL: imgUrl });
+	}
+	// Custom background replace for teams v2
+	else if (details.url.startsWith('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/')) {
+		const reqUrl = details.url.replace('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/', '');
 		const imgUrl = getBGRedirectUrl(reqUrl);
 		logger.debug(`Forwarding '${details.url}' to '${imgUrl}'`);
 		callback({ redirectURL: imgUrl });
@@ -272,8 +279,8 @@ function getBGRedirectUrl(rel) {
 }
 
 /**
- * @param {Electron.OnHeadersReceivedListenerDetails} details 
- * @param {Electron.HeadersReceivedResponse} callback 
+ * @param {Electron.OnHeadersReceivedListenerDetails} details
+ * @param {Electron.HeadersReceivedResponse} callback
  */
 function onHeadersReceivedHandler(details, callback) {
 	if (details.responseHeaders['content-security-policy']) {
@@ -302,8 +309,8 @@ function setImgSrcSecurityPolicy(policies) {
 }
 
 /**
- * @param {Electron.OnBeforeSendHeadersListenerDetails} detail 
- * @param {Electron.BeforeSendResponse} callback 
+ * @param {Electron.OnBeforeSendHeadersListenerDetails} detail
+ * @param {Electron.BeforeSendResponse} callback
  */
 function onBeforeSendHeadersHandler(detail, callback) {
 	if (detail.url.startsWith(customBGServiceUrl.href)) {
@@ -315,7 +322,7 @@ function onBeforeSendHeadersHandler(detail, callback) {
 }
 
 /**
- * @param {Electron.HandlerDetails} details 
+ * @param {Electron.HandlerDetails} details
  * @returns {{action: 'deny'} | {action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions}}
  */
 function onNewWindow(details) {
@@ -335,7 +342,7 @@ function onNewWindow(details) {
 }
 
 /**
- * @param {string} url 
+ * @param {string} url
  */
 async function writeUrlBlockLog(url) {
 	const curBlockTime = new Date();
@@ -354,7 +361,7 @@ async function writeUrlBlockLog(url) {
 }
 
 /**
- * @param {Error} e 
+ * @param {Error} e
  */
 function onLogStreamError(e) {
 	if (e) {
@@ -404,15 +411,15 @@ function initializeCustomBGServiceURL() {
 
 
 /**
- * @param {Electron.Event} event 
- * @param {Electron.Input} input 
+ * @param {Electron.Event} event
+ * @param {Electron.Input} input
  */
 function onBeforeInput(event, input) {
 	isControlPressed = input.control;
 }
 
 /**
- * @param {Electron.HandlerDetails} details 
+ * @param {Electron.HandlerDetails} details
  * @returns {{action: 'deny'} | {action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions}}
  */
 function secureOpenLink(details) {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -253,7 +253,7 @@ function onBeforeRequestHandler(details, callback) {
 		callback({ redirectURL: imgUrl });
 	}
 	// Custom background replace for teams v2
-	else if (details.url.startsWith('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/' && config.isCustomBackgroundEnabled)) {
+	else if (details.url.startsWith('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/') && config.isCustomBackgroundEnabled) {
 		const reqUrl = details.url.replace('https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/', '');
 		const imgUrl = getBGRedirectUrl(reqUrl);
 		logger.debug(`Forwarding '${details.url}' to '${imgUrl}'`);

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.36" date="2024-05-03">
+			<description>
+				<ul>
+					<li>Fix custom backgrounds in Teams V2</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.35" date="2024-05-03">
 			<description>
 				<ul>
@@ -1039,9 +1046,9 @@
 			<description>
 				<p>
 					While we wait for Microsoft... Here we go, we are now version 1.0.0 🍾🎉
-					
+
 					This release has been focus on fixing small issues, improving config options (specially for proxy),
-					adding some bots to help automation, adding more functionality to the right click button 
+					adding some bots to help automation, adding more functionality to the right click button
 					and automatically place your downloads into the download folder (opt in feature)
 				</p>
 				<ul>
@@ -1064,13 +1071,13 @@
 				</ul>
 				<p>
 					Thanks to @standagh, @emanuelbatista, @jef79m and everybody that created issues/enhancements, fixed and/or tested them.
-					
+
 					Special thanks to @julian-alarcon for continuously supporting the snap version of this project and to anyone else that is supporting other package types.
-					
+
 					Thanks also to @byteSamurai for introducing hacktoverfest. I manage to get a t-shirt and to get a few people on my team to also contribute.
-					
+
 					Its been a long ride, and looks like Microsoft has heard us out loud, but until they got something working as stable as this, I will continue contributing.
-					
+
 					Release notes partly done by Stamp.
 				</p>
 			</description>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Teams V2 changed the image and configuration search url to: https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/config.json?v=6

This implementation only replaces the root url (https://statics.teams.cdn.office.net/evergreen-assets/backgroundimages/) to fetch the local custom images.

This will replace Microsoft's default images.

To use standard Microsoft images, you must activate the flag --isCustomBackgroundEnabled=false

Fix #1167 