### PR TITLE
Support for SSO basic-auth without dialogue.

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -55,6 +55,11 @@ Here is the list of available arguments and its usage:
 | proxyServer                     | Proxy Server with format address:port                                                     | string                |
 | screenLockInhibitionMethod      | Screen lock inhibition method to be used (`Electron`/`WakeLockSentinel`)                      | Electron                |
 | spellCheckerLanguages           | Array of languages to use with Electron's spell checker                    | []                 |
+
+| ssoUser           | Login that will be sent for basic_auth SSO login. | string                 |
+
+| ssoPasswordCommand           | Command to execute, grab stdout and use it as a password for basic_auth SSO login. | string                 |
+
 | url                             | Microsoft Teams URL                                                                      | string                |
 | useMutationTitleLogic         | Use MutationObserver to update counter from title                                          | true               |
 | version                         | Show the version number                                                                  | false                 |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -265,6 +265,16 @@ function argv(configPath, appVersion) {
 				describe: 'Array of languages to use with Electron\'s spell checker (experimental)',
 				type: 'array'
 			},
+			ssoUser: {
+				default: '',
+				describe: 'User to use for SSO auth.',
+				type: 'string'
+			},
+			ssoPasswordCommand: {
+				default: '',
+				describe: 'Command to execute to retrieve password for SSO auth.',
+				type: 'string'
+			},
 			url: {
 				default: 'https://teams.microsoft.com/',
 				describe: 'Microsoft Teams URL',

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -73,6 +73,8 @@ exports.onAppReady = async function onAppReady(configGroup) {
 
 	addEventHandlers();
 
+	login.handleLoginDialogTry(window, {'ssoUser': config.ssoUser, 'ssoPasswordCommand': config.ssoPasswordCommand});
+
 	const url = processArgs(process.argv);
 	connMgr.start(url, {
 		window: window,
@@ -386,7 +388,6 @@ function addEventHandlers() {
 	window.webContents.session.webRequest.onBeforeRequest({ urls: ['https://*/*'] }, onBeforeRequestHandler);
 	window.webContents.session.webRequest.onHeadersReceived({ urls: ['https://*/*'] }, onHeadersReceivedHandler);
 	window.webContents.session.webRequest.onBeforeSendHeaders(getWebRequestFilterFromURL(), onBeforeSendHeadersHandler);
-	login.handleLoginDialogTry(window);
 	window.webContents.on('did-finish-load', onDidFinishLoad);
 	window.webContents.on('did-frame-finish-load', onDidFrameFinishLoad);
 	window.on('closed', onWindowClosed);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.4.39",
+  "version": "1.4.40",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Added two new config keys : `ssoUser`, `ssoPasswordCommand` that will be used instead of the regular login/password dialogue.

Authentication will be setup with the `login` with content of `ssoUser` key, and the password will be the stdout of the execution of the command in `ssoPasswordCommand`.

Example of config :

```json
{
  "ssoUser": "Thomas",
  "ssoPasswordCommand": "gopass -o work/mycompany.com"
}
```