### PR TITLE
feat: rename audio streams from "Chromium" to "Teams for Linux" in volume mixer

### DIFF
--- a/.changelog/pr-2407.txt
+++ b/.changelog/pr-2407.txt
@@ -1,0 +1,2 @@
+Update audio stream name from "Chromium" to "Teams for Linux" in volume mixer. - by @IsmaelMartinez (#2407)
+closes: #2382 https://github.com/IsmaelMartinez/teams-for-linux/issues/2382 [Feat]: Rename audio devices

--- a/app/index.js
+++ b/app/index.js
@@ -69,6 +69,14 @@ if (process.env.E2E_USER_DATA_DIR) {
   app.setPath("userData", process.env.E2E_USER_DATA_DIR);
 }
 
+// Set PulseAudio stream properties so volume mixers show "Teams for Linux"
+// instead of "Chromium". Must run before Chromium initialises audio.
+if (os.platform() === "linux") {
+  process.env.PULSE_PROP_application_name ??= "Teams for Linux";
+  process.env.PULSE_PROP_application_icon_name ??= "teams-for-linux";
+  process.env.PULSE_PROP_media_role ??= "phone";
+}
+
 // This must be executed before loading the config file.
 CommandLineManager.addSwitchesBeforeConfigLoad();
 

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -9,19 +9,14 @@ class CommandLineManager {
     // for applications to override these properties and must be set
     // before Chromium opens any audio streams.
     if (process.platform === "linux") {
-      // PulseAudio property names use dots (e.g. "application.name").
-      // The PULSE_PROP_ prefix is stripped and the remainder is used
-      // verbatim as the property key, so dots must be preserved.
-      // Bracket notation is required because JS dot-access can't
-      // handle keys containing literal dots.
-      if (!process.env["PULSE_PROP_application.name"]) {
-        process.env["PULSE_PROP_application.name"] = "Teams for Linux";
+      if (!process.env.PULSE_PROP_application_name) {
+        process.env.PULSE_PROP_application_name = "Teams for Linux";
       }
-      if (!process.env["PULSE_PROP_application.icon_name"]) {
-        process.env["PULSE_PROP_application.icon_name"] = "teams-for-linux";
+      if (!process.env.PULSE_PROP_application_icon_name) {
+        process.env.PULSE_PROP_application_icon_name = "teams-for-linux";
       }
-      if (!process.env["PULSE_PROP_media.role"]) {
-        process.env["PULSE_PROP_media.role"] = "phone";
+      if (!process.env.PULSE_PROP_media_role) {
+        process.env.PULSE_PROP_media_role = "phone";
       }
     }
 

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -3,23 +3,6 @@ const { app } = require("electron");
 class CommandLineManager {
   // Must be called before app.getPath('userData')
   static addSwitchesBeforeConfigLoad() {
-    // Override PulseAudio/PipeWire audio stream name from "Chromium" to
-    // "Teams for Linux".  Chromium hardcodes its product name for
-    // PulseAudio; the PULSE_PROP_* env-vars are the standard mechanism
-    // for applications to override these properties and must be set
-    // before Chromium opens any audio streams.
-    if (process.platform === "linux") {
-      if (!process.env.PULSE_PROP_application_name) {
-        process.env.PULSE_PROP_application_name = "Teams for Linux";
-      }
-      if (!process.env.PULSE_PROP_application_icon_name) {
-        process.env.PULSE_PROP_application_icon_name = "teams-for-linux";
-      }
-      if (!process.env.PULSE_PROP_media_role) {
-        process.env.PULSE_PROP_media_role = "phone";
-      }
-    }
-
     app.commandLine.appendSwitch("try-supported-channel-layouts");
 
     // Allow audio playback without requiring a prior user gesture.

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -3,6 +3,23 @@ const { app } = require("electron");
 class CommandLineManager {
   // Must be called before app.getPath('userData')
   static addSwitchesBeforeConfigLoad() {
+    // Override PulseAudio/PipeWire audio stream name from "Chromium" to
+    // "Teams for Linux".  Chromium hardcodes its product name for
+    // PulseAudio; the PULSE_PROP_* env-vars are the standard mechanism
+    // for applications to override these properties and must be set
+    // before Chromium opens any audio streams.
+    if (process.platform === "linux") {
+      if (!process.env.PULSE_PROP_application_name) {
+        process.env.PULSE_PROP_application_name = "Teams for Linux";
+      }
+      if (!process.env.PULSE_PROP_application_icon_name) {
+        process.env.PULSE_PROP_application_icon_name = "teams-for-linux";
+      }
+      if (!process.env.PULSE_PROP_media_role) {
+        process.env.PULSE_PROP_media_role = "phone";
+      }
+    }
+
     app.commandLine.appendSwitch("try-supported-channel-layouts");
 
     // Allow audio playback without requiring a prior user gesture.

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -9,14 +9,19 @@ class CommandLineManager {
     // for applications to override these properties and must be set
     // before Chromium opens any audio streams.
     if (process.platform === "linux") {
-      if (!process.env.PULSE_PROP_application_name) {
-        process.env.PULSE_PROP_application_name = "Teams for Linux";
+      // PulseAudio property names use dots (e.g. "application.name").
+      // The PULSE_PROP_ prefix is stripped and the remainder is used
+      // verbatim as the property key, so dots must be preserved.
+      // Bracket notation is required because JS dot-access can't
+      // handle keys containing literal dots.
+      if (!process.env["PULSE_PROP_application.name"]) {
+        process.env["PULSE_PROP_application.name"] = "Teams for Linux";
       }
-      if (!process.env.PULSE_PROP_application_icon_name) {
-        process.env.PULSE_PROP_application_icon_name = "teams-for-linux";
+      if (!process.env["PULSE_PROP_application.icon_name"]) {
+        process.env["PULSE_PROP_application.icon_name"] = "teams-for-linux";
       }
-      if (!process.env.PULSE_PROP_media_role) {
-        process.env.PULSE_PROP_media_role = "phone";
+      if (!process.env["PULSE_PROP_media.role"]) {
+        process.env["PULSE_PROP_media.role"] = "phone";
       }
     }
 

--- a/build/pipewire-pulse.conf.d/50-teams-for-linux.conf
+++ b/build/pipewire-pulse.conf.d/50-teams-for-linux.conf
@@ -1,0 +1,17 @@
+# Override Chromium's hardcoded "Chromium" audio stream name so that
+# Teams for Linux appears with its own name and icon in volume mixers.
+# Installed to /etc/pipewire/pipewire-pulse.conf.d/ by deb/rpm packages.
+#
+# See https://github.com/IsmaelMartinez/teams-for-linux/issues/2382
+
+pulse.rules = [
+  {
+    matches = [{ application.process.binary = "teams-for-linux" }]
+    actions = {
+      update-props = {
+        application.name = "Teams for Linux"
+        application.icon_name = "teams-for-linux"
+      }
+    }
+  }
+]

--- a/build/pipewire-pulse.conf.d/50-teams-for-linux.conf
+++ b/build/pipewire-pulse.conf.d/50-teams-for-linux.conf
@@ -1,6 +1,10 @@
 # Override Chromium's hardcoded "Chromium" audio stream name so that
 # Teams for Linux appears with its own name and icon in volume mixers.
-# Installed to /etc/pipewire/pipewire-pulse.conf.d/ by deb/rpm packages.
+#
+# This file ships with Teams for Linux packages but must be manually
+# copied to a PipeWire configuration directory to take effect:
+#   System-wide:  /etc/pipewire/pipewire-pulse.conf.d/
+#   Per-user:     ~/.config/pipewire/pipewire-pulse.conf.d/
 #
 # See https://github.com/IsmaelMartinez/teams-for-linux/issues/2382
 
@@ -11,6 +15,7 @@ pulse.rules = [
       update-props = {
         application.name = "Teams for Linux"
         application.icon_name = "teams-for-linux"
+        media.role = "phone"
       }
     }
   }

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -181,9 +181,11 @@ For configuration options, see [Configuration](configuration.md). For developmen
 
 **Description:** When using Teams for Linux, audio streams appear labeled as "Chromium" (or "chromium") in system volume mixers like `pavucontrol`, instead of "Teams for Linux".
 
-**Cause:** Electron/Chromium hardcodes its product name for PulseAudio audio streams. A PipeWire drop-in rule can override this at the system level.
+**Cause:** Electron/Chromium hardcodes its product name for PulseAudio audio streams.
 
-**Solution (PipeWire):**
+**Solution:** Teams for Linux automatically sets `PULSE_PROP_application_name`, `PULSE_PROP_application_icon_name`, and `PULSE_PROP_media_role` environment variables at startup, which should rename the streams on most PulseAudio and PipeWire setups. If the streams still appear as "Chromium" (for example, when using a PipeWire configuration that overrides client properties), you can apply a PipeWire drop-in rule as a supplementary fix.
+
+**PipeWire drop-in (optional):**
 
 Teams for Linux ships a PipeWire drop-in configuration file that renames the audio streams. Copy it to your PipeWire configuration directory:
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -177,6 +177,48 @@ For configuration options, see [Configuration](configuration.md). For developmen
 
 ---
 
+#### Issue: Audio streams show as "Chromium" in volume mixer
+
+**Description:** When using Teams for Linux, audio streams appear labeled as "Chromium" (or "chromium") in system volume mixers like `pavucontrol`, instead of "Teams for Linux".
+
+**Cause:** Electron/Chromium hardcodes its product name for PulseAudio audio streams. This cannot be changed from within the application.
+
+**Solution (PipeWire):**
+
+Teams for Linux ships a PipeWire drop-in configuration file that renames the audio streams. Copy it to your PipeWire configuration directory:
+
+```bash
+# System-wide (requires root)
+sudo cp /opt/teams-for-linux/pipewire-pulse.conf.d/50-teams-for-linux.conf \
+     /etc/pipewire/pipewire-pulse.conf.d/
+
+# Or per-user (no root required)
+mkdir -p ~/.config/pipewire/pipewire-pulse.conf.d
+cp /opt/teams-for-linux/pipewire-pulse.conf.d/50-teams-for-linux.conf \
+   ~/.config/pipewire/pipewire-pulse.conf.d/
+```
+
+After copying, restart PipeWire (`systemctl --user restart pipewire-pulse`) or log out and back in for the change to take effect.
+
+If you installed via AppImage or tar.gz, the config file is located inside the extracted application directory under `pipewire-pulse.conf.d/`. You can also create the file manually:
+
+```ini
+# ~/.config/pipewire/pipewire-pulse.conf.d/50-teams-for-linux.conf
+pulse.rules = [
+  {
+    matches = [{ application.process.binary = "teams-for-linux" }]
+    actions = {
+      update-props = {
+        application.name = "Teams for Linux"
+        application.icon_name = "teams-for-linux"
+      }
+    }
+  }
+]
+```
+
+---
+
 ### Login and Authentication
 
 #### Issue: Unable to log in, stuck on a blank screen after entering credentials

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -181,7 +181,7 @@ For configuration options, see [Configuration](configuration.md). For developmen
 
 **Description:** When using Teams for Linux, audio streams appear labeled as "Chromium" (or "chromium") in system volume mixers like `pavucontrol`, instead of "Teams for Linux".
 
-**Cause:** Electron/Chromium hardcodes its product name for PulseAudio audio streams. This cannot be changed from within the application.
+**Cause:** Electron/Chromium hardcodes its product name for PulseAudio audio streams. A PipeWire drop-in rule can override this at the system level.
 
 **Solution (PipeWire):**
 
@@ -211,6 +211,7 @@ pulse.rules = [
       update-props = {
         application.name = "Teams for Linux"
         application.icon_name = "teams-for-linux"
+        media.role = "phone"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
       }
     ],
     "linux": {
+      "extraFiles": [
+        {
+          "from": "build/pipewire-pulse.conf.d",
+          "to": "pipewire-pulse.conf.d"
+        }
+      ],
       "category": "Chat;Network;Office",
       "packageCategory": "net",
       "executableName": "teams-for-linux",


### PR DESCRIPTION
Set PULSE_PROP_application_name, PULSE_PROP_application_icon_name, and
PULSE_PROP_media_role environment variables before Chromium initializes
audio streams. This causes PulseAudio/PipeWire to display "Teams for
Linux" instead of "Chromium" in system volume mixers.

The env-vars are only set on Linux and respect any user-provided
overrides (e.g., via shell environment).

closes #2382

https://claude.ai/code/session_01XTTs3CUagZa2UbV79MPBZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio stream now appears as "Teams for Linux" (with correct icon/role) in system volume mixers instead of "Chromium".

* **Documentation**
  * Added troubleshooting guidance explaining audio-labeling behavior, PipeWire drop-in instructions, and a manual configuration snippet.

* **Chores**
  * Included a PipeWire/Pulse configuration file in packaging so the rename is distributed; added a changelog entry.

* **Other**
  * App now sets Pulse-related environment properties on Linux at startup to apply the rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->