### PR TITLE
fix(tests): unbreak cross-distro smoke test on main

### DIFF
--- a/.changelog/pr-2422.txt
+++ b/.changelog/pr-2422.txt
@@ -1,0 +1,1 @@
+Fix: Unbreak cross-distro smoke test by correcting AppImage download and checks. - by @IsmaelMartinez (#2422)

--- a/.github/workflows/cross-distro-smoke.yml
+++ b/.github/workflows/cross-distro-smoke.yml
@@ -27,8 +27,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Use .browser_download_url (direct CDN link) rather than .url (API
+          # URL). The API URL returns JSON metadata unless the request carries
+          # an Accept: application/octet-stream header, and the curl inside the
+          # container has no such header — so we would silently download JSON,
+          # chmod +x it, and "run" it.
           URL=$(gh release view --repo IsmaelMartinez/teams-for-linux --json assets \
-            --jq '.assets[] | select(.name | endswith(".AppImage")) | .url' | head -1)
+            --jq '.assets[] | select(.name | endswith(".AppImage") and (.name | contains("arm") | not)) | .browser_download_url' | head -1)
           if [ -z "$URL" ]; then
             echo "::error::Could not resolve AppImage URL from latest release"
             exit 1

--- a/.github/workflows/cross-distro-smoke.yml
+++ b/.github/workflows/cross-distro-smoke.yml
@@ -27,13 +27,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use .browser_download_url (direct CDN link) rather than .url (API
-          # URL). The API URL returns JSON metadata unless the request carries
-          # an Accept: application/octet-stream header, and the curl inside the
-          # container has no such header — so we would silently download JSON,
-          # chmod +x it, and "run" it.
+          # Use .browser_download_url rather than .url — the API URL returns
+          # JSON metadata unless the request carries
+          # Accept: application/octet-stream, which the curl inside the
+          # container does not set.
           URL=$(gh release view --repo IsmaelMartinez/teams-for-linux --json assets \
-            --jq '.assets[] | select(.name | endswith(".AppImage") and (.name | contains("arm") | not)) | .browser_download_url' | head -1)
+            --jq '.assets[] | select(.name | test("\\.AppImage$") and (test("-(arm64|armv7l)\\.AppImage$") | not)) | .browser_download_url' | head -1)
           if [ -z "$URL" ]; then
             echo "::error::Could not resolve AppImage URL from latest release"
             exit 1

--- a/tests/cross-distro/run.sh
+++ b/tests/cross-distro/run.sh
@@ -423,8 +423,10 @@ if [[ "$APP_LATEST" == "true" ]]; then
     fi
     echo "[*] Fetching latest release URL from GitHub..."
     GITHUB_REPO="IsmaelMartinez/teams-for-linux"
+    # Skip arm64/armv7l assets — containers run --platform linux/amd64.
     APP_URL=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
         | grep -o '"browser_download_url": *"[^"]*\.AppImage"' \
+        | grep -Ev '\-(arm64|armv7l)\.AppImage"' \
         | head -1 \
         | cut -d'"' -f4)
     if [[ -z "$APP_URL" ]]; then

--- a/tests/cross-distro/scripts/entrypoint.sh
+++ b/tests/cross-distro/scripts/entrypoint.sh
@@ -29,13 +29,30 @@ APP_LOCAL_DIR="/home/tester/app-local"
 mkdir -p "$APP_LOCAL_DIR"
 
 if [[ -n "${APP_URL:-}" ]] && [[ ! -f /app/teams-for-linux.AppImage ]] && [[ ! -f "${APP_LOCAL_DIR}/teams-for-linux.AppImage" ]]; then
+    DOWNLOADED="${APP_LOCAL_DIR}/teams-for-linux.AppImage"
     echo "[*] Downloading app from: ${APP_URL}"
-    if curl -fSL --retry 3 --retry-delay 2 -o "${APP_LOCAL_DIR}/teams-for-linux.AppImage" "${APP_URL}"; then
-        chmod +x "${APP_LOCAL_DIR}/teams-for-linux.AppImage"
-        echo "[*] Download complete: ${APP_LOCAL_DIR}/teams-for-linux.AppImage"
+    if curl -fSL --retry 3 --retry-delay 2 -o "${DOWNLOADED}" "${APP_URL}"; then
+        # Verify the download is an ELF binary (AppImages are ELF + appended
+        # squashfs). If it's JSON/HTML (e.g. API metadata served instead of
+        # the asset) we must fail now — chmod +x succeeds on anything, and
+        # "executing" a JSON blob later would time out the smoke check with
+        # no obvious cause.
+        DETECTED=$(file -b "${DOWNLOADED}" 2>/dev/null || echo "unknown")
+        if [[ "${DETECTED}" != ELF* ]]; then
+            echo "[!] Downloaded file is not an ELF binary."
+            echo "    file:   ${DETECTED}"
+            echo "    size:   $(stat -c%s "${DOWNLOADED}" 2>/dev/null || wc -c <"${DOWNLOADED}") bytes"
+            echo "    first 200 bytes:"
+            head -c 200 "${DOWNLOADED}" || true
+            echo
+            rm -f "${DOWNLOADED}"
+            exit 1
+        fi
+        chmod +x "${DOWNLOADED}"
+        echo "[*] Download complete: ${DOWNLOADED} ($(stat -c%s "${DOWNLOADED}" 2>/dev/null || wc -c <"${DOWNLOADED}") bytes)"
     else
         echo "[!] Download failed. You can still launch the app manually later."
-        rm -f "${APP_LOCAL_DIR}/teams-for-linux.AppImage"
+        rm -f "${DOWNLOADED}"
     fi
 fi
 

--- a/tests/cross-distro/scripts/smoke-check.sh
+++ b/tests/cross-distro/scripts/smoke-check.sh
@@ -3,39 +3,54 @@
 #
 # Usage: smoke-check.sh <container-name> [timeout-seconds]
 #
-# PASS conditions (app launched and Electron main process is alive):
-#   - The container stays running for the duration of the check.
-#   - /tmp/app.log appears (start-{x11,wayland,xwayland}.sh got far enough
-#     to redirect the AppImage's stdout/stderr into it).
-#   - /tmp/app.log grows past MIN_LOG_BYTES, confirming the Electron main
-#     process actually produced output (not just an empty file from an
-#     immediate crash).
-#   - /tmp/app.log contains no hard-failure signatures (exec format error,
-#     cannot execute binary file, Trace/breakpoint trapped, GLIBC error).
-#
-# FAIL conditions:
-#   - Container stops before the checks pass.
-#   - Log file never appears.
-#   - Log never grows above MIN_LOG_BYTES.
-#   - A hard-failure signature is found.
-#
-# This intentionally does NOT assert any navigation URL marker — the CI
-# container is unauthenticated and the main process does not log URLs to
-# stdout, so URL-based assertions were timing out even when the app
-# launched correctly.
+# Passes when the app produced real output (log file > MIN_LOG_BYTES) with
+# no hard-failure signature, meaning the Electron main process actually
+# started. Does NOT assert a navigation URL — the CI container is
+# unauthenticated and the main process does not log URLs to stdout, so
+# URL-based assertions used to time out even on successful launches.
 set -e
 
 CONTAINER="${1:?Usage: smoke-check.sh <container-name> [timeout-seconds]}"
 TIMEOUT="${2:-120}"
 POLL_INTERVAL=5
 LOG_FILE="/tmp/app.log"
+
+# Electron on startup typically emits ~100B of DevTools banner + several
+# hundred bytes of GPU/GL warnings and app-level [STARTUP]/[IPC Security]
+# lines. 500 bytes comfortably clears a crash-with-single-line-error but
+# stays below a minimal successful boot.
 MIN_LOG_BYTES=500
-FAIL_PATTERNS='exec format error|cannot execute binary file|Trace/breakpoint trapped|GLIBC_[0-9]'
+
+# Regexes for log signatures that mean we should stop waiting and fail.
+#   - exec format error / cannot execute binary file: kernel refused the
+#     file (wrong arch, not an ELF, etc.).
+#   - Trace/breakpoint trapped: SIGTRAP from a Chromium crash.
+#   - not found.*GLIBC_: missing libc version, only ever emitted on
+#     real dynamic-linker failure (benign contexts say "GLIBC_2.x" without
+#     "not found").
+FAIL_PATTERNS='exec format error|cannot execute binary file|Trace/breakpoint trapped|not found.*GLIBC_'
 
 echo "[smoke] Checking container: ${CONTAINER} (timeout: ${TIMEOUT}s)"
 
 container_running() {
     docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true
+}
+
+# Single-round-trip check: returns "<status> <size>" where status is
+# "fail" if FAIL_PATTERNS matched, "ok" otherwise, and size is the
+# current byte size of LOG_FILE (0 if unreadable).
+log_status() {
+    docker exec \
+        -e PATTERNS="$FAIL_PATTERNS" \
+        -e LOG="$LOG_FILE" \
+        "$CONTAINER" sh -c '
+            SIZE=$(stat -c%s "$LOG" 2>/dev/null || echo 0)
+            if grep -Eq "$PATTERNS" "$LOG" 2>/dev/null; then
+                echo "fail $SIZE"
+            else
+                echo "ok $SIZE"
+            fi
+        ' 2>/dev/null
 }
 
 dump_diagnostics() {
@@ -56,7 +71,7 @@ dump_diagnostics() {
     fi
 }
 
-# Phase 1: wait for the log file to appear.
+# Phase 1 — log file appears.
 ELAPSED=0
 while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
     if ! container_running; then
@@ -80,9 +95,7 @@ if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
     exit 1
 fi
 
-# Phase 2: poll until the log is non-trivial and free of hard-failure
-# signatures. The app passing this means Electron started, rendered, and
-# at least logged some GPU/GL/DevTools lines on the way up.
+# Phase 2 — log grows past threshold with no crash signature.
 while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
     if ! container_running; then
         echo "[smoke] FAIL: Container ${CONTAINER} stopped unexpectedly"
@@ -90,15 +103,17 @@ while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
         exit 1
     fi
 
-    # Hard-failure signatures — fail fast if any appear; no point waiting.
-    if docker exec "$CONTAINER" grep -Eq "$FAIL_PATTERNS" "$LOG_FILE" 2>/dev/null; then
+    STATUS_AND_SIZE=$(log_status || echo "ok 0")
+    STATUS="${STATUS_AND_SIZE%% *}"
+    LOG_SIZE="${STATUS_AND_SIZE##* }"
+
+    if [[ "$STATUS" == "fail" ]]; then
         echo "[smoke] FAIL: Hard-failure signature in ${LOG_FILE}"
         dump_diagnostics
         exit 1
     fi
 
-    LOG_SIZE=$(docker exec "$CONTAINER" stat -c%s "$LOG_FILE" 2>/dev/null || echo 0)
-    if [[ "$LOG_SIZE" -ge "$MIN_LOG_BYTES" ]]; then
+    if [[ "$LOG_SIZE" =~ ^[0-9]+$ ]] && [[ "$LOG_SIZE" -ge "$MIN_LOG_BYTES" ]]; then
         echo "[smoke] PASS: ${LOG_FILE} reached ${LOG_SIZE} bytes after ${ELAPSED}s (app launched)"
         exit 0
     fi

--- a/tests/cross-distro/scripts/smoke-check.sh
+++ b/tests/cross-distro/scripts/smoke-check.sh
@@ -1,32 +1,70 @@
 #!/bin/bash
 # Smoke check for cross-distro testing containers.
-# Polls /tmp/app.log inside a running container for the Microsoft login URL.
 #
 # Usage: smoke-check.sh <container-name> [timeout-seconds]
 #
-# Exit 0 if the app reaches login.microsoftonline.com within the timeout.
-# Exit 1 if the container stops, the log file never appears, or time runs out.
+# PASS conditions (app launched and Electron main process is alive):
+#   - The container stays running for the duration of the check.
+#   - /tmp/app.log appears (start-{x11,wayland,xwayland}.sh got far enough
+#     to redirect the AppImage's stdout/stderr into it).
+#   - /tmp/app.log grows past MIN_LOG_BYTES, confirming the Electron main
+#     process actually produced output (not just an empty file from an
+#     immediate crash).
+#   - /tmp/app.log contains no hard-failure signatures (exec format error,
+#     cannot execute binary file, Trace/breakpoint trapped, GLIBC error).
+#
+# FAIL conditions:
+#   - Container stops before the checks pass.
+#   - Log file never appears.
+#   - Log never grows above MIN_LOG_BYTES.
+#   - A hard-failure signature is found.
+#
+# This intentionally does NOT assert any navigation URL marker — the CI
+# container is unauthenticated and the main process does not log URLs to
+# stdout, so URL-based assertions were timing out even when the app
+# launched correctly.
 set -e
 
 CONTAINER="${1:?Usage: smoke-check.sh <container-name> [timeout-seconds]}"
 TIMEOUT="${2:-120}"
-MARKER="login.microsoftonline.com"
 POLL_INTERVAL=5
 LOG_FILE="/tmp/app.log"
+MIN_LOG_BYTES=500
+FAIL_PATTERNS='exec format error|cannot execute binary file|Trace/breakpoint trapped|GLIBC_[0-9]'
 
 echo "[smoke] Checking container: ${CONTAINER} (timeout: ${TIMEOUT}s)"
 
-# Phase 1: Wait for the log file to exist (app download + startup)
+container_running() {
+    docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true
+}
+
+dump_diagnostics() {
+    echo "[smoke] --- diagnostics ---"
+    echo "[smoke] container state:"
+    docker inspect --format='{{.State.Status}} (exit={{.State.ExitCode}})' "$CONTAINER" 2>/dev/null || true
+    echo "[smoke] docker logs (last 30):"
+    docker logs "$CONTAINER" 2>&1 | tail -30 || true
+    echo "[smoke] /tmp contents:"
+    docker exec "$CONTAINER" ls -la /tmp 2>/dev/null || true
+    if docker exec "$CONTAINER" test -f "$LOG_FILE" 2>/dev/null; then
+        LOG_SIZE=$(docker exec "$CONTAINER" stat -c%s "$LOG_FILE" 2>/dev/null || echo "?")
+        echo "[smoke] app.log size: ${LOG_SIZE} bytes"
+        echo "[smoke] app.log (last 200):"
+        docker exec "$CONTAINER" tail -200 "$LOG_FILE" 2>/dev/null || echo "(could not read log)"
+    else
+        echo "[smoke] ${LOG_FILE} does not exist inside the container"
+    fi
+}
+
+# Phase 1: wait for the log file to appear.
 ELAPSED=0
 while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
-    # Check container is still running
-    if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true; then
+    if ! container_running; then
         echo "[smoke] FAIL: Container ${CONTAINER} is not running"
-        docker logs "$CONTAINER" 2>&1 | tail -30 || true
+        dump_diagnostics
         exit 1
     fi
 
-    # Check if log file exists
     if docker exec "$CONTAINER" test -f "$LOG_FILE" 2>/dev/null; then
         echo "[smoke] Log file found after ${ELAPSED}s"
         break
@@ -38,19 +76,30 @@ done
 
 if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
     echo "[smoke] FAIL: Log file ${LOG_FILE} not found after ${TIMEOUT}s"
+    dump_diagnostics
     exit 1
 fi
 
-# Phase 2: Poll the log file for the login URL marker
+# Phase 2: poll until the log is non-trivial and free of hard-failure
+# signatures. The app passing this means Electron started, rendered, and
+# at least logged some GPU/GL/DevTools lines on the way up.
 while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
-    if ! docker inspect --format='{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true; then
+    if ! container_running; then
         echo "[smoke] FAIL: Container ${CONTAINER} stopped unexpectedly"
-        docker exec "$CONTAINER" cat "$LOG_FILE" 2>/dev/null | tail -30 || true
+        dump_diagnostics
         exit 1
     fi
 
-    if docker exec "$CONTAINER" grep -q "$MARKER" "$LOG_FILE" 2>/dev/null; then
-        echo "[smoke] PASS: Found ${MARKER} in ${LOG_FILE} after ${ELAPSED}s"
+    # Hard-failure signatures — fail fast if any appear; no point waiting.
+    if docker exec "$CONTAINER" grep -Eq "$FAIL_PATTERNS" "$LOG_FILE" 2>/dev/null; then
+        echo "[smoke] FAIL: Hard-failure signature in ${LOG_FILE}"
+        dump_diagnostics
+        exit 1
+    fi
+
+    LOG_SIZE=$(docker exec "$CONTAINER" stat -c%s "$LOG_FILE" 2>/dev/null || echo 0)
+    if [[ "$LOG_SIZE" -ge "$MIN_LOG_BYTES" ]]; then
+        echo "[smoke] PASS: ${LOG_FILE} reached ${LOG_SIZE} bytes after ${ELAPSED}s (app launched)"
         exit 0
     fi
 
@@ -58,7 +107,6 @@ while [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
     ELAPSED=$((ELAPSED + POLL_INTERVAL))
 done
 
-echo "[smoke] FAIL: ${MARKER} not found in ${LOG_FILE} after ${TIMEOUT}s"
-echo "[smoke] Last 30 lines of app log:"
-docker exec "$CONTAINER" tail -30 "$LOG_FILE" 2>/dev/null || echo "(could not read log)"
+echo "[smoke] FAIL: ${LOG_FILE} stayed below ${MIN_LOG_BYTES} bytes for ${TIMEOUT}s"
+dump_diagnostics
 exit 1


### PR DESCRIPTION
The workflow was failing all 9 matrix cells on every push to main for
two independent reasons, both of which made the test effectively assert
things that can't happen in an unauthenticated cold-start run.

1) AppImage download was never the AppImage.

   The "Resolve latest AppImage URL" step used `.assets[].url`, which is
   the GitHub API URL. curl inside the container has no
   `Accept: application/octet-stream` header, so GitHub returned JSON
   metadata instead of the binary. We saved JSON as
   `teams-for-linux.AppImage`, chmod +x'd it, and "ran" it — guaranteeing
   the smoke check would time out.

   Switched to `.browser_download_url` (matching what the local
   `tests/cross-distro/run.sh --latest` already does), and excluded arm
   AppImages so x86_64 runners pick the x86_64 asset rather than the
   alphabetically-first arm64 one.

2) Smoke check asserted an authenticated-flow artifact.

   `smoke-check.sh` polled `/tmp/app.log` (AppImage stdout+stderr) for
   the literal string `login.microsoftonline.com`. No main-process
   `console.*` call logs that URL — it only appears via auth-flow side
   effects that don't happen in a fresh container. Every cell was
   timing out even when the app launched correctly.

   Replaced with a "did it actually launch" assertion: /tmp/app.log
   appears, grows past 500 bytes (Electron produced real output), and
   contains no hard-failure signatures (`exec format error`,
   `cannot execute binary file`, `Trace/breakpoint trapped`,
   `GLIBC_*`). On failure, dump container state, file type of the
   downloaded binary, and the last 200 log lines so future failures
   are diagnosable instead of silent timeouts.

`entrypoint.sh` now also verifies the download is an ELF binary
immediately after curl, so if the CI URL regresses again we fail in
seconds with a clear message rather than after a 120s timeout.

https://claude.ai/code/session_01KdqAfer6KXX2wzeKkcfvUd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored cross-distro smoke tests by fixing AppImage selection to skip ARM variants and use direct download URLs.
  * Added post-download validation to ensure the artifact is a valid ELF and fail fast on corruption.
  * Improved readiness checks and expanded failure diagnostics (container state, recent logs, file listings, and size/tail info).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->