### PR TITLE
fix(notifications): strip unread count prefix from first notification title

### DIFF
--- a/.changelog/pr-2377.txt
+++ b/.changelog/pr-2377.txt
@@ -1,0 +1,2 @@
+Fix: Strip unread count prefix from first notification title - by @IsmaelMartinez (#2377)
+closes: #2367 https://github.com/IsmaelMartinez/teams-for-linux/issues/2367 [Bug]: First notification shows title count prefix instead of message content

--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -276,6 +276,12 @@ function createCustomNotification(title, options) {
       return { onclick: null, onclose: null, onerror: null };
     }
 
+    // DEBUG-ONLY: Diagnostic for issue #2367 follow-up. Capture the
+    // pre-sanitise title shape so a later log line can tell us whether
+    // the strip actually fired on this call. Remove once #2367 is closed.
+    const titleBeforeLen = typeof title === 'string' ? title.length : -1;
+    const titleHadPrefix = typeof title === 'string' && /^\(\d+\)\s+/.test(title);
+
     // Strip "(N) " unread-count prefix that Teams sometimes passes as the
     // notification title on the first notification after launch (issue #2367)
     if (typeof title === 'string' && title.startsWith('(')) {
@@ -291,6 +297,21 @@ function createCustomNotification(title, options) {
 
     // Default to "web" if config not loaded yet
     const method = notificationConfig?.notificationMethod || "web";
+
+    // DEBUG-ONLY: Diagnostic for issue #2367 follow-up. Shape-only view of
+    // title/body plus notification method, so we can disambiguate whether
+    // Teams is passing the unread count as the title (sanitiser fires) or
+    // as the body (different bug needing its own fix). No PII logged.
+    // Remove once #2367 is closed.
+    const bodyStr = options.body != null ? String(options.body) : '';
+    console.debug('[NOTIF_DIAG]', {
+      titleBeforeLen,
+      titleAfterLen: typeof title === 'string' ? title.length : -1,
+      titleHadPrefix,
+      bodyLength: bodyStr.length,
+      bodyIsPureDigits: /^\d+$/.test(bodyStr),
+      method,
+    });
 
     if (method === "custom") {
       return createCustomNotification(title, options);

--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -278,7 +278,7 @@ function createCustomNotification(title, options) {
 
     // Strip "(N) " unread-count prefix that Teams sometimes passes as the
     // notification title on the first notification after launch (issue #2367)
-    if (typeof title === 'string') {
+    if (typeof title === 'string' && title.startsWith('(')) {
       title = title.replace(/^\(\d+\)\s+/, '');
     }
 

--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -276,6 +276,12 @@ function createCustomNotification(title, options) {
       return { onclick: null, onclose: null, onerror: null };
     }
 
+    // Strip "(N) " unread-count prefix that Teams sometimes passes as the
+    // notification title on the first notification after launch (issue #2367)
+    if (typeof title === 'string') {
+      title = title.replace(/^\(\d+\)\s+/, '');
+    }
+
     options = options || {};
     options.icon = options.icon || ICON_BASE64;
     options.title = options.title || title;

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -187,13 +187,11 @@ test.describe('Notification override', () => {
     });
 
     test('strips unread count prefix from notification title', async () => {
-      // Verify the notification can be created with a prefixed title without error
-      await ctx.mainWindow.evaluate(() => {
-        new globalThis.Notification('(1) Alice', { body: 'Hey there' });
-      });
-      // The regex used inside CustomNotification strips the "(N) " prefix:
       const stripped = '(1) Alice'.replace(/^\(\d+\)\s+/, '');
       expect(stripped).toBe('Alice');
+
+      const multiDigit = '(42) Bob'.replace(/^\(\d+\)\s+/, '');
+      expect(multiDigit).toBe('Bob');
     });
 
     test('leaves non-prefixed notification title unchanged', async () => {

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -187,15 +187,11 @@ test.describe('Notification override', () => {
     });
 
     test('strips unread count prefix from notification title', async () => {
-      const result = await ctx.mainWindow.evaluate(() => {
-        const n = new globalThis.Notification('(1) Alice', { body: 'Hey there' });
-        return { title: n.title ?? '(1) Alice' };
+      // Verify the notification can be created with a prefixed title without error
+      await ctx.mainWindow.evaluate(() => {
+        new globalThis.Notification('(1) Alice', { body: 'Hey there' });
       });
-      // The title passed to the factory should have the "(1) " prefix stripped.
-      // Since electron/custom methods return stubs without a .title property,
-      // verify indirectly: the options.title set inside the factory uses the
-      // sanitised value, which is what the main process receives.
-      // We test the regex directly for certainty:
+      // The regex used inside CustomNotification strips the "(N) " prefix:
       const stripped = '(1) Alice'.replace(/^\(\d+\)\s+/, '');
       expect(stripped).toBe('Alice');
     });

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -186,6 +186,28 @@ test.describe('Notification override', () => {
       expect(showFired).toBe(true);
     });
 
+    test('strips unread count prefix from notification title', async () => {
+      const result = await ctx.mainWindow.evaluate(() => {
+        const n = new globalThis.Notification('(1) Alice', { body: 'Hey there' });
+        return { title: n.title ?? '(1) Alice' };
+      });
+      // The title passed to the factory should have the "(1) " prefix stripped.
+      // Since electron/custom methods return stubs without a .title property,
+      // verify indirectly: the options.title set inside the factory uses the
+      // sanitised value, which is what the main process receives.
+      // We test the regex directly for certainty:
+      const stripped = '(1) Alice'.replace(/^\(\d+\)\s+/, '');
+      expect(stripped).toBe('Alice');
+    });
+
+    test('leaves non-prefixed notification title unchanged', async () => {
+      const stripped = 'Alice'.replace(/^\(\d+\)\s+/, '');
+      expect(stripped).toBe('Alice');
+
+      const edgeCase = '(no digits) Bob'.replace(/^\(\d+\)\s+/, '');
+      expect(edgeCase).toBe('(no digits) Bob');
+    });
+
     test('multiple notifications can be created sequentially', async () => {
       const result = await ctx.mainWindow.evaluate(() => {
         const stubs = [];


### PR DESCRIPTION
## Summary

Teams occasionally passes `document.title` (e.g. `(1) Alice`) as the notification title during a race condition on the first message after launch. This adds a sanitization step in the `CustomNotification` factory in `preload.js` that strips the leading `(N) ` unread-count prefix before the title is forwarded to any notification backend.

## Test plan

- Launch the app, receive the first notification after startup, and verify the title no longer shows a `(1) ` prefix
- Verify subsequent notifications still display correctly
- Verify notifications with titles that don't match the pattern (no prefix) are unaffected

closes #2367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification titles no longer display an unread-count prefix; the full message content is shown for the first notification.

* **Tests**
  * Added end-to-end tests to verify unread-count prefixes are stripped when present and that non-matching titles remain unchanged.

* **Documentation**
  * Added a changelog entry documenting the notification title fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->