### PR TITLE
Fix crash when using custom CSS

### DIFF
--- a/.changelog/pr-2220.txt
+++ b/.changelog/pr-2220.txt
@@ -1,0 +1,1 @@
+Fix crash when using custom CSS - by @KrissN (#2220)

--- a/app/customCSS/index.js
+++ b/app/customCSS/index.js
@@ -60,7 +60,7 @@ function applyCustomCSSToFrame(webFrame, cssLocation) {
 				const style = document.createElement('style');
 				style.id = "${customCssId}";
 				style.type = "text/css";
-				style.innerHTML = \u0060${data}\u0060;
+				style.textContent = ${JSON.stringify(data)};
 				document.head.appendChild(style);
 			}
 		`);


### PR DESCRIPTION
When using custom CSS styles the application crashes after a few seconds with the following message:

```
[FATAL] Unhandled promise rejection: {
  message: "TypeError: This document requires 'TrustedHTML' assignment.\n" +
    '    at <anonymous>:6:25'
}
```

Fix this by using `textContent` instead of `innerHTML` to make TrustedTypes happy.