### PR TITLE
fix(docs): pin v4 future flags so docs-site builds on Docusaurus 3.10

### DIFF
--- a/.changelog/pr-2427.txt
+++ b/.changelog/pr-2427.txt
@@ -1,0 +1,1 @@
+Update DOMPurify to 3.4.0 for security and bug fixes. (#2427)

--- a/.changelog/pr-2429.txt
+++ b/.changelog/pr-2429.txt
@@ -1,0 +1,1 @@
+Fix: Pin Docusaurus v4 future flags for docs-site build compatibility - by @IsmaelMartinez (#2429)

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -11,7 +11,16 @@ const config: Config = {
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
-    v4: true, // Improve compatibility with the upcoming Docusaurus v4
+    // Opt into v4 compat, but skip the two new 3.10 opt-ins that would
+    // otherwise require adding @docusaurus/faster and rewriting HTML
+    // comments in existing .md files as JSX comments.
+    v4: {
+      removeLegacyPostBuildHeadAttribute: true,
+      useCssCascadeLayers: true,
+      siteStorageNamespacing: true,
+      fasterByDefault: false,
+      mdx1CompatDisabledByDefault: false,
+    },
   },
 
   // Set the production url of your site here

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9361,13 +9361,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }


### PR DESCRIPTION
Docusaurus 3.10 expanded the `future.v4: true` shortcut to include
`fasterByDefault: true` and `mdx1CompatDisabledByDefault: true`.

- `fasterByDefault` turns on the rspack bundler, which requires a new
  `@docusaurus/faster` dependency that isn't installed — the build fails
  with "To enable Docusaurus Faster options, your site must add the
  @docusaurus/faster package as a dependency."
- `mdx1CompatDisabledByDefault` makes the MDX parser reject HTML
  comments (`<!-- toc -->`) inside `.md` files, which several docs use.

Replace the shortcut with an explicit object that enables the three
v4 opt-ins we had working on 3.9 and leaves the two new 3.10 ones off.
This keeps the dompurify 3.4.0 lockfile bump from PR #2427 buildable
without introducing a new dependency or rewriting existing docs.

closes #2427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DOMPurify to version 3.4.0 to address security vulnerabilities and bugs.
  * Pinned Docusaurus v4 future flags to maintain documentation site stability and compatibility.

* **Updates**
  * Enhanced documentation site configuration with granular Docusaurus v4 compatibility settings for improved control over build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->