### PR TITLE
Added support for OpenSUSE to rpm

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.10.1" date="2024-09-09">
+			<description>
+				<ul>
+					<li>Added support for OpenSUSE to rpm distribution</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.10.0" date="2024-09-03">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -100,6 +100,16 @@
       }
     },
     "rpm": {
+      "depends": [
+        "gtk3",
+        "libnotify",
+        "nss",
+        "libXScrnSaver",
+        "(libXtst or libXtst6)",
+        "xdg-utils",
+        "at-spi2-core",
+        "(libuuid or libuuid1)"
+      ],
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links  none",
         "--rpm-digest=sha256"


### PR DESCRIPTION
OpenSUSE uses slightly different package names than CentOS/Fedora. 

This changes the requires section in the rpm to allow both the CentOS/Fedora (libXtst,libuuid) and the OpenSUSE (libXtst6,libuuid1) dependencies.

Upstream PR: https://github.com/develar/app-builder/pull/130

Fixes #521, #1183.