### PR TITLE
chore(deps): update electron, globals, and resolve follow-redirects CVE

### DIFF
--- a/.changelog/pr-2420.txt
+++ b/.changelog/pr-2420.txt
@@ -1,0 +1,1 @@
+Update dependencies, including Electron, and resolve follow-redirects CVE. - by @IsmaelMartinez (#2420)

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -10212,9 +10212,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -50,6 +50,7 @@
     "minimatch": ">=10.2.1",
     "schema-utils": "^4.0.0",
     "lodash-es": "^4.18.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "follow-redirects": "^1.16.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.59.1",
-        "electron": "41.1.1",
+        "electron": "41.2.0",
         "electron-builder": "^26.8.1",
         "eslint": "^10.2.0",
-        "globals": "^17.4.0",
+        "globals": "^17.5.0",
         "http-server": "^14.1.1",
         "xml2js": "^0.6.2"
       }
@@ -2749,9 +2749,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
-      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.0.tgz",
+      "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3617,9 +3617,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -3908,9 +3908,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,13 +65,16 @@
   "devDependencies": {
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "electron": "41.1.1",
+    "electron": "41.2.0",
     "@playwright/test": "1.59.1",
     "electron-builder": "^26.8.1",
     "eslint": "^10.2.0",
-    "globals": "^17.4.0",
+    "globals": "^17.5.0",
     "http-server": "^14.1.1",
     "xml2js": "^0.6.2"
+  },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
   },
   "build": {
     "appId": "teams-for-linux",


### PR DESCRIPTION
- Bump electron to 41.2.0 and globals to 17.5.0
- Add follow-redirects override (^1.16.0) in both root and docs-site to
  resolve GHSA-r4q5-vmmm-2653 (moderate severity)

https://claude.ai/code/session_01LU3BHUoTkW7KfHqGHieXf3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies, including electron to the latest version
  * Applied security updates to address known vulnerabilities in dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->