### PR TITLE
ci: one-shot simili-bot index seeder

### DIFF
--- a/.changelog/pr-2440.txt
+++ b/.changelog/pr-2440.txt
@@ -1,0 +1,1 @@
+Add workflow to backfill simili-bot Qdrant index - by @IsmaelMartinez (#2440)

--- a/.github/workflows/simili-seed.yml
+++ b/.github/workflows/simili-seed.yml
@@ -1,0 +1,37 @@
+name: Seed simili-bot Qdrant index
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Maximum issues to index (blank = all)"
+        required: false
+        default: ""
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install gh simili extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh extension install similigh/simili-bot
+
+      - name: Bulk-index closed issues into Qdrant
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          QDRANT_URL: ${{ secrets.QDRANT_URL }}
+          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          if [ -n "$LIMIT" ]; then
+            gh simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5 --limit "$LIMIT"
+          else
+            gh simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5
+          fi


### PR DESCRIPTION
Adds a `workflow_dispatch` job that runs `gh simili index` against this repo, using the `GEMINI_API_KEY`/`QDRANT_URL`/`QDRANT_API_KEY` secrets already set up for PR #2438. Run it once to backfill the Qdrant collection with existing closed issues, then the normal simili.yml workflow keeps the index in sync on new issues.

## After merge

Trigger from the Actions tab: **Seed simili-bot Qdrant index → Run workflow**. Leave `limit` blank for a full backfill (expected: ~1,400 issues, roughly 5-10 min with 5 workers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to seed and backfill the search index with closed issues, enabling enhanced indexing capabilities.
  * Added changelog entry documenting the infrastructure update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->