### PR TITLE
docs: add Recall.ai sponsorship section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ### Recall.ai — API for Meeting Recording and Transcription
 > If you're looking for a meeting recording API, consider checking out [Recall.ai](https://www.recall.ai/product/microsoft-teams-recording-api?utm_source=github&utm_medium=sponsorship&utm_campaign=ismaelmartinez-teams-for-linux), an API that records and transcribes Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
-<sub>This sponsorship helps support the ongoing development of teams-for-linux.</sub>
+_This sponsorship helps support the ongoing development of teams-for-linux._
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Add Recall.ai sponsorship section to README
- Placed after project description, before Installation section
- Includes brief description of their meeting recording API service

## Changes
- Added new "Sponsor" section with Recall.ai information
- Links to their Microsoft Teams recording API product page (with UTM tracking)
- Note that sponsorship supports ongoing development

## Context
Recall.ai is sponsoring teams-for-linux via GitHub Sponsors to support ongoing development and maintenance of the project.
