### PR TITLE
refine disabling gpu & fix render-process-gone logging

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -129,6 +129,7 @@ function addCommandLineSwitchesAfterConfigLoad() {
 	if (config.disableGpu) {
 		console.info('Disabling GPU support...');
 		app.commandLine.appendSwitch('disable-gpu');
+		app.commandLine.appendSwitch('disable-gpu-compositing');
 		app.commandLine.appendSwitch('disable-software-rasterizer');
 		app.disableHardwareAcceleration();
 	}
@@ -203,9 +204,10 @@ async function playNotificationSound(_event, options) {
 	console.debug('No notification sound played', player, options);
 }
 
-function onRenderProcessGone(event, details) {
-	console.error(`render-process-gone with reason: '${details.reason}'.`);
-	console.error(`Event '${event}' and details '${details}'`);
+function onRenderProcessGone(event, webContents, details) {
+	// https://www.electronjs.org/docs/latest/api/app#event-render-process-gone
+	// only details provides useful information
+	console.error(`render-process-gone ${JSON.stringify(details)}`);
 	app.quit();
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -205,8 +205,6 @@ async function playNotificationSound(_event, options) {
 }
 
 function onRenderProcessGone(event, webContents, details) {
-	// https://www.electronjs.org/docs/latest/api/app#event-render-process-gone
-	// only details provides useful information
 	console.error(`render-process-gone ${JSON.stringify(details)}`);
 	app.quit();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Relates to #1369. Example of the log message:

```
08:03:09.099 › render-process-gone {"reason":"killed","exitCode":9}
```