### PR TITLE
docs: Fix ADR-002 references in ADR-003

### DIFF
--- a/docs-site/docs/development/adr/003-token-refresh-implementation.md
+++ b/docs-site/docs/development/adr/003-token-refresh-implementation.md
@@ -153,7 +153,7 @@ This ADR establishes the foundation for tasks 3.0-6.0 in `tasks-prd-configurable
 ---
 
 **References:**
-- ADR-001: Token Cache Secure Storage Implementation  
+- ADR-002: Token Cache Secure Storage Implementation  
 - POC Implementation: `app/browser/tools/reactHandler.js` (triggerTokenRefresh method)
 - Configuration Patterns: `app/appConfiguration/index.js`
 - Task List: `tasks/tasks-prd-configurable-token-refresh.md`


### PR DESCRIPTION
ADR-001 is referenced instead of ADR-002 which is meant to be.