### PR TITLE
Ensure that microphone and camera entitlements are requested on OSX

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+  <!-- Hardened runtime exceptions for Electron -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+  <!-- Network access -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+
+  <!-- Camera & microphone -->
+  <key>com.apple.security.device.camera</key>
+  <true/>
+  <key>com.apple.security.device.microphone</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -138,7 +138,14 @@
       ]
     },
     "mac": {
-      "category": "public.app-category.productivity"
+      "category": "public.app-category.productivity",
+      "extendInfo": {
+        "NSCameraUsageDescription": "We need camera access for video calls.",
+        "NSMicrophoneUsageDescription": "We need microphone access for audio."
+      },
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "afterPack": "scripts/afterpack.js"
   }


### PR DESCRIPTION
I noticed that on my M3 MacBook Air the app would fail to request access to the microphone and to the camera.
This should now be fixed