### PR TITLE
Fix snap crash on startup - revert to core22 and Electron 37.7.0 (v2.6.3)

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,13 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="2.6.3" date="2025-10-21">
+			<description>
+				<ul>
+					<li>Fix: Revert to core22 and Electron 37.7.0 for snap compatibility - electron-builder doesn't support core24 yet (issue #8548)</li>
+				</ul>
+			</description>
+		</release>
 		<release version="2.6.2" date="2025-01-21">
 			<description>
 				<ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teams-for-linux",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teams-for-linux",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",


### PR DESCRIPTION
## Summary
Fixes #1881 - snap crashes on startup with libpcre.so.3 error

This PR reverts the snap configuration to core22 and downgrades Electron from 38 to 37.7.0 to restore snap functionality.

## Changes
- Reverted snap base from core24 → core22
- Downgraded Electron from 38.3.0 → 37.7.0
- Updated version to 2.6.3

## Root Cause Analysis
The original fix (core24 upgrade) attempted to resolve the LIBDBUS_PRIVATE_1.12.20 error introduced by Electron 38. However:
1. electron-builder doesn't support core24 yet ([issue #8548](https://github.com/electron-userland/electron-builder/issues/8548))
2. core24 uses `platforms:` instead of `architectures:` in snapcraft.yaml, causing build failures
3. This resulted in missing libpcre.so.3 library error

## Solution
Revert to the working configuration from v2.2.1:
- core22 (Ubuntu 22.04) snap base
- Electron 37.7.0 (latest 37.x with security fixes)

## Future Work
When electron-builder adds proper core24 support, we can upgrade back to Electron 38+ and core24.

## Test Plan
- [ ] Snap builds successfully for amd64, arm64, armv7l
- [ ] Snap installs and launches without errors on Ubuntu 22.04+
- [ ] No LIBDBUS_PRIVATE_1.12.20 errors
- [ ] No libpcre.so.3 missing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)