### PR TITLE
initial implemenation of the creation of a release-info.json file with the relevant releease information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,13 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Build
         run: npm ci
+
+      - name: Validate Release Notes
+        run: npm run generate-release-info
 
       - name: Release
         if: contains(github.ref, 'main')
@@ -39,10 +42,13 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci
+
+      - name: Validate Release Notes
+        run: npm run generate-release-info
 
       - name: Release
         if: contains(github.ref, 'main')
@@ -58,10 +64,13 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci
+
+      - name: Validate Release Notes
+        run: npm run generate-release-info
 
       - name: Release
         if: contains(github.ref, 'main')
@@ -77,10 +86,13 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci
+
+      - name: Validate Release Notes
+        run: npm run generate-release-info
 
       - name: Release
         if: contains(github.ref, 'main')
@@ -96,10 +108,13 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci
+
+      - name: Validate Release Notes
+        run: npm run generate-release-info
 
       - name: Release
         if: contains(github.ref, 'main')

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -7,7 +7,6 @@ defaults:
     shell: bash
 
 jobs:
-
   snap:
     runs-on: ubuntu-latest
 
@@ -24,7 +23,7 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci
@@ -49,7 +48,7 @@ jobs:
       - name: Install Node.js and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: npm ci

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
-name: 'Close stale issues and PR'
+name: "Close stale issues and PR"
 on:
   schedule:
-    - cron: '30 9 * * *'
+    - cron: "30 9 * * *"
   workflow_dispatch:
 
 jobs:
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
           days-before-stale: 30
           days-before-close: 5
           days-before-pr-close: -1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ generated-sources.json
 flatpak-build/
 .idea
 .DS_Store
+release-info.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ The version increase follows the next rules:
   (Example: 1.0.0 -> 1.1.0)
 - The higher number is reserved at the moment
 
-### appdata.xml
+### com.github.IsmaelMartinez.teams_for_linux.appdata.xml
 
 For each release, create a new section in the
 [com.github.IsmaelMartinez.teams_for_linux.appdata.xml](com.github.IsmaelMartinez.teams_for_linux.appdata.xml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,23 +88,36 @@ sudo snap install teams-for-linux
 
 ## Release process
 
-The release is mostly automated using GitHub Actions. The release is triggered
-by merging to main.
+## Adding Release Notes
 
-### Versioning
+To add release notes and prepare a new release, follow these steps:
 
-The version increase follows the next rules:
+1. **Update the version** in `package.json` according to the versioning rules:
+  - Increment the last number for patches (e.g., `1.0.0` → `1.0.1`)
+  - Increment the middle number for minor or breaking changes (e.g., `1.0.0` → `1.1.0`)
+  - The first number is reserved
 
-- By default increase the lower number of the version in the `package.json`
-  file. (Example: 1.0.0 -> 1.0.1)
-- For any release that can break changes, increase the middle number. Please
-  increase this number if you are increasing a major version of electron.
-  (Example: 1.0.0 -> 1.1.0)
-- The higher number is reserved at the moment
+2. **Run** `npm install` to update `package-lock.json`.
 
-### com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+3. **Add release notes** for the new version in the [`release_info.md`](release_info.md) file. List new features, bug fixes, and improvements.
 
-For each release, create a new section in the
-[com.github.IsmaelMartinez.teams_for_linux.appdata.xml](com.github.IsmaelMartinez.teams_for_linux.appdata.xml)
-file. This will automatically update the appstream data in the flathub
-repository.
+4. **Update** `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`:
+  - Add a new `<release>` entry with the new version and date, and a summary of changes. For example:
+
+  ```xml
+  <release version="2.0.17" date="2025-06-15">
+    <description>
+     <ul>
+      <li>New feature description</li>
+      <li>Bug fix description</li>
+      <li>Performance improvement</li>
+     </ul>
+    </description>
+  </release>
+  ```
+
+5. **Commit and push** your changes, then open a pull request.
+
+The release process is mostly automated using GitHub Actions and is triggered by merging to `main`.
+
+For more details on how the release info is generated, see the [Release Info](docs/RELEASE_INFO.md) documentation.

--- a/RELEASE_INFO.md
+++ b/RELEASE_INFO.md
@@ -161,11 +161,3 @@ npm run pack  # Automatically runs prebuild and afterPack hooks
 ```
 
 The release info will be automatically generated and bundled with the application.
-
-## Benefits
-
-1. **Consistency**: Ensures version numbers are synchronized across all files
-2. **Automation**: No manual work required during builds
-3. **Standards Compliance**: Follows electron-builder conventions
-4. **Runtime Access**: Release info available to the application at runtime
-5. **Single Source of Truth**: `com.github.IsmaelMartinez.teams_for_linux.appdata.xml` serves as the authoritative source for release notes

--- a/RELEASE_INFO.md
+++ b/RELEASE_INFO.md
@@ -1,0 +1,171 @@
+# Release Info Integration
+
+This document explains how release information is automatically generated and bundled with the Teams for Linux application using electron-builder.
+
+## Overview
+
+The release info integration automatically:
+
+1. Validates version consistency across `package.json`, `package-lock.json`, and `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`
+2. Extracts release notes from the `com.github.IsmaelMartinez.teams_for_linux.appdata.xml` file
+3. Generates a `release-info.json` file conforming to [electron-builder's ReleaseInfo interface](https://www.electron.build/app-builder-lib.interface.releaseinfo)
+4. Makes release info available for Linux publishing to GitHub
+
+## How It Works
+
+### Build Process Integration
+
+1. **Pre-build**: The `prebuild` npm script runs `generate-release-info` before any build
+2. **After Pack**: The `afterPack` hook in electron-builder generates fresh release info for Linux builds
+3. **Publishing**: The `release-info.json` file is used by electron-builder when publishing Linux releases to GitHub
+
+### Generated Files
+
+- **`release-info.json`** (project root): Used for Linux publishing process
+
+## Usage
+
+### NPM Scripts
+
+```bash
+# Generate release info manually
+npm run generate-release-info
+
+# Build with automatic release info generation
+npm run pack
+npm run dist
+```
+
+## File Structure
+
+```
+project/
+├── package.json                           # Contains version and build config
+├── package-lock.json                      # Version consistency check
+├── com.github.IsmaelMartinez.teams_for_linux.appdata.xml  # Source of release notes
+├── release-info.json                      # Generated release info (dev)
+├── scripts/
+│   ├── generateReleaseInfo.js             # Release info generator
+│   └── afterpack.js                       # Build
+```
+
+## Configuration
+
+### electron-builder Configuration (package.json)
+
+```json
+{
+  "build": {
+    "extraResources": [
+      {
+        "from": "release-info.json",
+        "to": "release-info.json"
+      }
+    ],
+    "afterPack": "scripts/afterpack.js"
+  }
+}
+```
+
+### NPM Scripts (package.json)
+
+```json
+{
+  "scripts": {
+    "generate-release-info": "node scripts/generateReleaseInfo.js",
+    "prebuild": "npm run generate-release-info"
+  }
+}
+```
+
+## Release Info Schema
+
+The generated `release-info.json` follows electron-builder's ReleaseInfo interface:
+
+```json
+{
+  "releaseName": "2.0.16",
+  "releaseNotes": "• Added feature A\n• Fixed bug B\n• Improved performance C",
+  "releaseDate": "2025-06-05"
+}
+```
+
+### Properties
+
+- **`releaseName`**: Current version from `package.json`
+- **`releaseNotes`**: Release notes extracted from `com.github.IsmaelMartinez.teams_for_linux.appdata.xml` `<description>` section
+- **`releaseDate`**: Release date from `com.github.IsmaelMartinez.teams_for_linux.appdata.xml` `date` attribute
+
+## Adding Release Notes
+
+To add release notes for a new version:
+
+1. Update the version in `package.json`
+2. Run `npm install` to update `package-lock.json`
+3. Add a new `<release>` entry in `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`:
+
+```xml
+<release version="2.0.17" date="2025-06-15">
+  <description>
+    <ul>
+      <li>New feature description</li>
+      <li>Bug fix description</li>
+      <li>Performance improvement</li>
+    </ul>
+  </description>
+</release>
+```
+
+4. The release info will be automatically generated during the next build
+
+## Error Handling
+
+The system performs validation and provides helpful error messages:
+
+- **Version Mismatch**: If `package.json` and `package-lock.json` versions don't match
+- **Missing Release Entry**: If no release entry exists for the current version in `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`
+- **Empty Release Notes**: If the release entry has no description
+- **Missing Files**: If any required file is not found
+
+## Examples
+
+### Manual Generation
+
+```bash
+cd /path/to/teams-for-linux
+npm run generate-release-info
+```
+
+Output:
+```
+✅ Version consistency check passed!
+   package.json: 2.0.16
+   package-lock.json: 2.0.16
+   com.github.IsmaelMartinez.teams_for_linux.appdata.xml: 2.0.16 (with release notes)
+
+📋 Generated Release Info (electron-builder ReleaseInfo interface):
+
+{
+  "releaseName": "2.0.16",
+  "releaseNotes": "• Added a reimplementation of the call events to revive the incoming call scripts\n• Added an incoming call toast just like the one from the discontinued Linux Teams App from Microsoft",
+  "releaseDate": "2025-06-05"
+}
+
+💾 Release info saved to: /path/to/teams-for-linux/release-info.json
+```
+
+### Build Integration
+
+```bash
+npm run pack  # Automatically runs prebuild and afterPack hooks
+```
+
+The release info will be automatically generated and bundled with the application.
+
+## Benefits
+
+1. **Consistency**: Ensures version numbers are synchronized across all files
+2. **Automation**: No manual work required during builds
+3. **Standards Compliance**: Follows electron-builder conventions
+4. **Runtime Access**: Release info available to the application at runtime
+5. **Single Source of Truth**: `com.github.IsmaelMartinez.teams_for_linux.appdata.xml` serves as the authoritative source for release notes

--- a/RELEASE_INFO.md
+++ b/RELEASE_INFO.md
@@ -17,7 +17,7 @@ The release info integration automatically:
 
 1. **Pre-build**: The `prebuild` npm script runs `generate-release-info` before any build
 2. **After Pack**: The `afterPack` hook in electron-builder generates fresh release info for Linux builds
-3. **Publishing**: The `release-info.json` file is used by electron-builder when publishing Linux releases to GitHub
+3. **Publishing**: The `release-info.json` file is referenced by electron-builder's `releaseNotesFile` setting for Linux publishing to GitHub
 
 ### Generated Files
 
@@ -56,12 +56,15 @@ project/
 ```json
 {
   "build": {
-    "extraResources": [
-      {
-        "from": "release-info.json",
-        "to": "release-info.json"
+    "linux": {
+      "publish": {
+        "provider": "github",
+        "releaseType": "draft",
+        "releaseInfo": {
+          "releaseNotesFile": "release-info.json"
+        }
       }
-    ],
+    },
     "afterPack": "scripts/afterpack.js"
   }
 }
@@ -137,6 +140,7 @@ npm run generate-release-info
 ```
 
 Output:
+
 ```
 ✅ Version consistency check passed!
    package.json: 2.0.16

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -24,7 +24,7 @@ class ConnectionManager {
     powerMonitor.on("resume", this.refresh);
     this.window.webContents.on(
       "did-fail-load",
-      assignOnDidFailLoadEventHandler(this),
+      assignOnDidFailLoadEventHandler(this)
     );
     this.refresh();
   }
@@ -63,7 +63,7 @@ class ConnectionManager {
         tries: 10,
         networkTest: async () => {
           console.debug(
-            "Testing network using net.request() for " + this.config.url,
+            "Testing network using net.request() for " + this.config.url
           );
           return await isOnlineHttps(this.config.url);
         },
@@ -76,7 +76,7 @@ class ConnectionManager {
         networkTest: async () => {
           const testDomain = new URL(this.config.url).hostname;
           console.debug(
-            "Testing network using net.resolveHost() for " + testDomain,
+            "Testing network using net.resolveHost() for " + testDomain
           );
           return await isOnlineDns(testDomain);
         },
@@ -109,7 +109,7 @@ class ConnectionManager {
         const online = await onlineCheckMethod.networkTest();
         if (online) {
           console.debug(
-            "Network test successful with method " + onlineCheckMethod.method,
+            "Network test successful with method " + onlineCheckMethod.method
           );
           return true;
         }
@@ -123,7 +123,9 @@ class ConnectionManager {
 function assignOnDidFailLoadEventHandler(cm) {
   return (event, code, description) => {
     console.error(
-      `assignOnDidFailLoadEventHandler : ${JSON.stringify(event)} - ${code} - ${description}`,
+      `assignOnDidFailLoadEventHandler : ${JSON.stringify(
+        event
+      )} - ${code} - ${description}`
     );
     if (
       description === "ERR_INTERNET_DISCONNECTED" ||

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -19,6 +19,8 @@
 				<ul>
 					<li>Update electron to 36.4.0 and @homebridge/dbus-native to 0.7.1 for improved ARM compatibility and security</li>
 					<li>Adding release info generation from com.github.IsmaelMartinez.teams_for_linux.appdata.xml file</li>
+					<li>Validate the release version is ready on the build.yml github action</li>
+					<li>Updating github actions to use node 22</li>
 				</ul>
 			</description>
 		</release>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,7 +14,7 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
-		<release version="2.0.17" date="2025-06-14">
+		<release version="2.0.17" date="2025-06-15">
 			<description>
 				<ul>
 					<li>Update electron to 36.4.0 and @homebridge/dbus-native to 0.7.1 for improved ARM compatibility and security</li>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,14 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.0.17" date="2025-06-14">
+			<description>
+				<ul>
+					<li>Update electron to 36.4.0 and @homebridge/dbus-native to 0.7.1 for improved ARM compatibility and security</li>
+					<li>Adding release info generation from com.github.IsmaelMartinez.teams_for_linux.appdata.xml file</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.0.16" date="2025-06-05">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@homebridge/dbus-native": "0.6.0",
-        "electron-log": "^5.4.0",
+        "@homebridge/dbus-native": "0.7.1",
+        "electron-log": "^5.4.1",
         "electron-positioner": "^4.1.0",
         "electron-store": "8.2.0",
         "electron-window-state": "5.0.3",
@@ -21,12 +21,13 @@
       },
       "devDependencies": {
         "@electron/fuses": "^1.8.0",
-        "@eslint/js": "^9.26.0",
-        "electron": "^35.4.0",
+        "@eslint/js": "^9.29.0",
+        "electron": "^36.4.0",
         "electron-builder": "^26.0.12",
-        "eslint": "^9.26.0",
-        "globals": "^16.1.0",
-        "http-server": "^14.1.1"
+        "eslint": "^9.29.0",
+        "globals": "^16.2.0",
+        "http-server": "^14.1.1",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -531,9 +532,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -546,9 +547,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -580,9 +581,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -654,13 +655,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -674,14 +678,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.15.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -695,36 +712,20 @@
       "license": "MIT"
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-      "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.1.tgz",
+      "integrity": "sha512-ZywUbf0vy+DSN4gCCMERRpSh/nywPjRk/fMq5GGM58Cqm8/dg6/C5aFJPmgVLNUD4Etcamq2d0Jb9qiDSZktcA==",
       "license": "MIT",
       "dependencies": {
-        "@homebridge/long": "^5.2.1",
-        "@homebridge/put": "^0.0.8",
         "event-stream": "^4.0.1",
         "hexy": "^0.3.5",
-        "minimist": "^1.2.6",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
         "safe-buffer": "^5.1.2",
         "xml2js": "^0.6.2"
       },
       "bin": {
         "dbus2js": "bin/dbus2js.js"
-      }
-    },
-    "node_modules/@homebridge/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@homebridge/put": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-      "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
-      "license": "MIT/X11",
-      "engines": {
-        "node": ">=0.3.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -933,28 +934,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
-      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
-        "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -1205,57 +1184,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1631,27 +1563,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -1779,16 +1690,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
@@ -2263,49 +2164,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2313,20 +2171,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/corser": {
       "version": "2.0.1",
@@ -2511,16 +2355,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -2721,13 +2555,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2745,9 +2572,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.4.0.tgz",
-      "integrity": "sha512-VIPSNcUnic00aaE83w6BW4Dj1kE8A5DU0nVbvwqotN3+gseGunbP4WyHp/kfKXVKQj1S3No3HnYxU5LJmYbAtw==",
+      "version": "36.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-36.4.0.tgz",
+      "integrity": "sha512-LLOOZEuW5oqvnjC7HBQhIqjIIJAZCIFjQxltQGLfEC7XFsBoZgQ3u3iFj+Kzw68Xj97u1n57Jdt7P98qLvUibQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2831,9 +2658,9 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.0.tgz",
-      "integrity": "sha512-AXI5OVppskrWxEAmCxuv8ovX+s2Br39CpCAgkGMNHQtjYT3IiVbSQTncEjFVGPgoH35ZygRm/mvUMBDWwhRxgg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.1.tgz",
+      "integrity": "sha512-QvisA18Z++8E3Th0zmhUelys9dEv7aIeXJlbFw3UrxCc8H9qSRW0j8/ooTef/EtHui8tVmbKSL+EIQzP9GoRLg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2971,16 +2798,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -3084,13 +2901,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3105,24 +2915,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
-      "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-array": "^0.20.1",
         "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.26.0",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.29.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
-        "@modelcontextprotocol/sdk": "^1.8.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -3130,9 +2939,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3146,8 +2955,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "zod": "^3.24.2"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -3168,9 +2976,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3185,9 +2993,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3222,15 +3030,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3285,16 +3093,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
@@ -3317,117 +3115,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eventsource": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
       "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
-      }
-    },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -3543,24 +3236,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3664,26 +3339,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/from": {
@@ -3908,9 +3563,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
-      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4104,23 +3759,6 @@
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
@@ -4369,16 +4007,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -4449,13 +4077,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -4703,6 +4324,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -4834,29 +4461,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mime": {
@@ -5164,16 +4768,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5196,19 +4790,6 @@
       "optional": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -5384,16 +4965,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5458,16 +5029,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -5501,16 +5062,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
-      }
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -5695,20 +5246,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -5757,32 +5294,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -5946,23 +5457,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6031,52 +5525,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -6107,29 +5555,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6394,16 +5819,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/stream-combiner": {
@@ -6677,16 +6092,6 @@
         "tmp": "^0.2.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -6720,44 +6125,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -6829,16 +6196,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6869,16 +6226,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -7085,26 +6432,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "lint": "eslint **/*.js",
     "prestart": "npm ci",
     "start": "electron ./app --trace-warnings",
+    "generate-release-info": "node scripts/generateReleaseInfo.js",
+    "prebuild": "npm run generate-release-info",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "dist:linux": "electron-builder --linux",
@@ -41,8 +43,8 @@
     "release": "electron-builder"
   },
   "dependencies": {
-    "@homebridge/dbus-native": "0.6.0",
-    "electron-log": "^5.4.0",
+    "@homebridge/dbus-native": "0.7.1",
+    "electron-log": "^5.4.1",
     "electron-positioner": "^4.1.0",
     "electron-store": "8.2.0",
     "electron-window-state": "5.0.3",
@@ -52,12 +54,13 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
-    "@eslint/js": "^9.26.0",
-    "http-server": "^14.1.1",
-    "electron": "^35.4.0",
+    "@eslint/js": "^9.29.0",
+    "electron": "^36.4.0",
     "electron-builder": "^26.0.12",
-    "eslint": "^9.26.0",
-    "globals": "^16.1.0"
+    "eslint": "^9.29.0",
+    "globals": "^16.2.0",
+    "http-server": "^14.1.1",
+    "xml2js": "^0.6.2"
   },
   "build": {
     "appId": "teams-for-linux",
@@ -70,6 +73,7 @@
         "msteams"
       ]
     },
+    
     "extraResources": [
       {
         "from": "app/assets/sounds",
@@ -96,7 +100,10 @@
       ],
       "publish": {
         "provider": "github",
-        "releaseType": "draft"
+        "releaseType": "draft",
+        "releaseInfo": {
+          "releaseNotesFile": "release-info.json"
+        }
       }
     },
     "rpm": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",

--- a/scripts/generateReleaseInfo.js
+++ b/scripts/generateReleaseInfo.js
@@ -141,7 +141,7 @@ if (require.main === module) {
       console.log("");
       console.log(JSON.stringify(releaseInfo, null, 2));
 
-      // Optional: Save to file
+      // Save to file
       const outputPath = path.join(__dirname, "..", "release-info.json");
       fs.writeFileSync(outputPath, JSON.stringify(releaseInfo, null, 2));
       console.log("");

--- a/scripts/generateReleaseInfo.js
+++ b/scripts/generateReleaseInfo.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+/**
+ * Generate release info according to electron-builder ReleaseInfo interface
+ * from com.github.IsmaelMartinez.teams_for_linux.appdata.xml file, ensuring version consistency across package files.
+ *
+ * ReleaseInfo interface: https://www.electron.build/app-builder-lib.interface.releaseinfo
+ */
+
+const fs = require("fs");
+const path = require("path");
+const xml2js = require("xml2js");
+
+async function generateReleaseInfo(projectRoot = null) {
+  const root = projectRoot || path.join(__dirname, "..");
+
+  // Load package.json
+  const pkgPath = path.join(root, "package.json");
+  if (!fs.existsSync(pkgPath)) {
+    throw new Error("package.json not found.");
+  }
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+  // Load package-lock.json
+  const lockPath = path.join(root, "package-lock.json");
+  if (!fs.existsSync(lockPath)) {
+    throw new Error(
+      'package-lock.json not found. Please run "npm install" to generate package-lock.json'
+    );
+  }
+  const pkgLock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+
+  // Check version consistency between package.json and package-lock.json
+  if (pkgLock.version !== pkg.version) {
+    throw new Error(
+      `Version mismatch: package.json (${pkg.version}) vs package-lock.json (${pkgLock.version}). Please run "npm install" to update package-lock.json.`
+    );
+  }
+
+  // Load com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+  const appdataPath = path.join(
+    root,
+    "com.github.IsmaelMartinez.teams_for_linux.appdata.xml"
+  );
+  if (!fs.existsSync(appdataPath)) {
+    throw new Error(
+      "com.github.IsmaelMartinez.teams_for_linux.appdata.xml not found."
+    );
+  }
+  const appdataContent = fs.readFileSync(appdataPath, "utf8");
+
+  // Parse XML
+  const parser = new xml2js.Parser();
+  const result = await parser.parseStringPromise(appdataContent);
+
+  // Navigate to releases
+  const component = result.component;
+  if (
+    !component ||
+    !component.releases ||
+    !component.releases[0] ||
+    !component.releases[0].release
+  ) {
+    throw new Error(
+      "No releases found in com.github.IsmaelMartinez.teams_for_linux.appdata.xml."
+    );
+  }
+
+  const releases = component.releases[0].release;
+
+  // Find matching release for current version
+  const matchingRelease = releases.find((rel) => rel.$.version === pkg.version);
+  if (!matchingRelease) {
+    throw new Error(
+      `No release entry found for version ${pkg.version} in com.github.IsmaelMartinez.teams_for_linux.appdata.xml. Please add a release entry for this version.`
+    );
+  }
+
+  // Extract release information
+  const releaseDate = matchingRelease.$.date;
+  let releaseNotes = "";
+
+  if (matchingRelease.description && matchingRelease.description[0]) {
+    const descObj = matchingRelease.description[0];
+
+    if (descObj.ul && descObj.ul[0] && descObj.ul[0].li) {
+      // Extract list items and format as markdown
+      const listItems = descObj.ul[0].li.map((li) => {
+        // Handle both simple strings and complex objects
+        const text = typeof li === "string" ? li : li._ || li;
+        return `• ${text}`;
+      });
+      releaseNotes = listItems.join("\n");
+    } else if (typeof descObj === "string") {
+      releaseNotes = descObj;
+    } else if (descObj._) {
+      releaseNotes = descObj._;
+    }
+  }
+
+  if (!releaseNotes.trim()) {
+    throw new Error(
+      `Release ${pkg.version} has no description/notes in com.github.IsmaelMartinez.teams_for_linux.appdata.xml. Please add release notes to the <description> section for this version.`
+    );
+  }
+
+  // Generate ReleaseInfo according to electron-builder interface
+  // https://www.electron.build/app-builder-lib.interface.releaseinfo
+  const releaseInfo = {
+    releaseName: pkg.version,
+    releaseNotes: releaseNotes,
+    releaseDate: releaseDate,
+  };
+
+  return {
+    releaseInfo,
+    versionInfo: {
+      packageJson: pkg.version,
+      packageLock: pkgLock.version,
+      appdata: pkg.version,
+    },
+  };
+}
+
+// CLI mode when run directly
+if (require.main === module) {
+  (async () => {
+    try {
+      const { releaseInfo, versionInfo } = await generateReleaseInfo();
+
+      // Success output    console.log('✅ Version consistency check passed!');
+      console.log(`   package.json: ${versionInfo.packageJson}`);
+      console.log(`   package-lock.json: ${versionInfo.packageLock}`);
+      console.log(
+        `   com.github.IsmaelMartinez.teams_for_linux.appdata.xml: ${versionInfo.appdata} (with release notes)`
+      );
+      console.log("");
+      console.log(
+        "📋 Generated Release Info (electron-builder ReleaseInfo interface):"
+      );
+      console.log("");
+      console.log(JSON.stringify(releaseInfo, null, 2));
+
+      // Optional: Save to file
+      const outputPath = path.join(__dirname, "..", "release-info.json");
+      fs.writeFileSync(outputPath, JSON.stringify(releaseInfo, null, 2));
+      console.log("");
+      console.log(`💾 Release info saved to: ${outputPath}`);
+    } catch (error) {
+      console.error("❌ Error:", error.message);
+      process.exit(1);
+    }
+  })();
+}
+
+module.exports = { generateReleaseInfo };

--- a/scripts/generateReleaseInfo.js
+++ b/scripts/generateReleaseInfo.js
@@ -55,12 +55,7 @@ async function generateReleaseInfo(projectRoot = null) {
 
   // Navigate to releases
   const component = result.component;
-  if (
-    !component ||
-    !component.releases ||
-    !component.releases[0] ||
-    !component.releases[0].release
-  ) {
+  if (!component?.releases?.[0]?.release) {
     throw new Error(
       "No releases found in com.github.IsmaelMartinez.teams_for_linux.appdata.xml."
     );
@@ -80,10 +75,10 @@ async function generateReleaseInfo(projectRoot = null) {
   const releaseDate = matchingRelease.$.date;
   let releaseNotes = "";
 
-  if (matchingRelease.description && matchingRelease.description[0]) {
+  if (matchingRelease.description?.[0]) {
     const descObj = matchingRelease.description[0];
 
-    if (descObj.ul && descObj.ul[0] && descObj.ul[0].li) {
+    if (descObj.ul?.[0]?.li) {
       // Extract list items and format as markdown
       const listItems = descObj.ul[0].li.map((li) => {
         // Handle both simple strings and complex objects


### PR DESCRIPTION
## What's New

- Update electron to 36.4.0 and @homebridge/dbus-native to 0.7.1 for improved ARM compatibility and security
- Adding release info generation from com.github.IsmaelMartinez.teams_for_linux.appdata.xml file
- Validate the release version is ready on the build.yml github action
- Updating github actions to use node 22

## Notes

### ARM Compatibility Improvements

The @homebridge/dbus-native update fixes crashes on ARMv6 platforms and improves overall ARM compatibility for Linux users.

### Electron 36.4.0 Update

This Electron update includes security improvements and modern platform support.

**GNOME Users**: Electron 36+ defaults to GTK 4 on GNOME. If you experience theming issues, you can use GTK 3 mode.

More details: [Electron GTK 4 Changes](https://www.electronjs.org/docs/latest/breaking-changes#changed-gtk-4-is-default-when-running-gnome)
---
*For a detailed comparison of changes, see the [Electron v35.4.0 to v36.4.0 Changes](https://github.com/electron/electron/compare/v35.4.0...v36.4.0).*

Closes #1691 