### PR TITLE
Add cli option to set WM_CLASS property

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -24,6 +24,7 @@ Here is the list of available arguments and its usage:
 | authServerWhitelist             | Set auth-server-whitelist value (string)                                                           | *                |
 | awayOnSystemIdle                | Boolean to set the user status as away when system goes idle                                        | false               |
 | chromeUserAgent                 | Google Chrome User Agent                                                                 | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${process.versions.chrome} Safari/537.36                |
+| class							  | A custom value for the WM_CLASS property                                                  |                 |
 | contextIsolation 	   | Use context isolation in the renderer process (disabling this will break some functionality) | false               |
 | customBGServiceBaseUrl          | Base URL of the server which provides custom background images                            | http://localhost                |
 | customBGServiceIgnoreMSDefaults | A boolean flag indicates whether to ignore Microsoft provided images or not                       | false               |
@@ -247,4 +248,4 @@ or more complex
 
 ### Limitations
 
-I haven't explore all the options available in the `electron-log` configuration, so I can't guarantee all the options would work. (specially those options that require a function to be passed) 
+I haven't explore all the options available in the `electron-log` configuration, so I can't guarantee all the options would work. (specially those options that require a function to be passed)

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -133,6 +133,11 @@ function extractYargConfig(configObject, appVersion) {
 				describe: 'Custom User Directory so that you can have multiple profiles',
 				type: 'string'
 			},
+			class: {
+				default: null,
+				describe: 'A custom value for the WM_CLASS property',
+				type: 'string',
+			},
 			clearStorage: {
 				default: false,
 				describe: 'Whether to clear the storage before creating the window or not',
@@ -363,9 +368,9 @@ function argv(configPath, appVersion) {
 		configWarning: null,
 		isConfigFile: false
 	}
-	
+
 	populateConfigObjectFromFile(configObject, configPath);
-	
+
 	let config = extractYargConfig(configObject, appVersion);
 
 	if (configObject.configError) {

--- a/app/index.js
+++ b/app/index.js
@@ -117,6 +117,11 @@ function addCommandLineSwitchesAfterConfigLoad() {
 		app.commandLine.appendSwitch('proxy-server', config.proxyServer);
 	}
 
+	if (config.class) {
+		console.info('Setting WM_CLASS property to custom value ' + config.class);
+		app.setName(config.class);
+	}
+
 	app.commandLine.appendSwitch('auth-server-whitelist', config.authServerWhitelist);
 	app.commandLine.appendSwitch('enable-ntlm-v2', config.ntlmV2enabled);
 
@@ -222,17 +227,17 @@ function handleAppReady() {
 			}
 		);
 	}
-	// check for configuration warnings		
+	// check for configuration warnings
 	if (config.warning) {
 		dialog.showMessageBox(
-			{ 
+			{
 				title: 'Configuration Warning',
 				icon: nativeImage.createFromPath(path.join(config.appPath, 'assets/icons/alert-diamond.256x256.png')),
 				message: config.warning
 			}
 		);
 	}
-	
+
 	process.on('SIGTRAP', onAppTerminated);
 	process.on('SIGINT', onAppTerminated);
 	process.on('SIGTERM', onAppTerminated);
@@ -317,9 +322,9 @@ function handleCertificateError() {
 
 async function requestMediaAccess() {
 	['camera', 'microphone', 'screen'].map(async (permission) => {
-		const status = await 
+		const status = await
 			systemPreferences.askForMediaAccess(permission)
-				.catch(err => { 
+				.catch(err => {
 					console.error(`Error while requesting access for "${permission}": ${err}`); });
 		console.debug(`mac permission ${permission} asked current status ${status}`);
 	});

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.9.2" date="2024-08-22">
+			<description>
+				<ul>
+					<li>Add --class flag to allow setting the WM_CLASS property to a custom value</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.9.1" date="2024-08-20">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
This makes it possible to run multiple instances of teams-for-linux with different task bar icons (by setting StartupWMClass in the .desktop file and the --class option to the same value).