### PR TITLE
Update README.md to add required JSON comma

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -108,7 +108,7 @@ Example:
 ```json
 {
     "electronCLIFlags": [
-		["ozone-platform","wayland"]
+		["ozone-platform","wayland"],
 		"disable-software-rasterizer"
 	]
 }


### PR DESCRIPTION
When running the example config provided here for Electron CLI flags, I got a JSON parse error for a missing comma:

`A JavaScript error occurred in the main process
Uncaught Exception:
SyntaxError: Expected ',' or ']' after array element in JSON at position 61 (line 4 column 3)
    at JSON.parse (<anonymous>)`

This is a simple PR to add a single comma.