### PR TITLE
handle teams v2 meeting invites differently than v1 invites. making the default logger electron-log, as the config options seeem to be broken

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -52,7 +52,7 @@ Here is the list of available arguments and its usage:
 | incomingCallCommand             | Command to execute on an incoming call.  (string)                                                 |                       |
 | incomingCallCommandArgs         | Arguments for the incomming call command.                                                 |       []                |
 | isCustomBackgroundEnabled	   | A boolean flag to enable/disable custom background images                       | false              |
-| logConfig                       | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration)                | *console*                 |
+| logConfig                       | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration)                | *{}* (electron-log)        |
 | meetupJoinRegEx |  Meetup-join and channel regular expession | /^https:\/\/teams\.(microsoft|live)\.com\/.*(?:meetup-join|channel)/g |
 | menubar                         | A value controls the menu bar behaviour                                                   | *auto*, visible, hidden               |
 | minimized                       | Boolean to start the application minimized                                                          | false               |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -230,7 +230,7 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'boolean'
 			},
 			logConfig: {
-				default: 'console',
+				default: '{}',
 				describe: 'Electron-log configuration. See logger.js for configurable values. To disable it provide a Falsy value.',
 				type: 'object'
 			},

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -199,7 +199,8 @@ function restoreWindow() {
 }
 
 function processArgs(args) {
-	const regMS = /^msteams:\/.*(?:meetup-join|channel)/g;
+	const v1msTeams = /^msteams:\/l\/(?:meetup-join|channel)/g;
+	const v2msTeams = /^msteams:\/\/teams.microsoft.com\/l\/(?:meetup-join|channel)/g;
 	console.debug('processArgs:', args);
 	for (const arg of args) {
 		console.debug(`testing RegExp processArgs ${new RegExp(config.meetupJoinRegEx).test(arg)}`);
@@ -207,11 +208,16 @@ function processArgs(args) {
 			console.debug('A url argument received with https protocol');
 			window.show();
 			return arg;
-		}
-		if (regMS.test(arg)) {
-			console.debug('A url argument received with msteams protocol');
+		} 
+		if (v1msTeams.test(arg)) {
+			console.debug('A url argument received with msteams v1 protocol');
 			window.show();
 			return config.url + arg.substring(8, arg.length);
+		} 
+		if (v2msTeams.test(arg)) {
+			console.debug('A url argument received with msteams v2 protocol');
+			window.show();
+			return arg.replace('msteams', 'https');
 		}
 	}
 }

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,14 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.9.4" date="2024-08-23">
+			<description>
+				<ul>
+					<li>Update the logger to be `electron-log` by default, and update the documentation, as the config options don't seem to overwrite the logger</li>
+					<li>Adding a new conditional for msteams meeting invites to handle the differences between v1 and v2</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.9.3" date="2024-08-23">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
* handle teams v2 meeting invites differently than v1 invites. This might fix #1373 and #1370
* making the default logger electron-log, as the config options seem to be broken