### PR TITLE
Fix: Remove deb packaging and update version

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.1.2" date="2025-07-28">
+			<description>
+				<ul>
+					<li>Removed deb packaging version (Issue #1768)</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.1.1" date="2025-07-26">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
@@ -29,7 +29,6 @@
     "dist": "electron-builder",
     "dist:linux": "electron-builder --linux",
     "dist:linux:targz": "electron-builder --x64 --armv7l --arm64 -l tar.gz",
-    "dist:linux:deb": "electron-builder --x64 --armv7l --arm64 -l deb",
     "dist:linux:rpm": "electron-builder --x64 --armv7l --arm64 -l rpm",
     "dist:linux:appimage": "electron-builder --x64 --armv7l --arm64 -l AppImage",
     "dist:linux:snap": "electron-builder -l snap",
@@ -37,9 +36,9 @@
     "dist:mac:x64": "electron-builder --mac --x64",
     "dist:mac:arm64": "electron-builder --mac --arm64",
     "dist:windows": "electron-builder --windows --x64",
-    "dist:linux:x64": "electron-builder --x64 -l tar.gz deb rpm AppImage",
-    "dist:linux:arm64": "electron-builder --arm64 -l tar.gz deb rpm AppImage",
-    "dist:linux:arm": "electron-builder --armv7l -l tar.gz deb rpm AppImage",
+    "dist:linux:x64": "electron-builder --x64 -l tar.gz rpm AppImage",
+    "dist:linux:arm64": "electron-builder --arm64 -l tar.gz rpm AppImage",
+    "dist:linux:arm": "electron-builder --armv7l -l tar.gz rpm AppImage",
     "release": "electron-builder"
   },
   "dependencies": {
@@ -93,7 +92,6 @@
       },
       "target": [
         "rpm",
-        "deb",
         "tar.gz",
         "AppImage"
       ],
@@ -119,18 +117,6 @@
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links  none",
         "--rpm-digest=sha256"
-      ]
-    },
-    "deb": {
-      "depends": [
-        "gtk3",
-        "libnotify",
-        "nss",
-        "libxss1",
-        "libxtst6",
-        "xdg-utils",
-        "at-spi2-core",
-        "libuuid1"
       ]
     },
     "snap": {


### PR DESCRIPTION
This PR addresses issue #1768 by removing the 'deb' packaging configuration from `package.json`.
The `package.json` version has been updated to `2.1.2`, and a corresponding release entry has been added to `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`

Fixes #1768 