### PR TITLE
Fix awayOnSystemIdle behaviour when locking the screen: now it shows …

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.8.1" date="2024-07-10">
+			<description>
+				<ul>
+					<li>Fix awayOnSystemIdle behaviour when locking the screen: now it shows status as "Available" when locking the screen with awayOnSystemIdle = false</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.8.0" date="2024-07-08">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
…status as 'Available' when locking the screen with awayOnSystemIdle = false

See related discussions https://github.com/IsmaelMartinez/teams-for-linux/issues/1329 and https://github.com/IsmaelMartinez/teams-for-linux/issues/1320