### PR TITLE
feat: join teams meeting using link from clipboard

### DIFF
--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -9,6 +9,11 @@ exports = module.exports = (Menus) => ({
       click: () => Menus.open(),
     },
     {
+      label: "Join Meeting",
+      accelerator: "ctrl+J",
+      click: () => Menus.joinMeeting(),
+    },
+    {
       label: "Refresh",
       accelerator: "ctrl+R",
       click: () => Menus.reload(),

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.5.11" date="2025-10-03">
+			<description>
+				<ul>
+					<li>Feature: Add a new tray menu entry to join a teams meeting from a copied URL in the clipboard</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.5.10" date="2025-10-02">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
Issue: There isn't any way to join a meeting using a meeting url.

My fix: This pr adds a new entry to the tray menu "Join Meeting" that checks the clipboard for a meeting link and opens it in the app.

If someone knows how to make a dialog with changeable text please tell me. I wanted to make the UX better but Electron doesn't want to work the way I want it to 😭