### PR TITLE
Allow opening deep links to chats

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -231,7 +231,7 @@ function restoreWindow() {
 
 function processArgs(args) {
 	const v1msTeams = /^msteams:\/l\/(?:meetup-join|channel)/g;
-	const v2msTeams = /^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel)/g;
+	const v2msTeams = /^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel|chat)/g;
 	console.debug('processArgs:', args);
 	for (const arg of args) {
 		console.debug(`testing RegExp processArgs ${new RegExp(config.meetupJoinRegEx).test(arg)}`);

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.13.2" date="2025-03-25">
+			<description>
+				<ul>
+					<li>Update the deep link regex to allow /l/chat deep links in addition to meetings and channels</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.13.1" date="2025-03-20">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Update the deep link regex to allow `/l/chat` deep links in addition to meetings and channels.