### PR TITLE
Correct markup for icons hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ Read about the history of this project in the [`HISTORY.md`](HISTORY.md) file.
 
 ## License
 
-Some icons are from (Icon Duck)[https://iconduck.com/sets/hugeicons-essential-free-icons] under the `CC BY 4.0` license.
+Some icons are from [Icon Duck](https://iconduck.com/sets/hugeicons-essential-free-icons) under the `CC BY 4.0` license.
 
 License: [`GPLv3`](LICENSE.md)


### PR DESCRIPTION
Hi, going through the README I noticed the markup for the icons hyperlink had been reversed (parenthesis for name and square brackets for URL instead of the opposite), so I thought I'd offer the quick fix :-)

Cheers