### PR TITLE
reverting changes from default url to use teams v1 and updating libraries (electron to 30.4.0)

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -230,7 +230,7 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'boolean'
 			},
 			logConfig: {
-				default: '{}',
+				default: 'console',
 				describe: 'Electron-log configuration. See logger.js for configurable values. To disable it provide a Falsy value.',
 				type: 'object'
 			},
@@ -324,7 +324,7 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'boolean'
 			},
 			url: {
-				default: 'https://teams.microsoft.com/v2',
+				default: 'https://teams.microsoft.com',
 				describe: 'Microsoft Teams URL',
 				type: 'string'
 			},

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,16 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.9.3" date="2024-08-23">
+			<description>
+				<ul>
+					<li>Revert the default url to be teams v1, not v2.</li>
+					<li>Update the logger to be `console` by default, as the documentation indicates</li>
+					<li>Update electron from  30.2.0 to 30.4.0</li>
+					<li>Update electron from  eslint and global libraries</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.9.2" date="2024-08-22">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "1.9.0",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "1.9.0",
+      "version": "1.9.3",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -23,11 +23,11 @@
       },
       "devDependencies": {
         "@electron/fuses": "^1.7.0",
-        "@eslint/js": "^9.7.0",
-        "electron": "^30.2.0",
+        "@eslint/js": "^9.9.0",
+        "electron": "^30.4.0",
         "electron-builder": "^24.13.3",
-        "eslint": "^9.7.0",
-        "globals": "^15.8.0"
+        "eslint": "^9.9.0",
+        "globals": "^15.9.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.0.tgz",
-      "integrity": "sha512-A68TBu6/1mHHuc5YJL0U0VVeGNiklLAL6rRmhTCP2B5XjWLMnrX+HkO+IAXyHvks5cyyY1jjK5ITPQ1HGS2EVA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
+      "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
       "dev": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.4",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.7.0.tgz",
-      "integrity": "sha512-ChuWDQenef8OSFnvuxv0TCVxEwmu3+hPNKvM9B34qpM0rDRbjL8t5QkQeHHeAfsKQjuH9wS82WeCi1J/owatng==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
+      "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.2.0.tgz",
-      "integrity": "sha512-x4/pUsOyWReAAo3/ZfvL7AvNbfS5dE8HqMC1mjFM/mL847KE/LpRFfOe5DjKqI2OQMTNvSth1mH0LJageHB0Zg==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.4.0.tgz",
+      "integrity": "sha512-ric3KLPQ9anXYjtTDkj5NbEcXZqRUwqxrxTviIjLdMdHqd5O+hkSHEzXgbSJUOt+7uw+zZuybn9+IM9y7iEpqg==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -2236,16 +2236,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.7.0.tgz",
-      "integrity": "sha512-FzJ9D/0nGiCGBf8UXO/IGLTgLVzIxze1zpfA8Ton2mjLovXdAPlYDv+MQDcqj3TmrhAGYfOpz9RfR+ent0AgAw==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
+      "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.17.0",
+        "@eslint/config-array": "^0.17.1",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.7.0",
+        "@eslint/js": "9.9.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2284,6 +2284,14 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -2784,9 +2792,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.8.0.tgz",
-      "integrity": "sha512-VZAJ4cewHTExBWDHR6yptdIBlx9YSSZuwojj9Nt5mBRXQzrKakDsVKQ1J63sklLvzAJm0X5+RpO4i3Y2hcOnFw==",
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+      "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -54,11 +54,11 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.7.0",
-    "@eslint/js": "^9.7.0",
-    "electron": "^30.2.0",
+    "@eslint/js": "^9.9.0",
+    "electron": "^30.4.0",
     "electron-builder": "^24.13.3",
-    "eslint": "^9.7.0",
-    "globals": "^15.8.0"
+    "eslint": "^9.9.0",
+    "globals": "^15.9.0"
   },
   "build": {
     "appId": "teams-for-linux",


### PR DESCRIPTION
* Revert the default url to be teams v1, not v2.
* Update the logger to be `console` by default, as the documentation indicates
* Update electron from  30.2.0 to 30.4.0
* Update electron from  eslint and global libraries