### PR TITLE
feat: add webRTCIPHandlingPolicy config option

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -409,20 +409,17 @@ function extractYargConfig(configObject, appVersion) {
         type: "string",
       },
       network: {
-        default: [],
-      	webRTCIPHandlingPolicy: {
-      	  describe:
-      	    "WebRTC IP handling policy to control which network interfaces are used for ICE candidates. " +
-      	    "Use 'default_public_interface_only' to prevent WebRTC from advertising interfaces that have no internet route " +
-      	    "(e.g. a secondary ethernet adapter), which can cause calls to drop to OnHold due to asymmetric STUN routing. Disabled by default (opt-in).",
-      	  type: "string",
-      	  choices: [
-      	    "default",
-      	    "default_public_and_private_interfaces",
-      	    "default_public_interface_only",
-      	    "disable_non_proxied_udp",
-      	  ],
-      	}
+	default: {
+		webRTCIPHandlingPolicy: null,
+	},
+      	describe:
+	  "Network configuration. " +
+    	  "webRTCIPHandlingPolicy: WebRTC IP handling policy to control which network interfaces are used for ICE candidates. " +
+    	  "Use 'default_public_interface_only' to prevent WebRTC from advertising interfaces that have no internet route " +
+    	  "(e.g. a secondary ethernet adapter), which can cause calls to drop to OnHold due to asymmetric STUN routing. " +
+    	  "Valid values: 'default', 'default_public_and_private_interfaces', 'default_public_interface_only', 'disable_non_proxied_udp'. " +
+    	  "Disabled by default (opt-in).",
+	type: "object",
       },
       screenLockInhibitionMethod: {
         default: "Electron",

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -393,7 +393,7 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   // internet gateway) from being advertised, which causes asymmetric STUN
   // replies and drops calls to OnHold.
   if (config.network.webRTCIPHandlingPolicy) {
-    console.info(`Setting WebRTC IP handling policy to '${config.network.webRTCIPHandlingPolicy}'`);
+    console.info(`[WebRTC] IP handling policy applied`);
     window.webContents.setWebRTCIPHandlingPolicy(config.network.webRTCIPHandlingPolicy);
   }
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -198,14 +198,22 @@ Report-only Content Security Policy headers are automatically stripped for all n
 | `proxyServer` | `string` | `null` | Proxy Server with format address:port |
 | `network.webRTCIPHandlingPolicy` | `string` | `null` | Controls which network interfaces WebRTC uses for ICE candidate gathering. Choices: `default`, `default_public_and_private_interfaces`, `default_public_interface_only`, `disable_non_proxied_udp` |
 
-> [!NOTE]
-> **`webRTCIPHandlingPolicy`** is useful on systems with multiple network interfaces (e.g. WiFi for internet and a secondary Ethernet adapter with no internet gateway). Without this option, WebRTC advertises all interfaces as ICE candidates, which can cause asymmetric STUN routing and drop calls to **OnHold**. Setting it to `default_public_interface_only` restricts ICE gathering to the interface holding the default route only.
->
-> ```json
-> {
->   "webRTCIPHandlingPolicy": "default_public_interface_only"
-> }
-> ```
+*   `default` - Exposes user's public and local IPs. This is the default behavior. When this policy is used, WebRTC has the right to enumerate all interfaces and bind them to discover public interfaces.
+
+*   `default_public_interface_only` - Exposes user's public IP, but does not expose user's local IP. When this policy is used, WebRTC should only use the default route used by http. This doesn't expose any local addresses.
+
+*   `default_public_and_private_interfaces` - Exposes user's public and local IPs. When this policy is used, WebRTC should only use the default route used by http. This also exposes the associated default private address. Default route is the route chosen by the OS on a multi-homed endpoint.
+
+*   `disable_non_proxied_udp` - Does not expose public or local IPs. When this policy is used, WebRTC should only use TCP to contact peers or servers unless the proxy server supports UDP.
+
+[!NOTE]
+**`network.webRTCIPHandlingPolicy`** is useful on systems with multiple network interfaces (e.g. WiFi for internet and a secondary Ethernet adapter with no internet gateway). Without this option, WebRTC advertises all interfaces as ICE candidates, which can cause asymmetric STUN routing and drop calls to **OnHold**. Setting it to `default_public_interface_only` restricts ICE gathering to the interface holding the default route only.
+
+```json
+"network": {
+	"webRTCIPHandlingPolicy": "default_public_interface_only"
+}
+```
 
 ### Screen Sharing
 


### PR DESCRIPTION
# feat: add **webRTCIPHandlingPolicy** config option to fix OnHold drops on multi-interface systems

closes #2349

## Problem

On Linux systems with multiple network interfaces, Teams calls regularly drop to **OnHold**. WebRTC gathers ICE candidates from *all* interfaces, including ones with no internet gateway. When it sends a STUN binding request sourced from such an interface, the kernel routes the packet out via the default-route interface (e.g. WiFi), but the STUN server sends its reply back to the source IP — which arrives on the wrong interface. WebRTC rejects the reply (`Received non-STUN packet from unknown address`), the ICE candidate fails, and Teams drops the call to OnHold.

## Solution

Electron exposes `webContents.setWebRTCIPHandlingPolicy()` to restrict which interfaces WebRTC uses for ICE candidate gathering. This PR adds a `webRTCIPHandlingPolicy` config option that wires directly into that API.

Setting it to `default_public_interface_only` limits WebRTC to the interface holding the default route, eliminating candidates from secondary interfaces that have no internet path.

## Changes

### `app/config/index.js`
- Added `webRTCIPHandlingPolicy` yargs option with the four valid Chromium policy values as `choices`.
- No default value — the option is opt-in, leaving existing behaviour completely unchanged.

### `app/mainAppWindow/index.js`
- After `browserWindowManager.createWindow()`, calls `window.webContents.setWebRTCIPHandlingPolicy(config.webRTCIPHandlingPolicy)` when the option is set.
- Positioned immediately after window creation, before any WebRTC activity begins.

### `docs-site/docs/configuration.md`
- Added `webRTCIPHandlingPolicy` to the **Network & Proxy** section with description, available values, and a usage note explaining the multi-interface OnHold scenario.

## Usage

```json
{
  "webRTCIPHandlingPolicy": "default_public_interface_only"
}
```

## Testing

**Setup**: Machine with WiFi (`wlo1`, default route) and USB Ethernet adapter (`enx387c7603bc1f`, no internet gateway), both UP during a Teams call.

**Without fix:**
```
wlo1  Out  IP 192.168.0.1.47810    > 52.115.47.202.3478
wlo1  Out  IP 192.168.50.152.57271 > 52.115.47.202.3478
enx387c7603bc1f In  IP 52.115.47.202.3478 > 192.168.0.1.47810  ← asymmetric reply
```
→ Call drops to OnHold repeatedly.

**With fix (`default_public_interface_only`):**
```
wlo1  Out  IP 192.168.50.152.57271 > 52.115.47.202.3478
wlo1  In   IP 52.115.47.202.3478   > 192.168.50.152.57271
```
→ Only WiFi IP advertised, symmetric path, no OnHold drops.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test:e2e` passes (1 passed, 12.2s)
- [x] `docs-site/docs/configuration.md` updated with new option
- [x] No PII logged (policy value is not sensitive)
- [x] Option is opt-in — no behaviour change for existing users

## Notes

- `webContents.setWebRTCIPHandlingPolicy()` is the correct Electron API for this. The Chromium command-line switch `--force-webrtc-ip-handling-policy` was also investigated but confirmed ineffective in packaged Electron apps for renderer-level settings.
- Electron API reference: https://www.electronjs.org/docs/latest/api/web-contents#contentssetwebrtciphandlingpolicypolicy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable WebRTC IP handling policy to control how local IPs/interfaces are exposed during peer-to-peer connections; when set, the app applies the chosen policy at window creation. Multiple policy choices are supported to adjust behavior in multi-interface and proxied environments.

* **Documentation**
  * Added docs and examples describing the new WebRTC IP handling policy and guidance for multi-interface and proxied setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->