### PR TITLE
fix(customCSS): change style.innerHTML to style.textContent

### DIFF
--- a/app/customCSS/index.js
+++ b/app/customCSS/index.js
@@ -60,7 +60,7 @@ function applyCustomCSSToFrame(webFrame, cssLocation) {
 				const style = document.createElement('style');
 				style.id = "${customCssId}";
 				style.type = "text/css";
-				style.innerHTML = \u0060${data}\u0060;
+				style.textContent = \u0060${data}\u0060;
 				document.head.appendChild(style);
 			}
 		`);


### PR DESCRIPTION
I couldn't use custom css without patching this. 

20:46:48.397 › [FATAL] Unhandled promise rejection: {
  message: "TypeError: This document requires 'TrustedHTML' assignment.\n" +
    '    at <anonymous>:6:21'