### PR TITLE
Fix tray icon badge count functionality

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.5.7" date="2025-09-18">
+			<description>
+				<ul>
+					<li>Fix: Restore tray icon badge count functionality that was missing since v2.3.0 - properly initialize TrayIconRenderer module in preload script</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.5.6" date="2025-09-15">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
## Summary
• Restores tray icon badge count functionality that was missing since v2.3.0
• Re-applies the TrayIconRenderer fix that was previously reverted
• Updates version to 2.5.7 with proper release notes
• Fixes #1795 by releasing the wrongly direct push to main of https://github.com/IsmaelMartinez/teams-for-linux/commit/82ac0887e13db2383893d0b34d8ca114a9b0b4c0 

## Changes Included
- Reverted the revert commit to restore the tray icon fix
- Updated package.json to version 2.5.7
- Added release entry to appdata.xml with release notes
- Generated release-info.json for build process

## Test Plan
- [x] Tray icon badge count should work correctly
- [x] Version bumped properly in all files
- [x] Release information generated successfully
- [x] All changes committed and ready for release

🤖 Generated with [Claude Code](https://claude.ai/code)