### PR TITLE
adding --rpm-digest=sha256 to fix RPM insatll on FIPS enabled system

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.5.2" date="2024-05-28">
+			<description>
+				<ul>
+					<li>Adding --rpm-digest=sha256 to fix RPM insatll on FIPS enabled system</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.5.1" date="2024-05-28">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -96,7 +96,8 @@
     },
     "rpm": {
       "fpm": [
-        "--rpm-rpmbuild-define=_build_id_links none"
+        "--rpm-rpmbuild-define=_build_id_links  none",
+        "--rpm-digest=sha256" 
       ]
     },
     "snap": {


### PR DESCRIPTION
This might solve https://github.com/IsmaelMartinez/teams-for-linux/issues/1205