### PR TITLE
Modernize install instruction for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo mkdir -p /etc/apt/keyrings
 
 sudo wget -qO /etc/apt/keyrings/teams-for-linux.asc https://repo.teamsforlinux.de/teams-for-linux.asc
 
-echo "deb [signed-by=/etc/apt/keyrings/teams-for-linux.asc arch=$(dpkg --print-architecture)] https://repo.teamsforlinux.de/debian/ stable main" | sudo tee /etc/apt/sources.list.d/teams-for-linux-packages.list
+sh -c 'echo "Types: deb\nURIs: https://repo.teamsforlinux.de/debian/\nSuites: stable\nComponents: main\nSigned-By: /etc/apt/keyrings/teams-for-linux.asc" | sudo tee /etc/apt/sources.list.d/teams-for-linux-packages.sources'
 
 sudo apt update
 


### PR DESCRIPTION
The ".list" files are deprecated. Also older Versions of Debian/Ubuntu support the new format.