### PR TITLE
ci: trial simili-bot for duplicate detection (similarity-only)

### DIFF
--- a/.changelog/pr-2438.txt
+++ b/.changelog/pr-2438.txt
@@ -1,0 +1,1 @@
+Add trial of simili-bot for duplicate issue detection - by @IsmaelMartinez (#2438)

--- a/.github/simili.yaml
+++ b/.github/simili.yaml
@@ -1,0 +1,34 @@
+# simili-bot configuration for teams-for-linux.
+# Trial mode: similarity-only — post related-issue suggestions without labelling
+# or closing. Runs alongside ismael-triage-bot. Trial window 2026-04-20 → 2026-05-20.
+# See docs in the triage-bot repo: docs/plans/2026-04-16-simili-bot-trial.md
+#
+# Secrets required on this repo (Settings → Secrets and variables → Actions):
+#   GEMINI_API_KEY   reuse the same key the triage bot uses
+#   QDRANT_URL       Qdrant Cloud instance URL (https://...)
+#   QDRANT_API_KEY   Qdrant Cloud API key
+
+workflow: similarity-only
+
+qdrant:
+  url: "${QDRANT_URL}"
+  api_key: "${QDRANT_API_KEY}"
+  collection: "teams-for-linux-issues"
+
+embedding:
+  provider: "gemini"
+  api_key: "${GEMINI_API_KEY}"
+  model: "gemini-embedding-001"
+  dimensions: 3072
+
+llm:
+  provider: "gemini"
+  api_key: "${GEMINI_API_KEY}"
+  model: "gemini-2.5-flash"
+
+defaults:
+  # Start at the tool's recommended threshold per the trial plan. Re-evaluate
+  # at the first weekly review if precision/noise metrics miss the targets.
+  similarity_threshold: 0.65
+  max_similar_to_show: 5
+  duplicate_candidates: 5

--- a/.github/workflows/simili.yml
+++ b/.github/workflows/simili.yml
@@ -1,0 +1,26 @@
+name: Simili Issue Triage (trial)
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: similigh/simili-bot@main
+        with:
+          config_path: .github/simili.yaml
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          QDRANT_URL: ${{ secrets.QDRANT_URL }}
+          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}

--- a/.github/workflows/simili.yml
+++ b/.github/workflows/simili.yml
@@ -15,9 +15,9 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: similigh/simili-bot@main
+      - uses: similigh/simili-bot@fd948411e6d3949268a04ff96aa804ffcdbae15a  # main 2026-04-20
         with:
           config_path: .github/simili.yaml
         env:


### PR DESCRIPTION
## Summary

Starts the 30-day simili-bot trial documented at \`IsmaelMartinez/github-issue-triage-bot\` \`docs/plans/2026-04-16-simili-bot-trial.md\`. simili-bot fills the duplicate-detection gap left by removing Phase 3 from the triage bot in the lean pivot. It runs as a GitHub Action with its own Qdrant index — no integration with the triage bot, no shared state.

### What this PR adds

- \`.github/workflows/simili.yml\` — triggers \`similigh/simili-bot@main\` on issue open/edit/reopen/label and new issue comments.
- \`.github/simili.yaml\` — config pinned to \`similarity-only\` workflow (no labelling, no auto-close), Gemini embeddings (\`gemini-embedding-001\`, 3072-dim), Gemini 2.5 Flash LLM, threshold 0.65 with top-5 similar issues shown.

### Before merging — manual steps

The workflow fails fast without these three repo secrets. Add them at **Settings → Secrets and variables → Actions**:

- \`GEMINI_API_KEY\` — reuse the same key the triage bot uses.
- \`QDRANT_URL\` — create a free cluster at https://cloud.qdrant.io and copy the endpoint URL.
- \`QDRANT_API_KEY\` — the matching API key from Qdrant Cloud.

### After merging

1. Seed the Qdrant collection with existing closed issues: \`gh extension install similigh/simili-bot && gh simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml\`.
2. Open a weekly-review tracking issue on the triage-bot repo titled \`Simili-bot trial — teams-for-linux (2026-04-20 → 2026-05-20)\`.
3. Weekly review for 4 weeks, then write \`docs/decisions/007-simili-bot-trial.md\` with adopt/extend/drop decision.

### Out of scope

No MCP integration with the triage bot. No code changes to either bot. No multi-repo rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a trial issue-triage automation enabling AI-powered similarity detection for related/duplicate issues.
  * Added workflow and configuration to run the trial on relevant issue events.
  * Configured the system to generate suggestions only (no automatic labeling, closing, or edits).
  * Added a changelog entry documenting the trial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->