### PR TITLE
fix: use WebRTC-based call detection as fallback for MQTT in-call status (#2358)

### DIFF
--- a/.changelog/pr-2406.txt
+++ b/.changelog/pr-2406.txt
@@ -1,0 +1,1 @@
+Fix call status detection when hanging up from popup window. - by @IsmaelMartinez (#2406)

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -18,6 +18,21 @@ class ActivityHub {
     return removeEventHandler(event, handle);
   }
 
+  /**
+   * Emit an event externally (e.g. from WebRTC-based call detection).
+   * This allows modules like speakingIndicator to trigger call-connected /
+   * call-disconnected when the React-based detection misses a state change.
+   */
+  emit(event, data) {
+    if (!isSupportedEvent(event)) {
+      return;
+    }
+    const handlers = getEventHandlers(event);
+    for (const handler of handlers) {
+      handler.handler(data || {});
+    }
+  }
+
   start() {
     let attemptCount = 0;
     const maxAttempts = 12; // Try for up to 2 minutes

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -29,7 +29,11 @@ class ActivityHub {
     }
     const handlers = getEventHandlers(event);
     for (const handler of handlers) {
-      handler.handler(data || {});
+      try {
+        handler.handler(data || {});
+      } catch (err) {
+        console.error(`ActivityHub: handler for '${event}' threw:`, err);
+      }
     }
   }
 

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -30,7 +30,9 @@ class ActivityHub {
     const handlers = getEventHandlers(event);
     for (const handler of handlers) {
       try {
-        handler.handler(data || {});
+        Promise.resolve(handler.handler(data || {})).catch((err) => {
+          console.error(`ActivityHub: handler for '${event}' threw:`, err);
+        });
       } catch (err) {
         console.error(`ActivityHub: handler for '${event}' threw:`, err);
       }

--- a/app/browser/tools/speakingIndicator.js
+++ b/app/browser/tools/speakingIndicator.js
@@ -206,8 +206,11 @@ class SpeakingIndicator {
 			this.#polling = false;
 		}
 
-		// WebRTC-based call-connected: audio stats detected for the first time (#2358)
-		if (foundAudioStats && !this.#inCall) {
+		// WebRTC-based call-connected: audio stats detected with an established
+		// connection. The connectionState check prevents premature emission during
+		// pre-join setup when audio stats may appear with zero audioLevel. (#2358)
+		const hasConnectedPeer = this.#peerConnections.some(pc => pc.connectionState === 'connected');
+		if (foundAudioStats && hasConnectedPeer && !this.#inCall) {
 			this.#inCall = true;
 			console.info(`${LOG_PREFIX} Audio stats detected, emitting call-connected (WebRTC)`);
 			activityHub.emit('call-connected');

--- a/app/browser/tools/speakingIndicator.js
+++ b/app/browser/tools/speakingIndicator.js
@@ -16,7 +16,6 @@
  * connections close (e.g. hanging up from the popup window), it emits
  * call-disconnected through activityHub — fixing #2358 where the React
  * event doesn't fire for popup hang-ups.
- *
  * The RTCPeerConnection patching activates when either the visual overlay
  * is enabled (media.microphone.speakingIndicator) or MQTT is enabled
  * (mqtt.enabled), ensuring reliable in-call detection for home automation.
@@ -44,9 +43,9 @@ class SpeakingIndicator {
 	#pollInterval = null;
 	#polling = false;
 	#overlayVisible = false;
-	#overlayEnabled = false; // whether to show the visual overlay
+	#overlayEnabled = false;
 	#hasSeenAudio = false; // true once audioLevel >= MUTED_LEVEL — prevents pre-join zeros reading as muted
-	#inCall = false; // WebRTC-based call state tracking for reliable disconnect detection (#2358)
+	#inCall = false;
 
 	init(config) {
 		const overlayEnabled = config.media?.microphone?.speakingIndicator === true;

--- a/app/browser/tools/speakingIndicator.js
+++ b/app/browser/tools/speakingIndicator.js
@@ -11,6 +11,16 @@
  * in Teams' internal React event emission. It appears automatically when
  * audio stats are detected and disappears when all connections close.
  *
+ * Additionally, this module provides WebRTC-based call state detection as a
+ * fallback for the React-based detection in activityHub. When all peer
+ * connections close (e.g. hanging up from the popup window), it emits
+ * call-disconnected through activityHub — fixing #2358 where the React
+ * event doesn't fire for popup hang-ups.
+ *
+ * The RTCPeerConnection patching activates when either the visual overlay
+ * is enabled (media.microphone.speakingIndicator) or MQTT is enabled
+ * (mqtt.enabled), ensuring reliable in-call detection for home automation.
+ *
  * Overlay states:
  * - Green (pulsing): speaking — audio is being transmitted
  * - Grey: silent — mic is open but quiet
@@ -34,18 +44,25 @@ class SpeakingIndicator {
 	#pollInterval = null;
 	#polling = false;
 	#overlayVisible = false;
+	#overlayEnabled = false; // whether to show the visual overlay
 	#hasSeenAudio = false; // true once audioLevel >= MUTED_LEVEL — prevents pre-join zeros reading as muted
+	#inCall = false; // WebRTC-based call state tracking for reliable disconnect detection (#2358)
 
 	init(config) {
-		const enabled = config.media?.microphone?.speakingIndicator;
-		if (!enabled) {
+		const overlayEnabled = config.media?.microphone?.speakingIndicator === true;
+		const mqttEnabled = config.mqtt?.enabled === true;
+
+		if (!overlayEnabled && !mqttEnabled) {
 			return;
 		}
+
+		this.#overlayEnabled = overlayEnabled;
 
 		try {
 			this.#patchRTCPeerConnection();
 			this.#registerCallEvents();
-			console.info(`${LOG_PREFIX} Initialized`);
+			const mode = overlayEnabled ? 'overlay + call detection' : 'call detection only';
+			console.info(`${LOG_PREFIX} Initialized (${mode})`);
 		} catch (error) {
 			console.error(`${LOG_PREFIX} Failed to initialize:`, error);
 		}
@@ -79,14 +96,16 @@ class SpeakingIndicator {
 	}
 
 	#registerCallEvents() {
-		// call-disconnected used as a cleanup hint only — the poll loop is the
-		// primary driver of overlay visibility.
+		// React-based call events are used as hints; WebRTC polling is the
+		// authoritative source for call state (fixes #2358).
 		activityHub.on('call-connected', () => {
-			console.info(`${LOG_PREFIX} call-connected event received`);
+			console.info(`${LOG_PREFIX} call-connected event received (React)`);
+			this.#inCall = true;
 		});
 
 		activityHub.on('call-disconnected', () => {
-			console.info(`${LOG_PREFIX} call-disconnected event received, clearing connections`);
+			console.info(`${LOG_PREFIX} call-disconnected event received (React), clearing connections`);
+			this.#inCall = false;
 			this.#peerConnections = [];
 			this.#hasSeenAudio = false;
 			this.#stopPolling();
@@ -125,6 +144,12 @@ class SpeakingIndicator {
 			console.info(`${LOG_PREFIX} No active connections, stopping polling`);
 			this.#stopPolling();
 			this.#hideOverlay();
+			// WebRTC-based call-disconnected: all connections closed (#2358)
+			if (this.#inCall) {
+				this.#inCall = false;
+				console.info(`${LOG_PREFIX} All connections closed, emitting call-disconnected (WebRTC)`);
+				activityHub.emit('call-disconnected');
+			}
 			return;
 		}
 
@@ -182,7 +207,14 @@ class SpeakingIndicator {
 			this.#polling = false;
 		}
 
-		if (foundAudioStats && !this.#overlayVisible) {
+		// WebRTC-based call-connected: audio stats detected for the first time (#2358)
+		if (foundAudioStats && !this.#inCall) {
+			this.#inCall = true;
+			console.info(`${LOG_PREFIX} Audio stats detected, emitting call-connected (WebRTC)`);
+			activityHub.emit('call-connected');
+		}
+
+		if (foundAudioStats && !this.#overlayVisible && this.#overlayEnabled) {
 			console.info(`${LOG_PREFIX} Audio stats detected, showing overlay`);
 			this.#showOverlay();
 		} else if (!foundAudioStats && this.#overlayVisible) {

--- a/app/browser/tools/speakingIndicator.js
+++ b/app/browser/tools/speakingIndicator.js
@@ -99,12 +99,12 @@ class SpeakingIndicator {
 		// React-based call events are used as hints; WebRTC polling is the
 		// authoritative source for call state (fixes #2358).
 		activityHub.on('call-connected', () => {
-			console.info(`${LOG_PREFIX} call-connected event received (React)`);
+			console.info(`${LOG_PREFIX} call-connected event received`);
 			this.#inCall = true;
 		});
 
 		activityHub.on('call-disconnected', () => {
-			console.info(`${LOG_PREFIX} call-disconnected event received (React), clearing connections`);
+			console.info(`${LOG_PREFIX} call-disconnected event received, clearing connections`);
 			this.#inCall = false;
 			this.#peerConnections = [];
 			this.#hasSeenAudio = false;

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -286,6 +286,7 @@ Media settings are organized under the `media` configuration object with subgrou
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `media.microphone.disableAutogain` | `boolean` | `false` | Disable microphone auto gain control - prevents Teams from automatically adjusting microphone volume levels. Useful for professional audio setups or when manual gain control is preferred |
+| `media.microphone.speakingIndicator` | `boolean` | `false` | Enable visual overlay showing microphone state during calls (speaking/silent/muted). When enabled, also provides WebRTC-based call state detection. Note: when `mqtt.enabled` is true, the WebRTC call detection activates automatically even without this option, ensuring reliable `in-call` topic publishing |
 | `media.camera.resolution.enabled` | `boolean` | `false` | Enable camera resolution control |
 | `media.camera.resolution.mode` | `string` | `"remove"` | Resolution mode: `"remove"` removes Teams' constraints allowing native camera resolution, `"override"` sets specific width/height |
 | `media.camera.resolution.width` | `number` | - | Target width when mode is `"override"` |
@@ -381,7 +382,7 @@ When MQTT is enabled, the following topics are automatically published:
 |-------|---------|-------------|
 | `\{topicPrefix\}/connected` | `"true"` or `"false"` | App connection state (uses MQTT Last Will) |
 | `\{topicPrefix\}/status` | JSON object | User presence status (Available, Busy, DND, Away, BRB) |
-| `\{topicPrefix\}/in-call` | `"true"` or `"false"` | Active call state (connected/disconnected) |
+| `\{topicPrefix\}/in-call` | `"true"` or `"false"` | Active call state (connected/disconnected). Uses WebRTC fallback for reliable detection even from popup windows. |
 | `\{topicPrefix\}/camera` | `"true"` or `"false"` | Camera on/off state (Phase 2) |
 | `\{topicPrefix\}/microphone` | `"true"` or `"false"` | Microphone on/off state (Phase 2) |
 | `\{topicPrefix\}/screen-sharing` | `"true"` or `"false"` | Screen sharing active state |

--- a/docs-site/docs/development/module-index.md
+++ b/docs-site/docs/development/module-index.md
@@ -42,7 +42,7 @@ User-facing features and integrations.
 | **InTune SSO** | `app/intune/` | Microsoft InTune single sign-on integration | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/intune/README.md), [User Guide](../intune-sso.md) |
 | **Global Shortcuts** | `app/globalShortcuts/` | System-wide keyboard shortcuts | No README yet |
 | **Graph API** | `app/graphApi/` | Microsoft Graph API integration for calendar and mail | [Research](./research/graph-api-integration-research.md) |
-| **Speaking Indicator** | `app/browser/tools/speakingIndicator.js` | Visual overlay showing microphone state during calls (speaking/silent/muted) via RTCPeerConnection.getStats() | [PR #2299](https://github.com/IsmaelMartinez/teams-for-linux/pull/2299) |
+| **Speaking Indicator** | `app/browser/tools/speakingIndicator.js` | Visual overlay showing microphone state during calls (speaking/silent/muted) via RTCPeerConnection.getStats(). Also provides WebRTC-based call state fallback for reliable MQTT in-call detection ([#2358](https://github.com/IsmaelMartinez/teams-for-linux/issues/2358)). | [PR #2299](https://github.com/IsmaelMartinez/teams-for-linux/pull/2299) |
 
 ## System Integration Modules
 

--- a/docs-site/docs/development/plan/roadmap.md
+++ b/docs-site/docs/development/plan/roadmap.md
@@ -36,7 +36,7 @@ Camera and microphone issues remain the most common user-reported bugs. Recent w
 
 Call drops on multi-interface systems ([#2349](https://github.com/IsmaelMartinez/teams-for-linux/issues/2349)) are addressed via a `webRTCIPHandlingPolicy` config option. Users with VPN + physical NIC setups should test with `"default_public_interface_only"` and report back.
 
-MQTT in-call detection doesn't detect hang-ups from the small popup window ([#2358](https://github.com/IsmaelMartinez/teams-for-linux/issues/2358)). Root cause identified: the popup tear-down doesn't fire through Teams' React `commandChangeReportingService`. The fix requires adding a WebRTC-based polling fallback in `activityHub.js`, following the pattern already proven in `speakingIndicator.js`.
+MQTT in-call detection from the small popup window ([#2358](https://github.com/IsmaelMartinez/teams-for-linux/issues/2358)) is now fixed. The solution uses WebRTC-based call state detection in `speakingIndicator.js` to emit `call-connected`/`call-disconnected` events through `activityHub` when RTCPeerConnection state changes. This works regardless of which hang-up button the user clicks. The RTCPeerConnection patching activates when either `media.microphone.speakingIndicator` or `mqtt.enabled` is true.
 
 Meeting join replacing the whole window ([#2322](https://github.com/IsmaelMartinez/teams-for-linux/issues/2322)) has been investigated --- all three code paths that handle meeting URLs call `window.loadURL()`, destroying the Teams SPA. Fix approach TBD (auto-navigate back vs separate BrowserWindow).
 

--- a/docs-site/docs/development/plan/roadmap.md
+++ b/docs-site/docs/development/plan/roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-**Last Updated:** 2026-04-01
+**Last Updated:** 2026-04-07
 **Current Version:** v2.7.13 → v2.8.0 in progress (Electron 41.0.2, Chromium 146, Node.js 24)
 **Status:** Living Document --- Electron 41 upgrade in PR [#2347](https://github.com/IsmaelMartinez/teams-for-linux/pull/2347); cross-distro tests passing 9/9; next focus is bug fixes and dev experience
 

--- a/docs-site/docs/development/research/mqtt-extended-status-investigation.md
+++ b/docs-site/docs/development/research/mqtt-extended-status-investigation.md
@@ -7,7 +7,7 @@ Infrastructure, LWT, and call state publishing are shipped. Phase 2 (WebRTC came
 **Date**: 2025-11-12
 **Updated**: 2026-01-18
 **Issue**: [#1938 - Extended MQTT Status Fields](https://github.com/IsmaelMartinez/teams-for-linux/issues/1938)
-**Status**: Phase 1 Complete (Infrastructure + Documentation + LWT) | Phase 2 DEFERRED
+**Status**: Phase 1 Complete (Infrastructure + Documentation + LWT + WebRTC Call State Fallback) | Phase 2 DEFERRED
 
 ## User Request
 

--- a/docs-site/docs/development/research/mqtt-microphone-state-research.md
+++ b/docs-site/docs/development/research/mqtt-microphone-state-research.md
@@ -97,6 +97,17 @@ The speaking indicator currently works independently of MQTT — users can enabl
 
 Both features need to be enabled for MQTT microphone state to work: `media.microphone.speakingIndicator=true` AND `mqtt.enabled=true`. This should be documented in the configuration reference.
 
+### WebRTC-Based Call State Fallback (#2358)
+
+As of the #2358 fix, `speakingIndicator.js` also emits `call-connected` and `call-disconnected` events through `activityHub` when RTCPeerConnection state changes. This provides a reliable fallback for in-call detection when Teams' React `commandChangeReportingService` doesn't fire (e.g., hanging up from the popup window).
+
+The RTCPeerConnection patching now activates when **either** feature is enabled:
+
+- `media.microphone.speakingIndicator=true` (visual overlay + call detection)
+- `mqtt.enabled=true` (call detection only, no overlay)
+
+This means MQTT users get reliable in-call detection even without enabling the visual speaking indicator overlay. The coupling is intentional: the same WebRTC monitoring serves both features.
+
 ---
 
 ## Why Not the Original Phase 2 Approach

--- a/tests/unit/speakingIndicator.test.js
+++ b/tests/unit/speakingIndicator.test.js
@@ -166,7 +166,7 @@ describe('SpeakingIndicator', () => {
 		const { instance, mockActivityHub } = loadSpeakingIndicator();
 		instance.init({ mqtt: { enabled: true } });
 
-		new globalThis.RTCPeerConnection();
+		const _pc = new globalThis.RTCPeerConnection();
 		await new Promise(r => setTimeout(r, 200));
 
 		const emitCalls = mockActivityHub.emit.mock.calls;
@@ -181,7 +181,7 @@ describe('SpeakingIndicator', () => {
 		const { instance, mockActivityHub } = loadSpeakingIndicator();
 		instance.init({ mqtt: { enabled: true } });
 
-		new globalThis.RTCPeerConnection();
+		const _pc = new globalThis.RTCPeerConnection();
 		await new Promise(r => setTimeout(r, 200));
 
 		// Verify call-connected was emitted first
@@ -203,7 +203,7 @@ describe('SpeakingIndicator', () => {
 		const { instance } = loadSpeakingIndicator();
 		instance.init({ media: { microphone: { speakingIndicator: false } }, mqtt: { enabled: true } });
 
-		new globalThis.RTCPeerConnection();
+		const _pc = new globalThis.RTCPeerConnection();
 		await new Promise(r => setTimeout(r, 200));
 
 		assert.strictEqual(

--- a/tests/unit/speakingIndicator.test.js
+++ b/tests/unit/speakingIndicator.test.js
@@ -166,7 +166,7 @@ describe('SpeakingIndicator', () => {
 		const { instance, mockActivityHub } = loadSpeakingIndicator();
 		instance.init({ mqtt: { enabled: true } });
 
-		const _pc = new globalThis.RTCPeerConnection();
+		assert.ok(new globalThis.RTCPeerConnection(), 'RTCPeerConnection should be constructable');
 		await new Promise(r => setTimeout(r, 200));
 
 		const emitCalls = mockActivityHub.emit.mock.calls;
@@ -181,7 +181,7 @@ describe('SpeakingIndicator', () => {
 		const { instance, mockActivityHub } = loadSpeakingIndicator();
 		instance.init({ mqtt: { enabled: true } });
 
-		const _pc = new globalThis.RTCPeerConnection();
+		assert.ok(new globalThis.RTCPeerConnection(), 'RTCPeerConnection should be constructable');
 		await new Promise(r => setTimeout(r, 200));
 
 		// Verify call-connected was emitted first
@@ -213,7 +213,7 @@ describe('SpeakingIndicator', () => {
 		const { instance } = loadSpeakingIndicator();
 		instance.init({ media: { microphone: { speakingIndicator: false } }, mqtt: { enabled: true } });
 
-		const _pc = new globalThis.RTCPeerConnection();
+		assert.ok(new globalThis.RTCPeerConnection(), 'RTCPeerConnection should be constructable');
 		await new Promise(r => setTimeout(r, 200));
 
 		assert.strictEqual(

--- a/tests/unit/speakingIndicator.test.js
+++ b/tests/unit/speakingIndicator.test.js
@@ -188,11 +188,21 @@ describe('SpeakingIndicator', () => {
 		const connectedEmit = mockActivityHub.emit.mock.calls.find(c => c.arguments[0] === 'call-connected');
 		assert.ok(connectedEmit, 'should have emitted call-connected');
 
+		// Verify no call-disconnected was emitted yet
+		assert.strictEqual(
+			mockActivityHub.emit.mock.calls.some(c => c.arguments[0] === 'call-disconnected'),
+			false,
+			'should not emit call-disconnected before connections close'
+		);
+		const emitCountBeforeClose = mockActivityHub.emit.mock.calls.length;
+
 		// Close all connections
 		closePeerConnections();
 		await new Promise(r => setTimeout(r, 200));
 
-		const disconnectedEmit = mockActivityHub.emit.mock.calls.find(c => c.arguments[0] === 'call-disconnected');
+		const disconnectedEmit = mockActivityHub.emit.mock.calls
+			.slice(emitCountBeforeClose)
+			.find(c => c.arguments[0] === 'call-disconnected');
 		assert.ok(disconnectedEmit, 'should emit call-disconnected when all connections close');
 	});
 

--- a/tests/unit/speakingIndicator.test.js
+++ b/tests/unit/speakingIndicator.test.js
@@ -41,7 +41,7 @@ function setupGlobals() {
 }
 
 function loadSpeakingIndicator() {
-	const mockActivityHub = { on: mock.fn(), off: mock.fn() };
+	const mockActivityHub = { on: mock.fn(), off: mock.fn(), emit: mock.fn() };
 	require.cache[activityHubPath] = {
 		id: activityHubPath,
 		exports: mockActivityHub,
@@ -76,21 +76,21 @@ describe('SpeakingIndicator', () => {
 		cleanup();
 	});
 
-	it('does not patch RTCPeerConnection when disabled', () => {
+	it('does not patch RTCPeerConnection when both overlay and MQTT are disabled', () => {
 		setupGlobals();
 		const { instance } = loadSpeakingIndicator();
 		const refBefore = globalThis.RTCPeerConnection;
 
-		instance.init({ media: { microphone: { speakingIndicator: false } } });
+		instance.init({ media: { microphone: { speakingIndicator: false } }, mqtt: { enabled: false } });
 
 		assert.strictEqual(
 			globalThis.RTCPeerConnection,
 			refBefore,
-			'RTCPeerConnection should remain unchanged when speakingIndicator is disabled'
+			'RTCPeerConnection should remain unchanged when both features are disabled'
 		);
 	});
 
-	it('patches RTCPeerConnection when enabled', () => {
+	it('patches RTCPeerConnection when overlay is enabled', () => {
 		setupGlobals();
 		const { instance } = loadSpeakingIndicator();
 		const refBefore = globalThis.RTCPeerConnection;
@@ -101,6 +101,20 @@ describe('SpeakingIndicator', () => {
 			globalThis.RTCPeerConnection,
 			refBefore,
 			'RTCPeerConnection should be replaced when speakingIndicator is enabled'
+		);
+	});
+
+	it('patches RTCPeerConnection when only MQTT is enabled (#2358)', () => {
+		setupGlobals();
+		const { instance } = loadSpeakingIndicator();
+		const refBefore = globalThis.RTCPeerConnection;
+
+		instance.init({ media: { microphone: { speakingIndicator: false } }, mqtt: { enabled: true } });
+
+		assert.notStrictEqual(
+			globalThis.RTCPeerConnection,
+			refBefore,
+			'RTCPeerConnection should be patched for call detection when MQTT is enabled'
 		);
 	});
 
@@ -142,6 +156,60 @@ describe('SpeakingIndicator', () => {
 		assert.ok(
 			globalThis.document.body.appendChild.mock.calls.length > 0,
 			'overlay should appear when audio stats with non-zero audioLevel are detected'
+		);
+	});
+
+	it('emits call-connected via activityHub when audio stats first detected (#2358)', async () => {
+		setupGlobals();
+		getStatsFn = async () => makeStatsReport(0.05);
+
+		const { instance, mockActivityHub } = loadSpeakingIndicator();
+		instance.init({ mqtt: { enabled: true } });
+
+		new globalThis.RTCPeerConnection();
+		await new Promise(r => setTimeout(r, 200));
+
+		const emitCalls = mockActivityHub.emit.mock.calls;
+		const connectedEmit = emitCalls.find(c => c.arguments[0] === 'call-connected');
+		assert.ok(connectedEmit, 'should emit call-connected when audio stats are first detected');
+	});
+
+	it('emits call-disconnected via activityHub when all connections close (#2358)', async () => {
+		setupGlobals();
+		getStatsFn = async () => makeStatsReport(0.05);
+
+		const { instance, mockActivityHub } = loadSpeakingIndicator();
+		instance.init({ mqtt: { enabled: true } });
+
+		new globalThis.RTCPeerConnection();
+		await new Promise(r => setTimeout(r, 200));
+
+		// Verify call-connected was emitted first
+		const connectedEmit = mockActivityHub.emit.mock.calls.find(c => c.arguments[0] === 'call-connected');
+		assert.ok(connectedEmit, 'should have emitted call-connected');
+
+		// Close all connections
+		closePeerConnections();
+		await new Promise(r => setTimeout(r, 200));
+
+		const disconnectedEmit = mockActivityHub.emit.mock.calls.find(c => c.arguments[0] === 'call-disconnected');
+		assert.ok(disconnectedEmit, 'should emit call-disconnected when all connections close');
+	});
+
+	it('does not show overlay when only MQTT is enabled (#2358)', async () => {
+		setupGlobals();
+		getStatsFn = async () => makeStatsReport(0.05);
+
+		const { instance } = loadSpeakingIndicator();
+		instance.init({ media: { microphone: { speakingIndicator: false } }, mqtt: { enabled: true } });
+
+		new globalThis.RTCPeerConnection();
+		await new Promise(r => setTimeout(r, 200));
+
+		assert.strictEqual(
+			globalThis.document.body.appendChild.mock.calls.length,
+			0,
+			'overlay should not appear when only MQTT is enabled (no visual indicator)'
 		);
 	});
 });


### PR DESCRIPTION
The React-based call-disconnected event doesn't fire when hanging up
from the small popup window. This adds WebRTC peer connection monitoring
(the speaking indicator pattern) as a reliable fallback — when all
RTCPeerConnections close, call-disconnected is emitted through
activityHub regardless of which UI button was used.

Changes:
- Add emit() method to activityHub for external event triggering
- Track #inCall state in speakingIndicator via RTCPeerConnection lifecycle
- Emit call-connected when audio stats first detected
- Emit call-disconnected when all peer connections close
- Activate RTCPeerConnection patching when MQTT is enabled (even without
  the visual overlay), ensuring reliable in-call detection for home
  automation users
- Add tests for MQTT-only init, call state emission, and overlay suppression

https://claude.ai/code/session_011od5tKoqNghDv97DPRBhPy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added media.microphone.speakingIndicator setting for an on-screen microphone overlay; WebRTC-based call-state detection now also activates when MQTT is enabled even if the overlay is disabled.

* **Bug Fixes**
  * Fixed call status detection for hang-ups originating from popup windows.

* **Documentation**
  * Updated configuration, development, roadmap, and research docs to describe the speaking indicator and WebRTC call-state fallback.

* **Tests**
  * Expanded unit tests to cover call-connected/call-disconnected events and MQTT-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes: #2358 