### PR TITLE
Fix ActivityManager (#1644)

### DIFF
--- a/app/browser/index.js
+++ b/app/browser/index.js
@@ -1,10 +1,12 @@
 (function () {
   const { ipcRenderer } = require("electron");
+  const ActivityManager = require("./notifications/activityManager");
 
   let config;
   ipcRenderer.invoke("get-config").then((mainConfig) => {
     config = mainConfig;
     initializeModules(config, ipcRenderer);
+    new ActivityManager(ipcRenderer, config).start();
   });
 
   let classicNotification = window.Notification;


### PR DESCRIPTION
These two lines were accidentally removed in (#1638). Adding back in the ensure the ActivityManager runs.