### PR TITLE
Add video menu entry that allows control of video elements

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -345,6 +345,11 @@ function extractYargConfig(configObject, appVersion) {
         describe: "Enable debug at start",
         type: "boolean",
       },
+      videoMenu: {
+        default: false,
+        describe: "Enable menu entry for controlling video elements",
+        type: "boolean",
+      }
     })
     .help()
     .parse(process.argv.slice(1));

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -37,6 +37,12 @@ exports = module.exports = (Menus) => ({
       click: () => Menus.about(),
     },
     getHelpMenu(),
+    ...(Menus.configGroup.startupConfig.videoMenu ? [
+      {
+        type: "separator",
+      },
+      getVideoMenu(Menus),
+    ]: []),
     {
       type: "separator",
     },
@@ -168,4 +174,20 @@ function getHelpMenu() {
       },
     ],
   };
+}
+
+function getVideoMenu(Menus) {
+  return       {
+    label: "Video",
+    submenu: [
+      {
+        label: "Force enable PiP mode for shared screen",
+        click: () => { Menus.forcePip() }
+      },
+      {
+        label: "Force toggle controls for all video elements",
+        click: () => { Menus.forceVideoControls() }
+      }
+    ]
+  }
 }

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -238,6 +238,16 @@ class Menus {
     this.configGroup.legacyConfigStore.set("defaultNotificationUrgency", value);
     this.updateMenu();
   }
+
+  forcePip() {
+    const script = `document.querySelectorAll('div[data-type="screen-sharing"] video').forEach(v => {v.removeAttribute("disablepictureinpicture"); v.requestPictureInPicture();})`;
+    this.window.webContents.executeJavaScript(script, true);
+  }
+
+  forceVideoControls() {
+    const script = `document.querySelectorAll('video').forEach(v => {v.removeAttribute("disablepictureinpicture"); v.toggleAttribute("controls");})`;
+    this.window.webContents.executeJavaScript(script, true);
+  }
 }
 
 function saveSettingsInternal(_event, arg) {

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.14" date="2025-05-20">
+			<description>
+				<ul>
+					<li>Adding --videoMenu option to enable a menu section which contains options to manipulate video elements (enable video controls, enter picture-in-picture mode)</li>
+				</ul>
+			</description>
+		</release>
 	    <release version="2.0.13" date="2025-05-15">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
This PR adds a command line switch `--videoMenu`.

When set to true, a new menu entry `Video` is added to the menu.
This menu entry contains two sub entries to manipulate video elements on the current page:

- `Force enable PiP mode for shared screen`
- `Force toggle controls for all video elements`