### PR TITLE
deprecate onlineCheckMethod and change log level to console.info

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -19,7 +19,7 @@ Here is the list of available arguments and its usage:
 | appIconType                     | Type of tray icon to be used default/light/dark                                           | *default*, light, dark              |
 | appIdleTimeout                  | A numeric value in seconds as duration before app considers the system as idle             | 300                   |
 | appIdleTimeoutCheckInterval     | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached      | 10                    |
-| appLogLevels                    | Comma separated list of log levels (error,warn,info,debug)                                | error,warn            |
+| appLogLevels  **deprecated - use logLevels**                  | Comma separated list of log levels (error,warn,info,debug)                                | error,warn            |
 | appTitle                        | A text to be suffixed with page title                                                    | Microsoft Teams       |
 | authServerWhitelist             | Set auth-server-whitelist value (string)                                                           | *                |
 | awayOnSystemIdle                | Boolean to set the user status as away when system goes idle                                        | false               |
@@ -53,13 +53,13 @@ Here is the list of available arguments and its usage:
 | incomingCallCommand             | Command to execute on an incoming call.  (string)                                                 |                       |
 | incomingCallCommandArgs         | Arguments for the incomming call command.                                                 |       []                |
 | isCustomBackgroundEnabled	   | A boolean flag to enable/disable custom background images                       | false              |
-| logConfig                       | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration)                | *{}* (electron-log)        |
-| meetupJoinRegEx |  Meetup-join and channel regular expession | /^https:\/\/teams\.(microsoft|live)\.com\/.*(?:meetup-join|channel)/g |
+| logConfig                       | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration)                | **console.info** via (electron-log)        |
+| meetupJoinRegEx |  Meetup-join and channel regular expession |  /^https:\/\/teams\.(microsoft\|live)\.com\/.*(?:meetup-join\|channel)/g |
 | menubar                         | A value controls the menu bar behaviour                                                   | *auto*, visible, hidden               |
 | minimized                       | Boolean to start the application minimized                                                          | false               |
 | notificationMethod | Notification method to be used by the application (`web`/`electron`) | *web*, electron |
 | ntlmV2enabled                   | Set enable-ntlm-v2 value                                                                 | 'true'                |
-| onlineCheckMethod               | Type of network test for checking online status.                                          | *https*, dns, native, none                |
+| onlineCheckMethod  **automated - please remove**             | Type of network test for checking online status.                                          | *https*, dns, native, none                |
 | optInTeamsV2                    | Boolean to opt in to use Teams V2                                                                   | false               |
 | partition                       | BrowserWindow webpreferences partition                                                    | persist:teams-4-linux                |
 | proxyServer                     | Proxy Server with format address:port (string)                                                  | null                |
@@ -205,18 +205,14 @@ This is managed by the `logConfig` option, that has the following options:
 
 You have some simple options to use the `electron-log` as your log manager. Like:
 
-* Use the default `electron-log` values:
-```json
-{ "logConfig": "{}" }
-```
-
-* Making console level as `debug` and disabling the log to file
+**Current configuration**
+* Making console level as `info` and disabling the log to file. :
 ```json
 {
 	"logConfig": {
 		"transports": {
 			"console": {
-				"level": "debug"
+				"level": "info"
 			},
 			"file": {
 				"level": false
@@ -225,6 +221,13 @@ You have some simple options to use the `electron-log` as your log manager. Like
 	}
 }
 ```
+
+
+* Use the default `electron-log` values:
+```json
+{ "logConfig": {} }
+```
+
 
 Or more complex:
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -234,7 +234,16 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'boolean'
 			},
 			logConfig: {
-				default: '{}',
+				default: {
+					"transports": {
+						"console": {
+							"level": "info"
+						},
+						"file": {
+							"level": false
+						}
+					}
+				},
 				describe: 'Electron-log configuration. See logger.js for configurable values. To disable it provide a Falsy value.',
 				type: 'object'
 			},
@@ -266,6 +275,7 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'string'
 			},
 			onlineCheckMethod: {
+				deprecated: 'It has been automated. Please remove this option from your config file.',
 				default: 'https',
 				describe: 'Type of network test for checking online status.',
 				type: 'string',

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -275,7 +275,7 @@ function extractYargConfig(configObject, appVersion) {
 				type: 'string'
 			},
 			onlineCheckMethod: {
-				deprecated: 'It has been automated. Please remove this option from your config file.',
+				deprecated: 'It has been automated.\n Please remove this option from your config file',
 				default: 'https',
 				describe: 'Type of network test for checking online status.',
 				type: 'string',

--- a/app/config/logger.js
+++ b/app/config/logger.js
@@ -1,7 +1,6 @@
 const log = require('electron-log/main');
 const _ = require('lodash');
 
-
 exports.init = function (config) {
     if (config) {
         if (config == 'console') {
@@ -12,7 +11,6 @@ exports.init = function (config) {
             _.mergeWith(log, config,
                 (obj, src) => typeof obj === 'function' ? Object.assign(obj, src) : undefined,
             );
-            console.debug(`Logger initialised with transports: ${JSON.stringify(log.transports)}`);
             log.initialize();
             Object.assign(console, log.functions);    
             if (log.transports?.file?.level) {

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,14 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.11.1" date="2024-10-02">
+			<description>
+				<ul>
+					<li>Automated network check and deprecating `onlineCheckMethod`</li>
+					<li>Changing default logger to console.info and no file, instead of using the electron-log defaults</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.11.0" date="2024-09-24">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,7 +14,7 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
-		<release version="1.11.1" date="2024-10-02">
+		<release version="1.11.1" date="2024-10-03">
 			<description>
 				<ul>
 					<li>Automated network check and deprecating `onlineCheckMethod`</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -22,12 +22,12 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
-        "@electron/fuses": "^1.7.0",
-        "@eslint/js": "^9.9.0",
+        "@electron/fuses": "^1.8.0",
+        "@eslint/js": "^9.11.1",
         "electron": "^32.1.2",
         "electron-builder": "^25.0.5",
         "eslint": "^9.11.1",
-        "globals": "^15.9.0"
+        "globals": "^15.10.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -3250,9 +3250,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-      "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.10.0.tgz",
+      "integrity": "sha512-tqFIbz83w4Y5TCbtgjZjApohbuh7K9BxGYFm7ifwDR240tvdb7P9x+/9VvUKlmkPoiknoJtanI8UOrqxS3a7lQ==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -53,12 +53,12 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@electron/fuses": "^1.7.0",
-    "@eslint/js": "^9.9.0",
+    "@electron/fuses": "^1.8.0",
+    "@eslint/js": "^9.11.1",
     "electron": "^32.1.2",
     "electron-builder": "^25.0.5",
     "eslint": "^9.11.1",
-    "globals": "^15.9.0"
+    "globals": "^15.10.0"
   },
   "build": {
     "appId": "teams-for-linux",


### PR DESCRIPTION
* Automating the isOnline test to deprecate the need of onlineCheckMethod. 
* If the onlineCheckMethod is detected in the config file, you will get this warning on starting the app.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5ba46e7a-2b3b-4159-a71f-90954be7e321">

* Changing the default log level to console.info instead of using the electron-log defaults.

Might help with https://github.com/IsmaelMartinez/teams-for-linux/issues/1405, https://github.com/IsmaelMartinez/teams-for-linux/issues/1381 