### PR TITLE
fix: don't apply camera resolution override to screen-share tracks

### DIFF
--- a/.changelog/pr-2437.txt
+++ b/.changelog/pr-2437.txt
@@ -1,0 +1,2 @@
+Fix: Prevent camera resolution override from blurring screen shares - by @IsmaelMartinez (#2437)
+closes: #2432 https://github.com/IsmaelMartinez/teams-for-linux/issues/2432 [Bug]: Camera resolution override applied to screen share stream, causing blurry/low-res screen sharing

--- a/app/browser/tools/cameraResolution.js
+++ b/app/browser/tools/cameraResolution.js
@@ -156,9 +156,12 @@ const applyCameraResolutionPatch = function (resolutionConfig) {
     "applyConstraints",
     function (original) {
       return function applyConstraints(constraints) {
-        // Only modify if this is a video track
-        if (this.kind === "video") {
-          // Wrap in a constraints-like object for the modifier function
+        // Only modify camera tracks. Screen-share tracks (from getDisplayMedia
+        // or getUserMedia with chromeMediaSource:desktop) expose displaySurface
+        // in their settings; the constraints payload at this point no longer
+        // carries chromeMediaSource, so the skip-check in modifyVideoConstraints
+        // can't tell them apart. Filter on the track itself instead.
+        if (this.kind === "video" && !this.getSettings?.().displaySurface) {
           const wrappedConstraints = { video: constraints };
           modifyVideoConstraints(wrappedConstraints);
           constraints = wrappedConstraints.video;


### PR DESCRIPTION
## Summary

The `media.camera.resolution` override was leaking into screen-share tracks via the `MediaStreamTrack.applyConstraints` patch, forcing users' screen share to the camera's target resolution (e.g. 640x360) and producing a blurry image for remote participants.

The tool already intends to skip screen-share streams — `app/browser/tools/cameraResolution.js:59-69` checks `chromeMediaSource` on the `getUserMedia` constraints payload. That works at capture time, but when Teams later calls `track.applyConstraints({ width, height, ... })` to adapt screen-share quality mid-call, the payload no longer carries `chromeMediaSource` markers, the skip-check silently fails, and the camera override is applied to the screen-share track.

This patch gates the `applyConstraints` wrapper on the track itself using `track.getSettings().displaySurface`, which is only defined for display-capture tracks (from `getDisplayMedia` or `getUserMedia` with `chromeMediaSource:desktop`). Camera tracks continue to receive overrides; screen-share tracks pass through untouched.

## Test plan

- [ ] Set `media.camera.resolution` to `{ enabled: true, mode: "override", width: 640, height: 360 }` in config
- [ ] Join a meeting, share screen, confirm remote participant sees sharp/native-resolution screen share
- [ ] Camera stream is still constrained to 640x360 (existing behaviour unchanged)
- [ ] Debug log shows `[CAMERA_RESOLUTION] Patched ... applyConstraints` at startup and no camera-resolution modifications occur on screen-share track constraint changes

closes #2432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed camera resolution override settings being incorrectly applied to screen share streams, resulting in blurry or low-resolution screen sharing. Camera and screen share now maintain independent resolution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->