### PR TITLE
removing unused and deprecated config options

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -32,8 +32,6 @@ Here is the list of available arguments and its usage:
 | customCACertsFingerprints          | Array of custom CA Certs Fingerprints to allow SSL unrecognized signer or self signed certificate                                       | []                                                                                                                     |
 | customCSSName                      | custom CSS name for the packaged available css files                                                                                    |                                                                                                                        |
 | customCSSLocation                  | custom CSS styles file location                                                                                                         |                                                                                                                        |
-| customUserDir (deprecated)         | Deprecated: Use `--user-data-dir` env variable instead.                                                                                 | null                                                                                                                   |
-| clearStorage (deprecated)          | Deprecated: Use `clearStorageData` instead.                                                                                             | false                                      |
 | clearStorageData                   | Flag to clear storage data. Expects an object of the type <https://www.electronjs.org/docs/latest/api/session#sesclearstoragedataoptions> | null   |
 | clientCertPath | Custom Client Certs for corporate authentication (certificate must be in pkcs12 format) | string |
 | clientCertPassword | Custom Client Certs password for corporate authentication (certificate must be in pkcs12 format) | string |
@@ -42,7 +40,6 @@ Here is the list of available arguments and its usage:
 | defaultURLHandler | Default application to be used to open the HTTP URLs (string) | |
 | disableAutogain | Disable mic auto gain or not | false |
 | disableGpu | Disable GPU and hardware acceleration (can be useful if the window remains blank) | false |
-| disableMeetingNotifications | Disable meeting notifications | false |
 | disableNotifications | Disable all notifications | false |
 | disableNotificationSound | Disable chat/meeting start notification sound | false |
 | disableNotificationSoundIfNotAvailable | Disables notification sound unless status is Available (e.g. while in a call, busy, etc.) | false |
@@ -52,16 +49,13 @@ Here is the list of available arguments and its usage:
 | emulateWinChromiumPlatform| Use windows platform information in chromium. This is helpful if MFA app does not support Linux.| false |
 | followSystemTheme | Boolean to determine if to follow system theme | false |
 | frame | Specify false to create a Frameless Window. Default is true | false |
-| incomingCallCommand | Command to execute on an incoming call. (string) | |
-| incomingCallCommandArgs | Arguments for the incomming call command. | [] |
 | isCustomBackgroundEnabled | A boolean flag to enable/disable custom background images | false |
 | logConfig | A string value to set the log manager to use (`Falsy`, `console`, or a valid electron-log configuration) | **console.info** via (electron-log) |
 | meetupJoinRegEx | Meetup-join and channel regular expession | /^https:\/\/teams\.(microsoft\|live)\.com\/.*(?:meetup-join\|channel\|chat)/g | |
 menubar | A value controls the menu bar behaviour | _auto_, visible, hidden |
 | minimized | Boolean to start the application minimized | false |
 | notificationMethod | Notification method to be used by the application (`web`/`electron`) | _web_, electron |
-| ntlmV2enabled | Set enable-ntlm-v2 value | 'true' |
-| onNewWindowOpenMeetupJoinUrlInApp: | Open meetupJoinRegEx URLs in the app instead of the default browser | false |
+| onNewWindowOpenMeetupJoinUrlInApp | Open meetupJoinRegEx URLs in the app instead of the default browser | true |
 | partition | BrowserWindow webpreferences partition | persist:teams-4-linux |
 | proxyServer | Proxy Server with format address:port (string) | null |
 | sandbox | Sandbox for the renderer process (disabling this will break functionality) | false |

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { ipcMain } = require("electron");
 const logger = require("./logger");
+const { deprecate } = require("util");
 
 function getConfigFilePath(configPath) {
   return path.join(configPath, "config.json");
@@ -123,24 +124,10 @@ function extractYargConfig(configObject, appVersion) {
           "Use contextIsolation on the main BrowserWindow (WIP - Disabling this will break most functionality)",
         type: "boolean",
       },
-      customUserDir: {
-        default: null,
-        deprecated: "Use `--user-data-dir` env variable instead",
-        describe:
-          "Custom User Directory so that you can have multiple profiles",
-        type: "string",
-      },
       class: {
         default: null,
         describe: "A custom value for the WM_CLASS property",
         type: "string",
-      },
-      clearStorage: {
-        default: false,
-        deprecated: "Use `clearStorageData` instead",
-        describe:
-          "Whether to clear the storage before creating the window or not",
-        type: "boolean",
       },
       clearStorageData: {
         default: null,
@@ -185,11 +172,6 @@ function extractYargConfig(configObject, appVersion) {
         default: false,
         describe:
           "A flag to disable GPU and hardware acceleration (can be useful if the window remains blank)",
-        type: "boolean",
-      },
-      disableMeetingNotifications: {
-        default: false,
-        describe: "Whether to disable meeting notifications or not",
         type: "boolean",
       },
       disableNotifications: {
@@ -240,16 +222,6 @@ function extractYargConfig(configObject, appVersion) {
         describe: "Specify false to create a Frameless Window. Default is true",
         type: "boolean",
       },
-      incomingCallCommand: {
-        default: null,
-        describe: "Command to execute on an incoming call.",
-        type: "string",
-      },
-      incomingCallCommandArgs: {
-        default: [],
-        describe: "Arguments for the incoming call command.",
-        type: "array",
-      },
       isCustomBackgroundEnabled: {
         default: false,
         describe: "A flag indicates whether to enable custom background or not",
@@ -294,13 +266,8 @@ function extractYargConfig(configObject, appVersion) {
         type: "string",
         choices: ["web", "electron"],
       },
-      ntlmV2enabled: {
-        default: "true",
-        describe: "Set enable-ntlm-v2 value",
-        type: "string",
-      },
       onNewWindowOpenMeetupJoinUrlInApp: {
-        default: false,
+        default: true,
         describe:
           "Open meetupJoinRegEx URLs in the app instead of the default browser",
         type: "boolean",

--- a/app/index.js
+++ b/app/index.js
@@ -21,7 +21,7 @@ addCommandLineSwitchesBeforeConfigLoad();
 const { AppConfiguration } = require("./appConfiguration");
 const appConfig = new AppConfiguration(
   app.getPath("userData"),
-  app.getVersion(),
+  app.getVersion()
 );
 
 const config = appConfig.startupConfig;
@@ -49,7 +49,7 @@ try {
   player = NodeSound.getDefaultPlayer();
 } catch (err) {
   console.warn(
-    `No audio players found. Audio notifications might not work. ${err}`,
+    `No audio players found. Audio notifications might not work. ${err}`
   );
 }
 
@@ -88,7 +88,7 @@ if (!gotTheLock) {
   ipcMain.handle("get-zoom-level", handleGetZoomLevel);
   ipcMain.handle("save-zoom-level", handleSaveZoomLevel);
   ipcMain.handle("desktop-capturer-get-sources", (_event, opts) =>
-    desktopCapturer.getSources(opts),
+    desktopCapturer.getSources(opts)
   );
   ipcMain.handle("play-notification-sound", playNotificationSound);
   ipcMain.handle("show-notification", showNotification);
@@ -143,9 +143,8 @@ function addCommandLineSwitchesAfterConfigLoad() {
 
   app.commandLine.appendSwitch(
     "auth-server-whitelist",
-    config.authServerWhitelist,
+    config.authServerWhitelist
   );
-  app.commandLine.appendSwitch("enable-ntlm-v2", config.ntlmV2enabled);
 
   // GPU
   if (config.disableGpu) {
@@ -174,7 +173,7 @@ function addElectronCLIFlagsFromConfig() {
           )
         ) {
           console.debug(
-            `Adding electron CLI flag '${flag[0]}' with value '${flag[1]}'`,
+            `Adding electron CLI flag '${flag[0]}' with value '${flag[1]}'`
           );
           app.commandLine.appendSwitch(flag[0], flag[1]);
         } else {
@@ -211,7 +210,7 @@ async function showNotification(_event, options) {
 
 async function playNotificationSound(_event, options) {
   console.debug(
-    `Notification => Type: ${options.type}, Audio: ${options.audio}, Title: ${options.title}, Body: ${options.body}`,
+    `Notification => Type: ${options.type}, Audio: ${options.audio}, Title: ${options.title}, Body: ${options.body}`
   );
   // Player failed to load or notification sound disabled in config
   if (!player || config.disableNotificationSound) {
@@ -259,7 +258,7 @@ function handleAppReady() {
     dialog.showMessageBox({
       title: "Configuration Error",
       icon: nativeImage.createFromPath(
-        path.join(config.appPath, "assets/icons/setting-error.256x256.png"),
+        path.join(config.appPath, "assets/icons/setting-error.256x256.png")
       ),
       message: `Error in config file '${config.error}'.\n Loading default configuration`,
     });
@@ -269,7 +268,7 @@ function handleAppReady() {
     dialog.showMessageBox({
       title: "Configuration Warning",
       icon: nativeImage.createFromPath(
-        path.join(config.appPath, "assets/icons/alert-diamond.256x256.png"),
+        path.join(config.appPath, "assets/icons/alert-diamond.256x256.png")
       ),
       message: config.warning,
     });
@@ -285,7 +284,7 @@ function handleAppReady() {
 
 async function handleGetSystemIdleState() {
   const systemIdleState = powerMonitor.getSystemIdleState(
-    config.appIdleTimeout,
+    config.appIdleTimeout
   );
 
   if (systemIdleState !== "active" && idleTimeUserStatus == -1) {
@@ -296,7 +295,7 @@ async function handleGetSystemIdleState() {
         config.appIdleTimeoutCheckInterval
       }s, ActiveCheckPollInterval: ${
         config.appActiveCheckInterval
-      }s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`,
+      }s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`
     );
     idleTimeUserStatus = userStatus;
   }
@@ -317,7 +316,7 @@ async function handleGetSystemIdleState() {
         config.appIdleTimeoutCheckInterval
       }s, ActiveCheckPollInterval: ${
         config.appActiveCheckInterval
-      }s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`,
+      }s, IdleTime: ${powerMonitor.getSystemIdleTime()}s, IdleState: '${systemIdleState}'`
     );
     idleTimeUserStatus = -1;
   }
@@ -382,11 +381,11 @@ async function requestMediaAccess() {
       .askForMediaAccess(permission)
       .catch((err) => {
         console.error(
-          `Error while requesting access for "${permission}": ${err}`,
+          `Error while requesting access for "${permission}": ${err}`
         );
       });
     console.debug(
-      `mac permission ${permission} asked current status ${status}`,
+      `mac permission ${permission} asked current status ${status}`
     );
   });
 }

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -91,12 +91,6 @@ function getNotificationsMenu(Menus) {
         click: () => Menus.toggleDisableNotifications(),
       },
       {
-        label: "Disable Meeting Notifications",
-        type: "checkbox",
-        checked: Menus.configGroup.startupConfig.disableMeetingNotifications,
-        click: () => Menus.toggleDisableMeetingNotifications(),
-      },
-      {
         label: "Disable Notifications Sound",
         type: "checkbox",
         checked: Menus.configGroup.startupConfig.disableNotificationSound,
@@ -162,14 +156,14 @@ function getHelpMenu() {
         label: "Github Project",
         click: () =>
           shell.openExternal(
-            "https://github.com/IsmaelMartinez/teams-for-linux",
+            "https://github.com/IsmaelMartinez/teams-for-linux"
           ),
       },
       {
         label: "Microsoft Teams Support",
         click: () =>
           shell.openExternal(
-            "https://answers.microsoft.com/en-us/msteams/forum",
+            "https://answers.microsoft.com/en-us/msteams/forum"
           ),
       },
     ],

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -203,16 +203,6 @@ class Menus {
     this.updateMenu();
   }
 
-  toggleDisableMeetingNotifications() {
-    this.configGroup.startupConfig.disableMeetingNotifications =
-      !this.configGroup.startupConfig.disableMeetingNotifications;
-    this.configGroup.legacyConfigStore.set(
-      "disableMeetingNotifications",
-      this.configGroup.startupConfig.disableMeetingNotifications
-    );
-    this.updateMenu();
-  }
-
   toggleDisableNotificationSound() {
     this.configGroup.startupConfig.disableNotificationSound =
       !this.configGroup.startupConfig.disableNotificationSound;

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,18 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.9" date="2025-04-18">
+			<description>
+				<ul>
+					<li>Remove disableMeetingNotifications as it is not possible anymore</li>
+					<li>Removing the incomingCallCommand and incomingCallCommandArgs as they are not working anymore</li>
+					<li>Removing ntlmV2enabled as it is not documented anymore in Chromium and it should be the default value</li>
+					<li>Removing deprecated `clearStorage` in favor of `clearStorageData`</li>
+					<li>Removing deprecated `customUserDir` in favor of `--user-data-dir`</li>
+					<li>Changing the default value of `onNewWindowOpenMeetupJoinUrlInApp` to `true`</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.8" date="2025-04-11">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@homebridge/dbus-native": "0.6.0",
-        "electron-log": "^5.3.3",
+        "electron-log": "^5.3.4",
         "electron-store": "8.2.0",
         "electron-window-state": "5.0.3",
         "lodash": "^4.17.21",
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.3.3.tgz",
-      "integrity": "sha512-ZOnlgCVfhKC0Nef68L0wDhwhg8nh5QkpEOA+udjpBxcPfTHGgbZbfoCBS6hmAgVHTAWByHNPkHKpSbEOPGZcxA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.3.4.tgz",
+      "integrity": "sha512-QLj0EbsA5R5Yy4vjGlLe7m8hPNZ/Enp7c7a2WH7RUPr0hIOp0vDaC+6bJM0th6+uZKiZGGH5a2aKzvYp3eYwDQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@homebridge/dbus-native": "0.6.0",
-    "electron-log": "^5.3.3",
+    "electron-log": "^5.3.4",
     "electron-store": "8.2.0",
     "electron-window-state": "5.0.3",
     "lodash": "^4.17.21",


### PR DESCRIPTION
- Remove disableMeetingNotifications as it is not possible anymore - found from #1659
- Removing the incomingCallCommand and incomingCallCommandArgs as they are not working anymore 
- Removing ntlmV2enabled as it is not documented anymore in Chromium and it should be the default value
- Removing deprecated `clearStorage` in favor of `clearStorageData`
- Removing deprecated `customUserDir` in favor of `--user-data-dir` 
- Changing the default value of `onNewWindowOpenMeetupJoinUrlInApp` to `true` - #1379

				