### PR TITLE
move "Quit" above "Quit (Clear Storage) in appMenu.js

### DIFF
--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -41,13 +41,13 @@ exports = module.exports = (Menus) => ({
       type: "separator",
     },
     {
+      label: "Quit (Clear Storage)",
+      click: () => Menus.quit(true),
+    },
+    {
       label: "Quit",
       accelerator: "ctrl+Q",
       click: () => Menus.quit(),
-    },
-    {
-      label: "Quit (Clear Storage)",
-      click: () => Menus.quit(true),
     },
   ],
 });


### PR DESCRIPTION
The Quit option should be last in the list because it is the one most people use daily.