### PR TITLE
fix: removing the appTitle setting the name of the app as that breaks the tray icon in linux systems

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -136,11 +136,6 @@ function addCommandLineSwitchesAfterConfigLoad() {
     app.commandLine.appendSwitch("proxy-server", config.proxyServer);
   }
 
-  if (config.appTitle) {
-    console.info("Setting app name to custom value " + config.appTitle);
-    app.setName(config.appTitle);
-  }
-
   if (config.class) {
     console.info("Setting WM_CLASS property to custom value " + config.class);
     app.setName(config.class);

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,14 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.11" date="2025-04-25">
+			<description>
+				<ul>
+					<li>Removing using the appTitle to setup the app name introduced in the previous version, as that breaks the icon in linux systems</li>
+					<li>Update electrno to 35.2.1</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.10" date="2025-04-20">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -18,7 +18,7 @@
 			<description>
 				<ul>
 					<li>Removing using the appTitle to setup the app name introduced in the previous version, as that breaks the icon in linux systems</li>
-					<li>Update electrno to 35.2.1</li>
+					<li>Update electron to 35.2.1</li>
 				</ul>
 			</description>
 		</release>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@electron/fuses": "^1.8.0",
         "@eslint/js": "^9.25.1",
-        "electron": "^35.2.0",
+        "electron": "^35.2.1",
         "electron-builder": "^26.0.12",
         "eslint": "^9.25.1",
         "globals": "^16.0.0",
@@ -2570,9 +2570,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.2.0.tgz",
-      "integrity": "sha512-GHda7oCkN0pA23qzah735DEbRa06IPwlzP3uvjAmf9af8gxdj5i93JEHeQVGVmSVpd7sSb1pfecs9nz7B1q5ag==",
+      "version": "35.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.2.1.tgz",
+      "integrity": "sha512-LO4xXLpzkPPUVLvAbdHMlW7N9Z+Qqz+7QsmSWXluTIQMeJk+v7o36nUTZghyA2I1s//tlMvuaCtle6Qo2W0Ktg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -53,7 +53,7 @@
     "@electron/fuses": "^1.8.0",
     "@eslint/js": "^9.25.1",
     "http-server": "^14.1.1",
-    "electron": "^35.2.0",
+    "electron": "^35.2.1",
     "electron-builder": "^26.0.12",
     "eslint": "^9.25.1",
     "globals": "^16.0.0"


### PR DESCRIPTION
* Removing using the appTitle to setup the app name introduced in the previous version, as that breaks the icon in linux systems
* Update electron to 35.2.1