### PR TITLE
Fix 1379 allow links offline meetings to open in app

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -61,6 +61,7 @@ menubar | A value controls the menu bar behaviour | *auto*, visible, hidden |
 | minimized | Boolean to start the application minimized | false |
 | notificationMethod | Notification method to be used by the application (`web`/`electron`) | *web*, electron |
 | ntlmV2enabled | Set enable-ntlm-v2 value | 'true' |
+| onNewWindowOpenMeetupJoinUrlInApp: | Open meetupJoinRegEx URLs in the app instead of the default browser | false |
 | partition | BrowserWindow webpreferences partition | persist:teams-4-linux |
 | proxyServer | Proxy Server with format address:port (string) | null |
 | sandbox | Sandbox for the renderer process (disabling this will break functionality) | false |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -299,6 +299,12 @@ function extractYargConfig(configObject, appVersion) {
         describe: "Set enable-ntlm-v2 value",
         type: "string",
       },
+      onNewWindowOpenMeetupJoinUrlInApp: {
+        default: false,
+        describe:
+          "Open meetupJoinRegEx URLs in the app instead of the default browser",
+        type: "boolean",
+      },
       partition: {
         default: "persist:teams-4-linux",
         describe: "BrowserWindow webpreferences partition",

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -287,6 +287,9 @@ function onNewWindow(details) {
   );
   if (new RegExp(config.meetupJoinRegEx).test(details.url)) {
     console.debug("DEBUG - captured meetup-join url");
+    if (config.onNewWindowOpenMeetupJoinUrlInApp) {
+      window.loadURL(details.url, { userAgent: config.chromeUserAgent });
+    }
     return { action: "deny" };
   } else if (
     details.url === "about:blank" ||

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.6" date="2025-04-08">
+			<description>
+				<ul>
+					<li>Fix 1379 allow option for links in offline meetings to open in the app</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.5" date="2025-04-08">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -17,7 +17,7 @@
 		<release version="2.0.6" date="2025-04-08">
 			<description>
 				<ul>
-					<li>Fix 1379 allow option for links in offline meetings to open in the app</li>
+					<li>Fix 1379 allow option for links in offline meetings to open in the app. The config option called onNewWindowOpenMeetupJoinUrlInApp and defaults to false</li>
 				</ul>
 			</description>
 		</release>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Added a new config option called `onNewWindowOpenMeetupJoinUrlInApp` to allow for meeting links inside an offline meeting to open in the app. 

This should in theory fix #1379 