### PR TITLE
Fix #1313 Attach appropriate function to ipc "select-souce" to fix screen sharing

### DIFF
--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -69,7 +69,7 @@ class BrowserWindowManager {
 
 
     assignEventHandlers() {
-        ipcMain.on('select-source', this.assignSelectSourceHandler);
+        ipcMain.on('select-source', this.assignSelectSourceHandler());
         ipcMain.handle('incoming-call-created', this.handleOnIncomingCallCreated);
         ipcMain.handle('incoming-call-connecting', this.incomingCallCommandTerminate);
         ipcMain.handle('incoming-call-disconnecting', this.incomingCallCommandTerminate);

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.7.4" date="2024-06-25">
+			<description>
+				<ul>
+					<li>FIX broken screen sharing during calls</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.7.3" date="2024-06-18">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
In order to test I ran:

```bash
npm run dist:linux:appimage 
```

Then:

```bash
./dist/teams-for-linux-1.7.3.AppImage --no-sandbox
```

And I was able to successfully screen share during a call.