### PR TITLE
Add fluent overlay scrollbar feature flag

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -133,6 +133,9 @@ function addCommandLineSwitchesAfterConfigLoad() {
 		app.disableHardwareAcceleration();
 	}
 
+	// Fluent Scrollbar (flag feature)
+	app.commandLine.appendSwitch('enable-fluent-scrollbar');
+
 	addElectronCLIFlagsFromConfig();
 }
 


### PR DESCRIPTION
This small change is for modernizing of the scrollbar. It looks in general a bit better, plus in dark mode, it doesn't blind with the white bar :D Here is the comparison:

Without the change:
![Screenshot From 2024-12-09 23-47-18](https://github.com/user-attachments/assets/058be25d-c565-44f6-881e-f61ae6233872)

With the change:
![Screenshot From 2024-12-09 23-23-18](https://github.com/user-attachments/assets/8af07059-16f2-429c-8ea2-3cbb4d369d70)

For now, it doesn't only work on the login page. Maybe I will find a way to fix it there.