### PR TITLE
fix: preserve Teams shell when joining meeting and add return path

### DIFF
--- a/.changelog/pr-2439.txt
+++ b/.changelog/pr-2439.txt
@@ -1,0 +1,2 @@
+Fix: Preserve Teams shell when joining meetings and add return path - by @IsmaelMartinez (#2439)
+closes: #2322 https://github.com/IsmaelMartinez/teams-for-linux/issues/2322 [Bug]: action "Join meeting" replaces whole window content

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -13,6 +13,10 @@ exports = module.exports = (Menus) => ({
       accelerator: "ctrl+J",
       click: () => Menus.joinMeeting(),
     },
+    {
+      label: "Return to Teams",
+      click: () => Menus.returnToTeams(),
+    },
     ...(Menus.configGroup.startupConfig.quickChat?.enabled
       ? [
           {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -300,12 +300,52 @@ class Menus {
 
   joinMeetingWithUrl(meetingUrl) {
     try {
-      this.window.webContents.loadURL(meetingUrl);
+      // Snapshot the current Teams URL so the user can jump back after the
+      // meeting ends (see #2322). When an org forces anonymous/guest join,
+      // Teams' post-meeting screen is a full-page takeover with no sidebar.
+      this.preJoinUrl = this.window.webContents.getURL();
+
+      // Navigate inside the loaded Teams SPA (same-origin) so the app shell
+      // is preserved when the org allows authenticated join. For enforced
+      // anonymous joins this still gets taken over, which is why we also
+      // expose the "Return to Teams" menu item.
+      const script = `(() => {
+        try {
+          const incoming = new URL(${JSON.stringify(meetingUrl)});
+          const target = window.location.origin + incoming.pathname + incoming.search + incoming.hash;
+          window.location.assign(target);
+        } catch (e) {
+          window.location.assign(${JSON.stringify(meetingUrl)});
+        }
+      })();`;
+      this.window.webContents.executeJavaScript(script, true);
       this.window.show();
       this.window.focus();
     } catch (error) {
       console.error('Error loading meeting URL:', error);
       dialog.showErrorBox('Error', 'Failed to join meeting. Please check the URL.');
+    }
+  }
+
+  returnToTeams() {
+    const fallbackUrl = this.configGroup.startupConfig.url;
+    const target = this.#isValidTeamsUrl(this.preJoinUrl)
+      ? this.preJoinUrl
+      : fallbackUrl;
+    this.window.webContents.loadURL(target, {
+      userAgent: this.configGroup.startupConfig.chromeUserAgent,
+    });
+    this.window.show();
+    this.window.focus();
+  }
+
+  #isValidTeamsUrl(url) {
+    if (!url || typeof url !== 'string') return false;
+    try {
+      const host = new URL(url).hostname;
+      return /(^|\.)teams\.(microsoft\.com|live\.com|cloud\.microsoft)$/.test(host);
+    } catch {
+      return false;
     }
   }
 

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -19,6 +19,8 @@ const autoUpdaterModule = require("../autoUpdater");
 
 let _Menus_onSpellCheckerLanguageChanged = new WeakMap();
 class Menus {
+  #preJoinUrl = null;
+
   constructor(window, configGroup, iconPath, connectionManager) {
     this.window = window;
     this.iconPath = iconPath;
@@ -298,45 +300,69 @@ class Menus {
     });
   }
 
-  joinMeetingWithUrl(meetingUrl) {
+  async joinMeetingWithUrl(meetingUrl) {
     try {
       // Snapshot the current Teams URL so the user can jump back after the
-      // meeting ends (see #2322). When an org forces anonymous/guest join,
-      // Teams' post-meeting screen is a full-page takeover with no sidebar.
-      this.preJoinUrl = this.window.webContents.getURL();
+      // meeting ends (see #2322). Skip the snapshot if we're already on a
+      // meeting URL (e.g. a prior takeover page) so repeat joins don't
+      // overwrite the last known good Teams location.
+      const currentUrl = this.window.webContents.getURL();
+      if (!this.#isMeetingUrl(currentUrl)) {
+        this.#preJoinUrl = currentUrl;
+      }
 
       // Navigate inside the loaded Teams SPA (same-origin) so the app shell
-      // is preserved when the org allows authenticated join. For enforced
-      // anonymous joins this still gets taken over, which is why we also
-      // expose the "Return to Teams" menu item.
+      // is preserved when the org allows authenticated join. Only rewrite
+      // to the current origin if we're actually on a Teams page; otherwise
+      // (login page, error page) fall through to the original URL.
+      const useSameOrigin = this.#isValidTeamsUrl(currentUrl);
       const script = `(() => {
         try {
           const incoming = new URL(${JSON.stringify(meetingUrl)});
-          const target = window.location.origin + incoming.pathname + incoming.search + incoming.hash;
+          const target = ${JSON.stringify(useSameOrigin)}
+            ? window.location.origin + incoming.pathname + incoming.search + incoming.hash
+            : incoming.href;
           window.location.assign(target);
         } catch (e) {
           window.location.assign(${JSON.stringify(meetingUrl)});
         }
       })();`;
-      this.window.webContents.executeJavaScript(script, true);
       this.window.show();
       this.window.focus();
-    } catch (error) {
-      console.error('Error loading meeting URL:', error);
+      await this.window.webContents.executeJavaScript(script, true);
+    } catch {
+      // Avoid logging the error object: URL query parameters may contain tokens.
+      console.error('[JOIN_MEETING] Failed to navigate to meeting URL');
       dialog.showErrorBox('Error', 'Failed to join meeting. Please check the URL.');
     }
   }
 
-  returnToTeams() {
+  async returnToTeams() {
     const fallbackUrl = this.configGroup.startupConfig.url;
-    const target = this.#isValidTeamsUrl(this.preJoinUrl)
-      ? this.preJoinUrl
+    const target = this.#isValidTeamsUrl(this.#preJoinUrl)
+      ? this.#preJoinUrl
       : fallbackUrl;
-    this.window.webContents.loadURL(target, {
-      userAgent: this.configGroup.startupConfig.chromeUserAgent,
-    });
-    this.window.show();
-    this.window.focus();
+    try {
+      this.window.show();
+      this.window.focus();
+      await this.window.webContents.loadURL(target, {
+        userAgent: this.configGroup.startupConfig.chromeUserAgent,
+      });
+    } catch {
+      console.error('[RETURN_TO_TEAMS] Navigation failed');
+      dialog.showErrorBox('Error', 'Failed to return to Teams.');
+    }
+  }
+
+  #isMeetingUrl(url) {
+    if (!url || typeof url !== 'string') return false;
+    const pattern = this.configGroup.startupConfig.meetupJoinRegEx;
+    if (!pattern) return false;
+    try {
+      return new RegExp(pattern).test(url);
+    } catch {
+      return false;
+    }
   }
 
   #isValidTeamsUrl(url) {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -302,6 +302,14 @@ class Menus {
 
   async joinMeetingWithUrl(meetingUrl) {
     try {
+      // Validate the incoming URL up front so a parse failure or a
+      // non-matching URL falls through to the outer catch rather than
+      // ending up assigned raw inside the Teams window.
+      const parsed = new URL(meetingUrl);
+      if (!this.#isMeetingUrl(meetingUrl)) {
+        throw new Error('Not a recognised meeting URL');
+      }
+
       // Snapshot the current Teams URL so the user can jump back after the
       // meeting ends (see #2322). Skip the snapshot if we're already on a
       // meeting URL (e.g. a prior takeover page) so repeat joins don't
@@ -313,20 +321,12 @@ class Menus {
 
       // Navigate inside the loaded Teams SPA (same-origin) so the app shell
       // is preserved when the org allows authenticated join. Only rewrite
-      // to the current origin if we're actually on a Teams page; otherwise
-      // (login page, error page) fall through to the original URL.
-      const useSameOrigin = this.#isValidTeamsUrl(currentUrl);
-      const script = `(() => {
-        try {
-          const incoming = new URL(${JSON.stringify(meetingUrl)});
-          const target = ${JSON.stringify(useSameOrigin)}
-            ? window.location.origin + incoming.pathname + incoming.search + incoming.hash
-            : incoming.href;
-          window.location.assign(target);
-        } catch (e) {
-          window.location.assign(${JSON.stringify(meetingUrl)});
-        }
-      })();`;
+      // to the current origin when the current page is actually on a Teams
+      // host; otherwise (login page, error page) navigate to the URL as-is.
+      const target = this.#isValidTeamsUrl(currentUrl)
+        ? new URL(currentUrl).origin + parsed.pathname + parsed.search + parsed.hash
+        : parsed.href;
+      const script = `window.location.assign(${JSON.stringify(target)});`;
       this.window.show();
       this.window.focus();
       await this.window.webContents.executeJavaScript(script, true);
@@ -368,8 +368,11 @@ class Menus {
   #isValidTeamsUrl(url) {
     if (!url || typeof url !== 'string') return false;
     try {
-      const host = new URL(url).hostname;
-      return /(^|\.)teams\.(microsoft\.com|live\.com|cloud\.microsoft)$/.test(host);
+      const { protocol, hostname } = new URL(url);
+      return (
+        protocol === 'https:' &&
+        /(^|\.)teams\.(microsoft\.com|live\.com|cloud\.microsoft)$/.test(hostname)
+      );
     } catch {
       return false;
     }

--- a/docs-site/docs/development/research/README.md
+++ b/docs-site/docs/development/research/README.md
@@ -30,6 +30,13 @@ These documents capture in-depth analysis and strategic insights that inform dev
   - Completes original request from #1938 (@vbartik's RGB LED home automation)
   - **Status:** Research complete, ready for implementation (depends on PR #2299 merged)
 
+### First Iteration Shipped — Awaiting Feedback
+
+- **[Join Meeting Window Takeover Research](join-meeting-window-takeover-research.md)** — "Join Meeting" replacing the whole window ([#2322](https://github.com/IsmaelMartinez/teams-for-linux/issues/2322))
+  - First iteration: same-origin deep-link navigation + `Return to Teams` menu item
+  - Caveat: authenticated-org path not verifiable locally; some takeovers are Microsoft-enforced
+  - Follow-ups: navigation-event auto-return, dedicated meeting window, keyboard accelerator
+
 ### Awaiting User Feedback
 
 - **[MQTT Extended Status Investigation](mqtt-extended-status-investigation.md)** - Extended MQTT status publishing

--- a/docs-site/docs/development/research/join-meeting-window-takeover-research.md
+++ b/docs-site/docs/development/research/join-meeting-window-takeover-research.md
@@ -1,0 +1,58 @@
+# Join Meeting Window Takeover (Issue #2322)
+
+:::info Iterative Implementation
+Issue [#2322](https://github.com/IsmaelMartinez/teams-for-linux/issues/2322) reports that the "Join Meeting" action from the tray/app menu replaces the whole window content, leaving the user stranded on the "meeting ended" screen with no visible way back to chat. The first iteration of the fix lands alongside this research. Further iterations are possible once we have user feedback from non-enforced-anonymous orgs.
+:::
+
+Date: 2026-04-20
+Issue: [#2322](https://github.com/IsmaelMartinez/teams-for-linux/issues/2322)
+Status: First iteration shipped; follow-up options documented below
+
+## Background
+
+The "Join Meeting" flow (introduced in PR #1856) lets users paste a meeting link and join without manually navigating Teams. The handler in `app/menus/index.js` called `this.window.webContents.loadURL(meetingUrl)` on the main BrowserWindow. That replaced the entire Teams SPA document with whatever Microsoft returns for the `/l/meetup-join/...` path, which is typically a standalone meeting launcher rather than a route inside the authenticated Teams shell. When the meeting ended, the user landed on Microsoft's post-call screen (containing the "Rejoin" / "Sign in" / "Meetings are just one tool in our belt" copy) with no sidebar and no obvious path back to chat. The issue log excerpt `ReactHandler: Teams app element not found` is consistent with this: the Teams React root no longer exists in the document after the takeover.
+
+The reported workaround was `Alt-Left` twice, which is undiscoverable and depends on webContents navigation history being intact.
+
+## Reproduction
+
+Confirmed on macOS dev build with the reporter's meeting URL. The behaviour has two distinct causes that look the same from the outside.
+
+The first cause is the `loadURL` call itself. Even when the user's org would have allowed an authenticated in-SPA join, calling `loadURL` from the main process creates a fresh document load against Microsoft's servers, and that entry point routes to the standalone launcher. This case is tractable: we can avoid it by navigating inside the already-loaded, authenticated Teams page via `executeJavaScript`, using the same-origin deep-link pattern that the quick chat feature uses (see ADR 014).
+
+The second cause is org policy. When the meeting's tenant does not match the signed-in user's tenant, or when the target org forces anonymous/guest join, Microsoft's servers redirect the URL into the anonymous meeting experience regardless of how the navigation starts. That experience is a full-page takeover by design, and the post-meeting screen is the "Rejoin" page shown in the issue. We cannot prevent this from the client — Microsoft decides based on tenant and policy. This is what was observed during reproduction on a maintainer's account.
+
+## First iteration (shipped)
+
+Two complementary changes land together.
+
+The `joinMeetingWithUrl` handler no longer calls `loadURL`. It snapshots the current webContents URL into `this.preJoinUrl`, then runs an `executeJavaScript` snippet that constructs a same-origin URL from the meeting path and assigns `window.location`. When the org allows authenticated join, this keeps the user inside the Teams SPA with the sidebar preserved, mirroring how the quick chat deep links work. When the org forces anonymous join, this makes no difference — Microsoft's redirect chain still takes over the window — but there is no downside compared to the previous behaviour.
+
+For the cases we cannot prevent, a new `Return to Teams` app-menu entry was added next to `Join Meeting`. It prefers the snapshotted `preJoinUrl` (validated against the Teams hostname allow-list) and falls back to the configured `url` default (`https://teams.cloud.microsoft`). This replaces the undiscoverable `Alt-Left` workaround with a visible recovery action. The menu item is always present rather than conditionally shown, because users can get pushed out of the Teams shell through other flows too (login redirects, deep links clicked from elsewhere).
+
+## Caveats
+
+The same-origin trick only helps when the Teams SPA is actually loaded and authenticated. If the user has not logged in yet, `executeJavaScript` still runs in whatever document is loaded, which is fine in practice because the flow only makes sense post-login, but we are not explicitly guarding against the pre-login case.
+
+We cannot verify the authenticated-org path in this project's CI or on the maintainer's personal account because the only available meeting link points to an org that enforces anonymous join. Whether the same-origin navigation actually preserves the sidebar in authenticated-org cases is still unconfirmed and depends on a user with the right setup reporting back. The change is still worth shipping because it is strictly no worse than `loadURL` and it matches the documented pattern used elsewhere in the codebase.
+
+The `Return to Teams` item uses `loadURL` on the main window, which is the correct tool when the window is already outside the SPA (for example on the anonymous post-meeting page). It does not attempt any graceful state transition; the user gets a fresh Teams load. This is acceptable because the alternative — sitting on the Microsoft "Rejoin" page with no way forward — is worse.
+
+The snapshotted `preJoinUrl` is per-`Menus`-instance memory, lost on app restart. That is fine for the recovery use case but means we cannot restore the previous chat after a crash or reboot.
+
+## Follow-up iterations
+
+Several directions are possible if user reports indicate the first iteration is insufficient.
+
+Auto-detecting the "meeting ended" page via `did-navigate` events and either prompting or auto-navigating back is the next obvious step. The risk is that the same page is where the legitimate "Rejoin" button lives, so auto-redirect would frustrate users who want to rejoin. A prompt ("You left a meeting. Return to Teams?") is safer but adds a modal to a flow that should feel native.
+
+Opening the meeting in a dedicated BrowserWindow is the cleanest UX — the main Teams app is never disturbed, and closing the meeting window returns focus to chat. This conflicts with the spirit of ADR 010 (which rejected general multi-window chat workflows), but a transient meeting popup is a narrower pattern and matches how the official Windows Teams client behaves. If adopted it should be its own ADR, because it introduces questions about window lifecycle, camera/mic permissions across windows, and interaction with the existing tray/quit behaviour.
+
+A keyboard accelerator for `Return to Teams` (for example `Ctrl+Shift+T`) would improve discoverability further. It was intentionally omitted in the first iteration to avoid shortcut churn before we know the feature is useful.
+
+## Related
+
+- Issue [#2322](https://github.com/IsmaelMartinez/teams-for-linux/issues/2322) — Join Meeting replaces whole window content
+- PR [#1856](https://github.com/IsmaelMartinez/teams-for-linux/pull/1856) — original Join Meeting feature
+- [ADR 014](../adr/014-quick-chat-deep-link-approach.md) — same-origin deep link pattern reused here
+- [ADR 010](../adr/010-multiple-windows-support.md) — relevant if a meeting popup is ever proposed


### PR DESCRIPTION
## Summary

- `Join Meeting` now navigates inside the loaded Teams SPA via a same-origin deep link (same pattern as quick chat / ADR 014) instead of calling `loadURL`, which was replacing the whole window with Microsoft's standalone meeting launcher.
- Adds a `Return to Teams` app-menu entry that restores the URL the user was on before joining (or falls back to the configured Teams home) for cases where Microsoft takes the window over anyway — e.g. org-enforced anonymous/guest join.
- Documents the two distinct takeover modes, the caveats, and follow-up options in `docs-site/docs/development/research/join-meeting-window-takeover-research.md`.

## Why iterative

Reproduction on the maintainer's account could only exercise the enforced-anonymous path: Microsoft redirects the meeting URL into the standalone anonymous experience regardless of how navigation starts, so the same-origin trick alone cannot preserve the Teams shell there. It should help orgs that allow authenticated in-SPA joins, but that path is unverifiable locally. Shipping a discoverable recovery action (`Return to Teams`) unblocks users today and gives us data to decide whether to pursue option 2 (auto-return via `did-navigate`) or option 3 (dedicated meeting BrowserWindow) — both detailed in the research doc.

## Test plan

- [ ] Start the app, log in, and trigger `Teams for Linux → Join Meeting` with a valid meeting URL.
- [ ] Confirm joining works and, after the meeting ends, `Teams for Linux → Return to Teams` brings you back to the chat you were on before joining.
- [ ] For orgs that allow authenticated join: confirm the sidebar stays visible while the meeting is loading (cannot be verified on the maintainer's test org).
- [ ] `npm run lint` passes.

closes #2322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the Teams window when joining meetings so the app no longer gets replaced by the meeting page.

* **New Features**
  * Added a persistent "Return to Teams" menu item to restore the Teams workspace after joining a meeting.

* **Documentation**
  * Added research and guidance describing the change, verification notes, caveats, and planned follow-up work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->