### PR TITLE
ci: fix simili seed workflow (download binary directly)

### DIFF
--- a/.github/workflows/simili-seed.yml
+++ b/.github/workflows/simili-seed.yml
@@ -14,24 +14,33 @@ jobs:
     permissions:
       contents: read
       issues: read
+    env:
+      SIMILI_VERSION: v0.2.0-rc.1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Install gh simili extension
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh extension install similigh/simili-bot
+      - name: Download simili CLI binary
+        run: |
+          TARBALL="simili-bot_${SIMILI_VERSION#v}_linux_amd64.tar.gz"
+          curl -sfL -o /tmp/simili.tar.gz \
+            "https://github.com/similigh/simili-bot/releases/download/${SIMILI_VERSION}/${TARBALL}"
+          tar -xzf /tmp/simili.tar.gz -C /tmp
+          ls /tmp | grep -i simili
+          chmod +x /tmp/simili || chmod +x /tmp/simili-bot
+          (test -x /tmp/simili && sudo mv /tmp/simili /usr/local/bin/simili) \
+            || sudo mv /tmp/simili-bot /usr/local/bin/simili
+          simili --help | head -3
 
       - name: Bulk-index closed issues into Qdrant
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           LIMIT: ${{ inputs.limit }}
         run: |
           if [ -n "$LIMIT" ]; then
-            gh simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5 --limit "$LIMIT"
+            simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5 --limit "$LIMIT"
           else
-            gh simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5
+            simili index --repo IsmaelMartinez/teams-for-linux --config .github/simili.yaml --workers 5
           fi


### PR DESCRIPTION
PR #2440's seeder failed because `gh extension install similigh/simili-bot` errors with `extension name must start with gh-` — there's no `similigh/gh-simili` repo despite the README suggesting the install path works. Download the linux_amd64 tarball from the v0.2.0-rc.1 release instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to use a pinned version of a development tool with improved installation and execution methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->