### PR TITLE
dynamically set Dock icon for macOS

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -141,6 +141,11 @@ function addCommandLineSwitchesAfterConfigLoad() {
     app.setName(config.class);
   }
 
+  if (config.appTitle) {
+    console.info("Setting app name to custom value " + config.appTitle);
+    app.setName(config.appTitle);
+  }
+
   app.commandLine.appendSwitch(
     "auth-server-whitelist",
     config.authServerWhitelist

--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -1,10 +1,8 @@
 const {
-  app,
   BrowserWindow,
   ipcMain,
   session,
   nativeTheme,
-  nativeImage,
   powerSaveBlocker,
 } = require("electron");
 const path = require("path");
@@ -48,11 +46,7 @@ class BrowserWindowManager {
   }
 
   createNewBrowserWindow(windowState) {
-    if (process.platform === 'darwin') {
-        const icon = nativeImage.createFromPath(this.iconChooser.getFile());
-        console.log("Setting Dock icon for macOS");
-        app.dock.setIcon(icon);
-    }
+
     return new BrowserWindow({
       title: "Teams for Linux",
       x: windowState.x,

--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -1,8 +1,10 @@
 const {
+  app,
   BrowserWindow,
   ipcMain,
   session,
   nativeTheme,
+  nativeImage,
   powerSaveBlocker,
 } = require("electron");
 const path = require("path");
@@ -46,6 +48,11 @@ class BrowserWindowManager {
   }
 
   createNewBrowserWindow(windowState) {
+    if (process.platform === 'darwin') {
+        const icon = nativeImage.createFromPath(this.iconChooser.getFile());
+        console.log("Setting Dock icon for macOS");
+        app.dock.setIcon(icon);
+    }
     return new BrowserWindow({
       title: "Teams for Linux",
       x: windowState.x,

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -5,6 +5,7 @@ const {
   nativeTheme,
   dialog,
   webFrameMain,
+  nativeImage,
 } = require("electron");
 const login = require("../login");
 const customCSS = require("../customCSS");
@@ -15,6 +16,7 @@ const TrayIconChooser = require("../browser/tools/trayIconChooser");
 require("../appConfiguration");
 const connMgr = require("../connectionManager");
 const BrowserWindowManager = require("../mainAppWindow/browserWindowManager");
+const os = require("os");
 
 let iconChooser;
 let intune;
@@ -24,6 +26,8 @@ let config;
 let window = null;
 let appConfig = null;
 let customBackgroundService = null;
+
+const isMac = os.platform() === "darwin";
 
 exports.onAppReady = async function onAppReady(configGroup, customBackground) {
   appConfig = configGroup;
@@ -37,6 +41,18 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground) {
 
   if (config.trayIconEnabled) {
     iconChooser = new TrayIconChooser(config);
+
+    if (isMac) {
+        console.log("Setting Dock icon for macOS");
+        const icon = nativeImage.createFromPath(iconChooser.getFile());
+        const iconSize = icon.getSize();
+        if(iconSize.width < 128) {
+          console.warn("unable to set dock icon for macOS, icon size is less than 128x128, current size " + iconSize.width + "x" + iconSize.height);
+        }else{
+          app.dock.setIcon(icon);
+        }
+    }
+
   }
 
   const browserWindowManager = new BrowserWindowManager({

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -7,7 +7,7 @@ class ApplicationTray {
     this.appMenu = appMenu;
     this.config = config;
 
-    this.tray = new Tray(this.iconPath);
+    this.tray = new Tray(this.getIconImage(this.iconPath));
     this.tray.setToolTip(this.config.appTitle);
     this.tray.on("click", () => this.showAndFocusWindow());
     this.tray.setContextMenu(Menu.buildFromTemplate(this.appMenu));
@@ -15,6 +15,14 @@ class ApplicationTray {
     ipcMain.on("tray-update", (_event, { icon, flash }) =>
       this.updateTrayImage(icon, flash),
     );
+  }
+
+  getIconImage(iconPath){
+    let image = nativeImage.createFromDataURL(iconPath);
+    const size = isMac ? 16: 96;
+    // automatically resize the icon to 22x22 or 44x44 depending on the scale factor
+    image = image.resize({ width: size, height: size });
+    return image;
   }
 
   setContextMenu(appMenu) {
@@ -28,7 +36,7 @@ class ApplicationTray {
 
   updateTrayImage(iconUrl, flash) {
     if (this.tray && !this.tray.isDestroyed()) {
-      const image = nativeImage.createFromDataURL(iconUrl);
+      const image = this.getIconImage(iconUrl);
 
       this.tray.setImage(image);
       this.window.flashFrame(flash);

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.10" date="2025-04-20">
+			<description>
+				<ul>
+					<li>New: dynamically set Docker icon for macOS</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.9" date="2025-04-18">
 			<description>
 				<ul>
@@ -121,7 +128,7 @@
 				<ul>
 					<li>Update electron to 35.1.2</li>
 					<li>Update electron-builder to 26.0.12</li>
-					<li>BREAKING CHANGE: deprecating customUserDir as eletron doesn't support camelCase on those anymore. Use ELECTRON_USER_DATA_PATH env variable instead</li> 
+					<li>BREAKING CHANGE: deprecating customUserDir as eletron doesn't support camelCase on those anymore. Use ELECTRON_USER_DATA_PATH env variable instead</li>
 				</ul>
 			</description>
 		</release>
@@ -281,14 +288,14 @@
 					<li>Moving the notification number to be in the bottom right hand side of the icon</li>
 				</ul>
 			</description>
-		</release>		
+		</release>
 		<release version="1.10.2" date="2024-09-10">
 			<description>
 				<ul>
 					<li>Add support to simulate Windows-based Chromium Browser</li>
 				</ul>
 			</description>
-		</release>		
+		</release>
 		<release version="1.10.1" date="2024-09-09">
 			<description>
 				<ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
**Issue to resolve**
on macOS, the Dock icon is controlled by the app bundle, not the BrowserWindow icon.  therefore on macOS the icon display on the Dock is always the icon comes from the app bundle.

**Change**
This change allows the app to display the specified icon on Dock from on the configuration

**Key Consideration for the change**

1. the app-icon config provides customisation icon settings for **tray icons**, this is cool for windows but not Mac because it does not apply the dock icon
1. the app-icon is mis-leading, in my opinion I believe it should be named **tray-icon** but I think we do not want to rename it
1. I also do not want to introduce a new "dock-icon" configuration either because I think it is unnecessary so I decided to reuse the app-icon configuration and added the auto icon resize on tray.js to accommodate  it 

example:

```
# run from app source

electron ./app --trace-warnings --app-title='New Custom Title' --app-icon=`pwd`/app/assets/icons/icon-custom-128x128.png
```