### PR TITLE
Enable Background Authentication Calls and handing of undefined on lock resumption

### DIFF
--- a/app/browser/tools/reactHandler.js
+++ b/app/browser/tools/reactHandler.js
@@ -22,3 +22,5 @@ class ReactHandler {
 //document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices
 
 module.exports = new ReactHandler();
+
+// document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.authenticationService._coreAuthService._authProvider.acquireToken("https://graph.microsoft.com", { correlation: document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.correlation} )

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -213,6 +213,11 @@ function extractYargConfig(configObject, appVersion) {
 				default: false,
 				describe: 'Use windows platform information in chromium. This is helpful if MFA app does not support Linux.'
 			},
+			enableBackgroundCallsAuthentication: {
+				default: true,
+				describe: 'Enable background calls for authentication to open in a child browser window (temporary solution for debugging)',
+				type: 'boolean'
+			},
 			followSystemTheme: {
 				default: false,
 				describe: 'Follow system theme',
@@ -242,7 +247,7 @@ function extractYargConfig(configObject, appVersion) {
 				default: {
 					"transports": {
 						"console": {
-							"level": "info"
+							"level": "debug"
 						},
 						"file": {
 							"level": false

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -28,15 +28,21 @@ class ConnectionManager {
 	}
 
 	async refresh() {
-		const currentUrl = this.window.webContents.getURL();
+		if (!this.window) {
+			console.warn('Window is not available. Cannot refresh.');
+			return;
+		}
+		const currentUrl = this.window?.webContents?.getURL() || '';
 		const hasUrl = currentUrl?.startsWith('https://');
-		this.window.setTitle('Waiting for network...');
+		this.window?.setTitle('Waiting for network...');
 		console.debug('Waiting for network...');
 		const connected = await this.isOnline();
 		if (connected) {
 			if (hasUrl) {
+				console.debug('Reloading current page...');
 				this.window.reload();
 			} else {
+				console.debug('Loading initial URL...');
 				this.window.loadURL(this.currentUrl, { userAgent: this.config.chromeUserAgent });
 			}
 		} else {

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -6,10 +6,7 @@ class ApplicationTray {
 		this.iconPath = iconPath;
 		this.appMenu = appMenu;
 		this.config = config;
-		this.addTray();
-	}
 
-	addTray() {
 		this.tray = new Tray(this.iconPath);
 		this.tray.setToolTip(this.config.appTitle);
 		this.tray.on('click', () => this.showAndFocusWindow());
@@ -28,14 +25,16 @@ class ApplicationTray {
 	}
 
 	updateTrayImage(iconUrl, flash) {
-		const image = nativeImage.createFromDataURL(iconUrl);
+		if (this.tray && !this.tray.isDestroyed()) {
+			const image = nativeImage.createFromDataURL(iconUrl);
 
-		this.tray.setImage(image);
-		this.window.flashFrame(flash);
+			this.tray.setImage(image);
+			this.window.flashFrame(flash);
+		}
 	}
 
 	close() {
-		this.tray.destroy();
+		!this.tray.isDestroyed() ? this.tray.destroy() : null;
 	}
 }
 exports = module.exports = ApplicationTray;

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -34,7 +34,9 @@ class ApplicationTray {
 	}
 
 	close() {
-		!this.tray.isDestroyed() ? this.tray.destroy() : null;
+		if (!this.tray.isDestroyed()) {
+			this.tray.destroy()
+		}
 	}
 }
 exports = module.exports = ApplicationTray;

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,16 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.12.7" date="2025-02-15">
+			<description>
+				<ul>
+					<li>Adding enableBackgroundCallsAuthentication config option to validate if this keeps the user authenticated for longer</li>
+					<li>Removing the writeUrlBlockLog function that use to log those requests into a file for debugging</li>
+					<li>Handling of UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of undefined (reading 'webContents') at PowerMonitor.refresh (.../app/connectionManager/index.js:31:34)</li>
+					<li>Checking the tray status before trying to update the badge count</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.12.6" date="2025-01-17">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
* Adding enableBackgroundCallsAuthentication config option to validate if this keeps the user authenticated for longer
* Removing the writeUrlBlockLog function that use to log those requests into a file for debugging
* Handling of UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of undefined (reading 'webContents') at PowerMonitor.refresh (.../app/connectionManager/index.js:31:34)
* Checking the tray status before trying to update the badge count

Fixes #1545. Might fix #1521, #1495 and #1357