### PR TITLE
Feat/add v1 v2 msteams config

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -353,6 +353,14 @@ function extractYargConfig(configObject, appVersion) {
         describe: "Enable tray icon",
         type: "boolean",
       },
+      msTeamsProtocols: {
+        default: {
+          v1: "^msteams:\/l\/(?:meetup-join|channel|chat)",
+          v2: "^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel|chat)",
+        },
+        describe: "Regular expressions for Microsoft Teams protocol links (v1 and v2).",
+        type: "object",
+      },
       url: {
         default: "https://teams.microsoft.com/v2",
         describe: "Microsoft Teams URL",

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -135,7 +135,11 @@ function extractYargConfig(configObject, appVersion) {
         type: "string",
       },
       cacheManagement: {
-        default: { enabled: false, maxCacheSizeMB: 300, cacheCheckIntervalMs: 3600000 },
+        default: {
+          enabled: false,
+          maxCacheSizeMB: 300,
+          cacheCheckIntervalMs: 3600000,
+        },
         describe:
           "Cache management configuration to prevent daily logout issues",
         type: "object",
@@ -355,10 +359,11 @@ function extractYargConfig(configObject, appVersion) {
       },
       msTeamsProtocols: {
         default: {
-          v1: "^msteams:\/l\/(?:meetup-join|channel|chat)",
-          v2: "^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel|chat)",
+          v1: "^msteams:/l/(?:meetup-join|channel|chat|message)",
+          v2: "^msteams://teams.microsoft.com/l/(?:meetup-join|channel|chat|message)",
         },
-        describe: "Regular expressions for Microsoft Teams protocol links (v1 and v2).",
+        describe:
+          "Regular expressions for Microsoft Teams protocol links (v1 and v2).",
         type: "object",
       },
       url: {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -235,10 +235,9 @@ function restoreWindow() {
  */
 function processArgs(args) {
   // Legacy Teams protocol format: msteams:/l/meetup-join/...
-  const v1msTeams = /^msteams:\/l\/(?:meetup-join|channel|chat)/;
+  const v1msTeams = new RegExp(config.msTeamsProtocols.v1);
   // Modern Teams protocol format: msteams://teams.microsoft.com/l/...
-  const v2msTeams =
-    /^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel|chat)/;
+  const v2msTeams = new RegExp(config.msTeamsProtocols.v2);
   console.debug("processArgs:", args);
   for (const arg of args) {
     console.debug(

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.1.4" date="2025-08-04">
+			<description>
+				<ul>
+					<li>Add msTeamsProtocols config option to handle v1 and v2 Teams protocol links.</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.1.3" date="2025-08-01">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -17,7 +17,7 @@
 		<release version="2.1.4" date="2025-08-04">
 			<description>
 				<ul>
-					<li>Add msTeamsProtocols config option to handle v1 and v2 Teams protocol links.</li>
+					<li>Add msTeamsProtocols config option to handle v1 and v2 Teams protocol links, and adding messages</li>
 				</ul>
 			</description>
 		</release>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,7 @@ The cache manager automatically detects your partition configuration and cleans 
 | `ssoInTuneEnabled` | `boolean` | `false` | Enable Single-Sign-On using Microsoft InTune. |
 | `ssoInTuneAuthUser` | `string` | `""` | User (e-mail) to use for InTune SSO. |
 | `trayIconEnabled` | `boolean` | `true` | Enable tray icon. |
+| `msTeamsProtocols` | `object` | `{ v1: "^msteams:\/l\/(?:meetup-join|channel|chat)", v2: "^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join|channel|chat)" }` | Regular expressions for Microsoft Teams protocol links (v1 and v2). |
 | `url` | `string` | `"https://teams.microsoft.com/v2"` | Microsoft Teams URL. |
 | `useMutationTitleLogic` | `boolean` | `true` | Use MutationObserver to update counter from title. |
 | `watchConfigFile` | `boolean` | `false` | Watch for changes in the config file and reload the app. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Add msTeamsProtocols config option

Adds a new `msTeamsProtocols` object to the configuration, allowing custom regexes for v1 and v2 Teams protocol links. This improves flexibility and organization of protocol handling.

**Changes Made:**

- Introduced `msTeamsProtocols` object in `app/config/index.js` to centralize v1 and v2 Teams protocol regexes.
- Updated `app/mainAppWindow/index.js` to utilize the new `config.msTeamsProtocols.v1` and `config.msTeamsProtocols.v2` for processing command-line arguments.
- Documented the new `msTeamsProtocols` configuration option in `docs/configuration.md`.
- Added messages to the regex to try to fix issue #675 
- Bumped the patch version in `package.json` and added a new release entry in `com.github.IsmaelMartinez.teams_for_linux.appdata.xml`