### PR TITLE
Fixed url in CONTRIBUTING.MD and add link to screen-sharing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Documentation contributions involve:
 3. **Update navigation** in `docs-site/sidebars.ts` if adding new pages
 4. **Submit pull requests** which trigger automated builds and deployments
 
-See the [Documentation Contributing Guide](https://ismaelmartinez.github.io/teams-for-linux/contributing#documentation) for detailed instructions.
+See the [Documentation Contributing Guide](https://ismaelmartinez.github.io/teams-for-linux/development/contributing) for detailed instructions.
 
 ## Release Process
 

--- a/docs-site/docs/screen-sharing.md
+++ b/docs-site/docs/screen-sharing.md
@@ -46,6 +46,8 @@ flowchart TD
 
 ### Screen Sharing Thumbnail Settings
 
+To find your config file [see the “Configuration” section](configuration#configuration-locations)
+
 ```json
 {
   "screenSharingThumbnail": {


### PR DESCRIPTION
I have fixed the link that is pointing to the detailed instruction for Documentation contribution.
I have also added a link which point to the section where the configuration file is available, I believe this is good for new  comers which are not read the documentation top to bottom.