### PR TITLE
Fix: removing apt update warning "doesn't support architecture 'i386'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ installation instructions below.
 ```bash
 sudo mkdir -p /etc/apt/keyrings
 sudo wget -qO /etc/apt/keyrings/teams-for-linux.asc https://repo.teamsforlinux.de/teams-for-linux.asc
-sh -c 'echo "Types: deb\nURIs: https://repo.teamsforlinux.de/debian/\nSuites: stable\nComponents: main\nSigned-By: /etc/apt/keyrings/teams-for-linux.asc" | sudo tee /etc/apt/sources.list.d/teams-for-linux-packages.sources'
+sh -c 'echo "Types: deb\nURIs: https://repo.teamsforlinux.de/debian/\nSuites: stable\nComponents: main\nSigned-By: /etc/apt/keyrings/teams-for-linux.asc\nArchitectures: amd64" | sudo tee /etc/apt/sources.list.d/teams-for-linux-packages.sources'
 sudo apt update
 sudo apt install teams-for-linux
 ```


### PR DESCRIPTION
This PR fixes the warning during apt update && upgrade 
> "N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://repo.teamsforlinux.de/debian stable InRelease' doesn't support architecture 'i386'"

by appending the "Architectures: amd64" into `/etc/apt/sources.list.d/teams-for-linux-packages.sources`.

Small change and Thanks for reviewing!