### PR TITLE
fix: adapt to upstream react changes for idle tracking

### DIFF
--- a/app/browser/tools/reactHandler.js
+++ b/app/browser/tools/reactHandler.js
@@ -15,7 +15,8 @@ class ReactHandler {
 
     _getTeams2CoreServices() {
         const reactElement = this._getTeams2ReactElement();
-        return reactElement?._reactRootContainer?._internalRoot?.current?.updateQueue?.baseState?.element?.props?.coreServices;
+        const internalRoot = reactElement?._reactRootContainer?._internalRoot || reactElement?._reactRootContainer;
+        return internalRoot?.current?.updateQueue?.baseState?.element?.props?.coreServices;
     }
 }
 

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.35" date="2024-05-03">
+			<description>
+				<ul>
+					<li>Fix for away status detection (idle tracking)</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.34" date="2024-05-01">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.34",
+  "version": "1.4.35",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
It seems like the Teams developers changed some of the internal structure of how to access the core services components.  This commit makes accessing the core services more robust by trying out different attribute paths.

Possibly related to #1198