### PR TITLE
moving electron to 33.4.1, and multiple auth refresh tries

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -9,8 +9,8 @@ body:
   - type: dropdown
     id: can-reproduce-pwa
     attributes:
-      label: Can you reproduce this bug in the PWA?
-      description: "If you can reproduce the bug in the PWA, it's likely a bug in the web app. Please report it to Microsoft instead"
+      label: Can you reproduce this bug in the website/PWA?
+      description: "If you can reproduce the bug in the website/PWA, it's likely a bug in the web app. Please report it to Microsoft instead"
       options:
         - "Yes"
         - "No"

--- a/app/browser/tools/reactHandler.js
+++ b/app/browser/tools/reactHandler.js
@@ -23,4 +23,5 @@ class ReactHandler {
 
 module.exports = new ReactHandler();
 
-// document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.authenticationService._coreAuthService._authProvider.acquireToken("https://graph.microsoft.com", { correlation: document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.correlation} )
+// await document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.authenticationService._coreAuthService._authProvider.acquireToken("https://graph.microsoft.com", { correlation: document.getElementById('app')._reactRootContainer.current.updateQueue.baseState.element.props.coreServices.correlation, forceRenew: true} )
+

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -24,8 +24,8 @@ Here is the list of available arguments and its usage:
 | authServerWhitelist             | Set auth-server-whitelist value (string)                                                           | *                |
 | awayOnSystemIdle                | Boolean to set the user status as away when system goes idle                                        | false               |
 | chromeUserAgent                 | Google Chrome User Agent                                                                 | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${process.versions.chrome} Safari/537.36                |
-| class							  | A custom value for the WM_CLASS property                                                  |                 |
-| contextIsolation 	   | Use context isolation in the renderer process (disabling this will break some functionality) | false               |
+| class         | A custom value for the WM_CLASS property                                                  |                 |
+| contextIsolation     | Use context isolation in the renderer process (disabling this will break some functionality) | false               |
 | customBGServiceBaseUrl          | Base URL of the server which provides custom background images                            | http://localhost                |
 | customBGServiceIgnoreMSDefaults | A boolean flag indicates whether to ignore Microsoft provided images or not                       | false               |
 | customBGServiceConfigFetchInterval | A numeric value in seconds as poll interval to download background service config download | 0                |
@@ -53,7 +53,7 @@ Here is the list of available arguments and its usage:
 | frame | Specify false to create a Frameless Window. Default is true | false |
 | incomingCallCommand             | Command to execute on an incoming call.  (string)                                                 |                       |
 | incomingCallCommandArgs         | Arguments for the incomming call command.                                                 |       []                |
-| isCustomBackgroundEnabled	   | A boolean flag to enable/disable custom background images                       | false              |
+| isCustomBackgroundEnabled    | A boolean flag to enable/disable custom background images                       | false              |
 | logConfig                       | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration)                | **console.info** via (electron-log)        |
 | meetupJoinRegEx |  Meetup-join and channel regular expession |  /^https:\/\/teams\.(microsoft\|live)\.com\/.*(?:meetup-join\|channel)/g |
 | menubar                         | A value controls the menu bar behaviour                                                   | *auto*, visible, hidden               |
@@ -62,21 +62,21 @@ Here is the list of available arguments and its usage:
 | ntlmV2enabled                   | Set enable-ntlm-v2 value                                                                 | 'true'                |
 | optInTeamsV2                    | Boolean to opt in to use Teams V2                                                                   | false               |
 | partition                       | BrowserWindow webpreferences partition                                                    | persist:teams-4-linux                |
+| permissionHandlersConfig        | Permission Handlers configuration; `allowedDomains` and `allowedPermissions`. See [Permissions Handlers Configurarion](#permission-handlers-configuration) | allowedDomains : [ 'microsoft.com', 'microsoftonline.com', 'teams.skype.com', 'teams.microsoft.com', 'sfbassets.com','skypeforbusiness.com'], allowedPermissions: [ 'background-sync', 'notifications', 'media', 'speaker-selection'] |
 | proxyServer                     | Proxy Server with format address:port (string)                                                  | null                |
-| sandbox				  | Sandbox for the renderer process  (disabling this will break functionality)                                                | false               |
+| sandbox      | Sandbox for the renderer process  (disabling this will break functionality)                                                | false               |
 | screenLockInhibitionMethod      | Screen lock inhibition method to be used (`Electron`/`WakeLockSentinel`)                      | *Electron*, WakeLockSentinel                |
 | spellCheckerLanguages           | Array of languages to use with Electron's spell checker                    | []                 |
 | ssoBasicAuthUser           | Login that will be sent for basic_auth SSO login. (string) |                  |
 | ssoBasicAuthPasswordCommand           | Command to execute, grab stdout and use it as a password for basic_auth SSO login. |                  |
 | ssoInTuneEnabled                | Enable InTune Single-Sign-On                                                             | false
 | ssoInTuneAuthUser               | User (e-mail) to be used for InTune SSO login.                                           |                  |
-| trayIconEnabled				 | Enable tray icon                                                                          | true               |
+| trayIconEnabled     | Enable tray icon                                                                          | true               |
 | url                             | Microsoft Teams URL (string)                                                                    | https://teams.microsoft.com/                |
 | useMutationTitleLogic         | Use MutationObserver to update counter from title                                          | true               |
 | version                         | Show the version number                                                                  | false                 |
 | watchConfigFile | Watch for changes in the config file and restarts the app | false |
 | webDebug                        | Enable web debugging                                                                     | false               |
-
 
 As an example, to disable the persistence, you can run the following command:
 
@@ -110,9 +110,9 @@ Example:
 ```json
 {
     "electronCLIFlags": [
-		["ozone-platform","wayland"],
-		"disable-software-rasterizer"
-	]
+  ["ozone-platform","wayland"],
+  "disable-software-rasterizer"
+ ]
 }
 ```
 
@@ -134,42 +134,46 @@ You can find an example of this feature in the [../customBackground/example/READ
 6. To use you must activate the flag `--isCustomBackgroundEnabled=true`. From version 1.4.36 this flag is change default to `false`.
 
 For apache2, `/etc/apache2/apache2.conf` may need to have an entry like this.
+
 ```xml
 <Directory /var/www/>
-	Header set Access-Control-Allow-Origin "*"
-	Options Indexes FollowSymLinks
-	AllowOverride None
-	Require all granted
+ Header set Access-Control-Allow-Origin "*"
+ Options Indexes FollowSymLinks
+ AllowOverride None
+ Require all granted
 </Directory>
 ```
 
 ### Configuring list of images
 
 1. List of images are to be stored in `<customBGServiceBaseUrl>/config.json`.
-2. In Teams V1, it would look like this:
+1. In Teams V1, it would look like this:
+
 ```json
 [
-	{
-		"filetype": "jpg",
-		"id": "Custom_bg01",
-		"name": "Custom bg",
-		"src": "/<path-to-image>",
-		"thumb_src": "/<path-to-thumb-image>"
-	}
+ {
+  "filetype": "jpg",
+  "id": "Custom_bg01",
+  "name": "Custom bg",
+  "src": "/<path-to-image>",
+  "thumb_src": "/<path-to-thumb-image>"
+ }
 ]
 ```
-3. In Teams V2, it would look like this:
+
+1. In Teams V2, it would look like this:
+
 ```json
 {
-	"videoBackgroundImages": [
-		{
-			"filetype": "png",
-			"id": "Custom_bg01",
-			"name": "Custom bg",
-			"src": "/evergreen-assets/backgroundimages/<path-to-image>",
-			"thumb_src": "/evergreen-assets/backgroundimages/<path-to-thumb-image>"
-		}
-	]
+ "videoBackgroundImages": [
+  {
+   "filetype": "png",
+   "id": "Custom_bg01",
+   "name": "Custom bg",
+   "src": "/evergreen-assets/backgroundimages/<path-to-image>",
+   "thumb_src": "/evergreen-assets/backgroundimages/<path-to-thumb-image>"
+  }
+ ]
 }
 ```
 
@@ -183,9 +187,9 @@ As you can see from the above example, it's a JSON array so you can configure an
 - `src`: Path to the image to be loaded when selected from the preview. Provide a picture with resolution 1920x1080 (Based on Microsoft CDN) though any resolution would work. This is to avoid unnecessary traffic by loading large size images.
 - `thumb_src`: Path to the image to be shown on the preview screen. Provide a low resolution picture (280x158 based on Microsoft CDN) as it's shown on the preview page. The smaller the image the quicker the preview will be.
 
-Image paths are relative to `customBGServiceBaseUrl`. If your customBGServiceBaseUrl is `https://example.com` and your image is at `https://example.com/images/sample.jpg`, then `src` would be `/images/sample.jpg` and in Teams V2 `src` would be `/evergreen-assets/backgroundimages/images/sample.jpg`.
+Image paths are relative to `customBGServiceBaseUrl`. If your `customBGServiceBaseUrl` is `https://example.com` and your image is at `https://example.com/images/sample.jpg`, then `src` would be `/images/sample.jpg` and in Teams V2 `src` would be `/evergreen-assets/backgroundimages/images/sample.jpg`.
 
-## LogConfig option.
+## LogConfig option
 
 IMPORTANT: This option deprecates `appLogLevels`, that would be removed in the next major version.
 
@@ -206,50 +210,86 @@ This is managed by the `logConfig` option, that has the following options:
 You have some simple options to use the `electron-log` as your log manager. Like:
 
 **Current configuration**
-* Making console level as `info` and disabling the log to file. :
+
+- Making console level as `info` and disabling the log to file. :
+
 ```json
 {
-	"logConfig": {
-		"transports": {
-			"console": {
-				"level": "info"
-			},
-			"file": {
-				"level": false
-			}
-		}
-	}
+ "logConfig": {
+  "transports": {
+   "console": {
+    "level": "info"
+   },
+   "file": {
+    "level": false
+   }
+  }
+ }
 }
 ```
 
+- Use the default `electron-log` values:
 
-* Use the default `electron-log` values:
 ```json
 { "logConfig": {} }
 ```
 
-
 Or more complex:
 
-* Changing the console log format and rotating the file logs:
+- Changing the console log format and rotating the file logs:
+
 ```json
 {
-	"logConfig": {
-		"transports": {
-			"file": {
-				"maxSize": 100000,
-				"format": "{processType} [{h}:{i}:{s}.{ms}] {text}",
-				"level": "debug"
-			},
-			"console": {
-				"format": "[{h}:{i}:{s}.{ms}] {text}",
-				"level": "info"
-			}
-		}
-	}
+ "logConfig": {
+  "transports": {
+   "file": {
+    "maxSize": 100000,
+    "format": "{processType} [{h}:{i}:{s}.{ms}] {text}",
+    "level": "debug"
+   },
+   "console": {
+    "format": "[{h}:{i}:{s}.{ms}] {text}",
+    "level": "info"
+   }
+  }
+ }
 }
 ```
 
 ### Limitations
 
 I haven't explore all the options available in the `electron-log` configuration, so I can't guarantee all the options would work. (specially those options that require a function to be passed)
+
+## Permission Handlers Configuration
+
+In version 1.9.0 we added the ability to configure the permission handlers for the application. This is managed by the `permissionHandlersConfig` option, that has the following options:
+
+- `allowedDomains`: An array of domains that are allowed to request permissions. If the domain is not in this list, the request will be denied.
+- `allowedPermissions`: An array of permissions that are allowed to be requested. If the permission is not in this list, the request will be denied.
+
+The configuration is an object with the following structure:
+
+```json
+{
+ "permissionHandlersConfig": {
+  "allowedDomains": [
+   "microsoft.com",
+   "microsoftonline.com",
+   "teams.skype.com",
+   "teams.microsoft.com",
+   "sfbassets.com",
+   "skypeforbusiness.com",
+   "outlook.office.com",
+   "microsoftazuread-sso.com"
+  ],
+  "allowedPermissions": [
+   "background-sync",
+   "notifications",
+   "media",
+   "speaker-selection"
+  ]
+ }
+}
+```
+
+Please refer to [Issue 1357](https://github.com/IsmaelMartinez/teams-for-linux/issues/1357) for more information.

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -262,7 +262,7 @@ I haven't explore all the options available in the `electron-log` configuration,
 
 ## Permission Handlers Configuration
 
-In version 1.9.0 we added the ability to configure the permission handlers for the application. This is managed by the `permissionHandlersConfig` option, that has the following options:
+In version 1.12.8 we added the ability to configure the permission handlers for the application. This is managed by the `permissionHandlersConfig` option, that has the following options:
 
 - `allowedDomains`: An array of domains that are allowed to request permissions. If the domain is not in this list, the request will be denied.
 - `allowedPermissions`: An array of permissions that are allowed to be requested. If the permission is not in this list, the request will be denied.

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -213,11 +213,6 @@ function extractYargConfig(configObject, appVersion) {
 				default: false,
 				describe: 'Use windows platform information in chromium. This is helpful if MFA app does not support Linux.'
 			},
-			enableBackgroundCallsAuthentication: {
-				default: true,
-				describe: 'Enable background calls for authentication to open in a child browser window (temporary solution for debugging)',
-				type: 'boolean'
-			},
 			followSystemTheme: {
 				default: false,
 				describe: 'Follow system theme',
@@ -293,6 +288,29 @@ function extractYargConfig(configObject, appVersion) {
 				default: 'persist:teams-4-linux',
 				describe: 'BrowserWindow webpreferences partition',
 				type: 'string'
+			},
+			permissionHandlersConfig: {
+				default: {
+					allowedDomains : [
+						'microsoft.com',
+						'microsoftonline.com',
+						'teams.skype.com',
+						'teams.microsoft.com',
+						'sfbassets.com',
+						'skypeforbusiness.com',
+						'outlook.office.com',
+						'microsoftazuread-sso.com'
+					],
+					///autologon.microsoftazuread-sso.com
+					allowedPermissions: [
+						'background-sync',
+						'notifications',
+						'media',
+						'speaker-selection'
+					]
+				},
+				describe: 'Permission Handlers configuration',
+				type: 'object'
 			},
 			proxyServer: {
 				default: null,

--- a/app/index.js
+++ b/app/index.js
@@ -248,9 +248,9 @@ function handleAppReady() {
 
 async function handleGetSystemIdleState() {
 	const systemIdleState = powerMonitor.getSystemIdleState(config.appIdleTimeout);
-	console.debug(`GetSystemIdleState => IdleTimeout: ${config.appIdleTimeout}s, IdleTimeoutPollInterval: ${config.appIdleTimeoutCheckInterval}s, ActiveCheckPollInterval: ${config.appActiveCheckInterval}s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`);
-
+	
 	if (systemIdleState !== 'active' && idleTimeUserStatus == -1) {
+		console.debug(`GetSystemIdleState => IdleTimeout: ${config.appIdleTimeout}s, IdleTimeoutPollInterval: ${config.appIdleTimeoutCheckInterval}s, ActiveCheckPollInterval: ${config.appActiveCheckInterval}s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`);
 		idleTimeUserStatus = userStatus;
 	}
 
@@ -263,6 +263,7 @@ async function handleGetSystemIdleState() {
 	};
 
 	if (systemIdleState === 'active') {
+		console.debug(`GetSystemIdleState => IdleTimeout: ${config.appIdleTimeout}s, IdleTimeoutPollInterval: ${config.appIdleTimeoutCheckInterval}s, ActiveCheckPollInterval: ${config.appActiveCheckInterval}s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`);
 		idleTimeUserStatus = -1
 	}
 

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -1,4 +1,4 @@
-const { shell, BrowserWindow, app, nativeTheme, dialog, webFrameMain } = require('electron');
+const { shell, BrowserWindow, app, nativeTheme, dialog, webFrameMain, session } = require('electron');
 const login = require('../login');
 const customCSS = require('../customCSS');
 const Menus = require('../menus');
@@ -156,12 +156,44 @@ function onDidFinishLoad() {
 	customCSS.onDidFinishLoad(window.webContents, config);
 	initSystemThemeFollow(config);
 	window.webContents.session.cookies.on('changed', (_event, cookie, cause, removed) => { 
-		if ((cookie.name === 'authtoken') && (cookie.domain === 'teams.microsoft.com')) {
+		// if ((cookie.name === 'authtoken') && (cookie.domain === 'teams.microsoft.com')) {
 			console.debug(`cookie changed cause: ${cause} \n removed?: ${removed} \n`);
-			console.debug(`cookie: ${cookie.name} \n expirationDate: ${cookie.expirationDate} \n domain: ${cookie.domain}`);
+			console.debug(`cookie: ${cookie.name} \n expirationDate: ${cookie.expirationDate} \n domain: ${cookie.domain} \n secure: ${cookie.secure} \n httpOnly: ${cookie.httpOnly} \n path: ${cookie.path} \n session: ${cookie.session} \n sameSite: ${cookie.sameSite}`);
+		// }
+	});
+
+	setupPermissionHandlers();
+}
+
+function setupPermissionHandlers() {
+	const partitionSession=session.fromPartition(config.partition);
+	partitionSession.setPermissionRequestHandler((webContents,permission,callback) => {
+		const url=webContents?.getURL();
+		console.warn(`setPermissionRequestHandler ${permission} requested by ${url}`);
+
+		if(config.permissionHandlersConfig.allowedDomains.some(allowedDomain => url.includes(allowedDomain))&&
+			config.permissionHandlersConfig.allowedPermissions.some(allowedPermission => permission.includes(allowedPermission))) {
+			console.debug(`ALLOWED setPermissionRequestHandler ${permission} requested by ${url}`);
+			return callback(true);
 		}
+		console.debug(`DENIED setPermissionRequestHandler ${permission} requested by ${url}`);
+
+		callback(false);
+	});
+
+	partitionSession.setPermissionCheckHandler((webContents,permission,requestingOrigin) => {
+		const url=webContents?.getURL()||requestingOrigin;
+		if(config.permissionHandlersConfig.allowedDomains.some(allowedDomain => url.includes(allowedDomain))&&
+		   config.permissionHandlersConfig.allowedPermissions.some(allowedPermission => permission.includes(allowedPermission))) {
+			console.debug(`ALLOWED setPermissionCheckHandler check ${permission} requested by ${url} with origin ${requestingOrigin}`);
+			return true;
+		}
+
+		console.debug(`DENIED setPermissionCheckHandler check ${permission} requested by ${url} with origin ${requestingOrigin}`);
+		return false;
 	});
 }
+//https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/ (check for more info about the auth flow)
 
 function initSystemThemeFollow(config) {
 	if (config.followSystemTheme) {
@@ -235,15 +267,13 @@ function onBeforeRequestHandler(details, callback) {
 		callback({});
 	} else {
 		console.debug('DEBUG - webRequest to  ' + details.url + ' intercepted!');
-		if (this.config.enableBackgroundCallsAuthentication) {
-			console.debug('Opening the request in a hidden child window for authentication');
-			const child = new BrowserWindow({ parent: window, show: false });
-			child.loadURL(details.url);
-			child.once('ready-to-show', () => {
-				console.debug('Destroying the hidden child window');
-				child.destroy();
-			})	
-		}
+		console.debug('Opening the request in a hidden child window for authentication');
+		const child = new BrowserWindow({ parent: window, show: false });
+		child.loadURL(details.url);
+		child.once('ready-to-show', () => {
+			console.debug('Destroying the hidden child window');
+			child.destroy();
+		})	
 		
 		// decrement the counter
 		aboutBlankRequestCount -= 1;

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -156,10 +156,8 @@ function onDidFinishLoad() {
 	customCSS.onDidFinishLoad(window.webContents, config);
 	initSystemThemeFollow(config);
 	window.webContents.session.cookies.on('changed', (_event, cookie, cause, removed) => { 
-		// if ((cookie.name === 'authtoken') && (cookie.domain === 'teams.microsoft.com')) {
-			console.debug(`cookie changed cause: ${cause} \n removed?: ${removed} \n`);
-			console.debug(`cookie: ${cookie.name} \n expirationDate: ${cookie.expirationDate} \n domain: ${cookie.domain} \n secure: ${cookie.secure} \n httpOnly: ${cookie.httpOnly} \n path: ${cookie.path} \n session: ${cookie.session} \n sameSite: ${cookie.sameSite}`);
-		// }
+		console.debug(`cookie changed cause: ${cause} \n removed?: ${removed} \n`);
+		console.debug(`cookie: ${cookie.name} \n expirationDate: ${cookie.expirationDate} \n domain: ${cookie.domain} \n secure: ${cookie.secure} \n httpOnly: ${cookie.httpOnly} \n path: ${cookie.path} \n session: ${cookie.session} \n sameSite: ${cookie.sameSite}`);
 	});
 
 	setupPermissionHandlers();

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,7 +14,15 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
-		<release version="1.12.7" date="2025-02-15">
+		<release version="1.12.8" date="2025-02-21">
+			<description>
+				<ul>
+					<li>Adding permissionCheckHandler config option to verify if 3rd party cookies are affecting token refreshing</li>
+					<li>Removing enableBackgroundCallsAuthentication config option as it was broken, and probabaly not doing anything for us</li>
+					<li>Update electron to 33.4.1</li>
+				</ul>
+			</description>
+		<release version="1.12.7" date="2025-01-15">
 			<description>
 				<ul>
 					<li>Adding enableBackgroundCallsAuthentication config option to validate if this keeps the user authenticated for longer</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
       },
       "devDependencies": {
         "@electron/fuses": "^1.8.0",
-        "@eslint/js": "^9.20.1",
+        "@eslint/js": "^9.20.0",
         "electron": "^33.4.1",
         "electron-builder": "^25.1.8",
-        "eslint": "^9.20.1",
+        "eslint": "^9.20.0",
         "globals": "^15.15.0",
         "http-server": "^14.1.1"
       }
@@ -480,6 +480,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
+      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2763,16 +2773,6 @@
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "teams-for-linux",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@homebridge/dbus-native": "0.6.0",
-        "electron-log": "^5.2.4",
+        "electron-log": "^5.3.0",
         "electron-store": "8.2.0",
         "electron-window-state": "5.0.3",
         "lodash": "^4.17.21",
@@ -20,11 +20,11 @@
       },
       "devDependencies": {
         "@electron/fuses": "^1.8.0",
-        "@eslint/js": "^9.18.0",
-        "electron": "^33.3.1",
+        "@eslint/js": "^9.20.1",
+        "electron": "^33.4.1",
         "electron-builder": "^25.1.8",
-        "eslint": "^9.18.0",
-        "globals": "^15.14.0",
+        "eslint": "^9.20.1",
+        "globals": "^15.15.0",
         "http-server": "^14.1.1"
       }
     },
@@ -480,15 +480,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
-      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2405,11 +2396,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.1.tgz",
-      "integrity": "sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==",
+      "version": "33.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.1.tgz",
+      "integrity": "sha512-ICXI9hw3Ru3XwaZLZdwyARn85GpoF9n4BrrwkHJtsoi4rl3qA7IM/Qu5HlDhqnbH4XuPNmHwoJ8bGJqo0lJ4+A==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -2515,9 +2507,10 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.2.4.tgz",
-      "integrity": "sha512-iX12WXc5XAaKeHg2QpiFjVwL+S1NVHPFd3V5RXtCmKhpAzXsVQnR3UEc0LovM6p6NkUQxDWnkdkaam9FNUVmCA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.3.0.tgz",
+      "integrity": "sha512-ILgbh2k9IKbSaN8NAbQriVteEhmkdLo/e4J1dg+JIBTFzXS/kO8zNRZBh/4YPwIT/zeyxF1jP6Xz8GLsPE2IBQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -2674,17 +2667,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
-      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
+      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.11.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.18.0",
+        "@eslint/js": "9.20.0",
         "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2758,6 +2752,29 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
+      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
@@ -3268,10 +3285,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
-    "@eslint/js": "^9.20.1",
+    "@eslint/js": "^9.20.0",
     "http-server": "^14.1.1",
     "electron": "^33.4.1",
     "electron-builder": "^25.1.8",
-    "eslint": "^9.20.1",
+    "eslint": "^9.20.0",
     "globals": "^15.15.0"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@homebridge/dbus-native": "0.6.0",
-    "electron-log": "^5.2.4",
+    "electron-log": "^5.3.0",
     "electron-store": "8.2.0",
     "electron-window-state": "5.0.3",
     "lodash": "^4.17.21",
@@ -51,12 +51,12 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
-    "@eslint/js": "^9.18.0",
+    "@eslint/js": "^9.20.1",
     "http-server": "^14.1.1",
-    "electron": "^33.3.1",
+    "electron": "^33.4.1",
     "electron-builder": "^25.1.8",
-    "eslint": "^9.18.0",
-    "globals": "^15.14.0"
+    "eslint": "^9.20.1",
+    "globals": "^15.15.0"
   },
   "build": {
     "appId": "teams-for-linux",


### PR DESCRIPTION
- Removing enableBackgroundCallsAuthentication config option as it was broken, and probably not doing anything for us
- Update electron to 33.4.1
- Add website next to PWA in the bug template
- Adding permissionCheckHandler config option to verify if 3rd party cookies are affecting token refreshing. Default allowed domains/permissions are:
```
allowedDomains : [ 'microsoft.com', 'microsoftonline.com', 'teams.skype.com', 'teams.microsoft.com', 'sfbassets.com','skypeforbusiness.com'], allowedPermissions: [ 'background-sync', 'notifications', 'media', 'speaker-selection']
```

Fixes https://github.com/IsmaelMartinez/teams-for-linux/issues/1573 
Trying to fix https://github.com/IsmaelMartinez/teams-for-linux/issues/1357 (but I don't think it fully works... but worth a try I guess)