### PR TITLE
Improve wording referencing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Also available in:
 
 <a href='https://flathub.org/apps/details/com.github.IsmaelMartinez.teams_for_linux'><img width='170' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
-## Starting arguments
+## Configuration and starting arguments
 
-Check in the config [`README.md`](app/config/README.md) in the config folder.
+Please check in the config [`README.md`](app/config/README.md) of the config folder for startup or configuration options, to enable or disable certain features or behaviors.
 
 ## Contributing
 


### PR DESCRIPTION
To make it easier for new people to find where and how to set the configs make the statement more clear that config-file is described in the same file as startup options