### PR TITLE
fix: prevent crash on corrupted JSON config files

### DIFF
--- a/app/customBackground/index.js
+++ b/app/customBackground/index.js
@@ -58,7 +58,14 @@ class CustomBackground {
       "custom_bg_remote.json",
     );
     if (fs.existsSync(file)) {
-      return JSON.parse(fs.readFileSync(file));
+      try {
+        return JSON.parse(fs.readFileSync(file));
+      } catch (err) {
+        console.error(
+          `[CUSTOM_BG] Failed to parse custom background config at '${file}': ${err.message}`,
+        );
+        return [];
+      }
     } else {
       return [];
     }

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -189,10 +189,21 @@ class Menus {
       "teams_settings.json"
     );
     if (fs.existsSync(settingsPath)) {
-      this.window.webContents.send(
-        "set-teams-settings",
-        JSON.parse(fs.readFileSync(settingsPath))
-      );
+      try {
+        this.window.webContents.send(
+          "set-teams-settings",
+          JSON.parse(fs.readFileSync(settingsPath))
+        );
+      } catch (err) {
+        console.error(
+          `[SETTINGS] Failed to parse settings file at '${settingsPath}': ${err.message}`
+        );
+        dialog.showMessageBoxSync(this.window, {
+          message: "Settings file is corrupted. Using default settings.",
+          title: "Restore settings",
+          type: "warning",
+        });
+      }
     } else {
       dialog.showMessageBoxSync(this.window, {
         message: "Settings file not found. Using default settings.",


### PR DESCRIPTION
## Problem

Noticed while reading through the custom background code that `handleGetCustomBGList()` calls `JSON.parse(fs.readFileSync(file))` on `custom_bg_remote.json` without a try-catch. If that file gets corrupted — say the app crashes while `onCustomBGServiceConfigDownloadSuccess()` is writing it at line 166 — the unhandled `SyntaxError` from `JSON.parse` propagates up through the IPC handler and crashes the app.

The same issue exists in `menus/index.js` where `restoreSettings()` parses `teams_settings.json` without error handling. A corrupted settings file takes down the whole app with no recovery path.

## Changes

**`app/customBackground/index.js`** — `handleGetCustomBGList()`:
- Wrapped `JSON.parse(fs.readFileSync(...))` in try-catch
- Returns empty array on parse failure (same fallback as the `else` branch)
- Logs the error for debugging

**`app/menus/index.js`** — `restoreSettings()`:
- Wrapped the parse + IPC send in try-catch
- Shows a warning dialog on corruption (consistent with the existing "file not found" dialog below)
- Logs the error for debugging

## Reference

The same `customBackground/index.js` file already handles this correctly in `onCustomBGServiceConfigDownloadSuccess()` at line 161-174:

```javascript
try {
  const configJSON = JSON.parse(data);
  // ...
} catch (err) {
  console.warn(`Fetched custom background remote configuration but failed to save...`);
}
```

This PR brings the read path in line with that existing write-path pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for corrupted configuration files to prevent application crashes.
* Added user-friendly warning notification when settings file is corrupted, informing users that default settings will be applied.
* Enhanced robustness when loading custom backgrounds with better error recovery and graceful fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->