### PR TITLE
ci: narrow simili-bot triggers to stop duplicate comments

### DIFF
--- a/.changelog/pr-2448.txt
+++ b/.changelog/pr-2448.txt
@@ -1,0 +1,1 @@
+Fix: Prevent duplicate simili-bot comments on issues and PRs - by @IsmaelMartinez (#2448)

--- a/.github/workflows/simili.yml
+++ b/.github/workflows/simili.yml
@@ -2,9 +2,11 @@ name: Simili Issue Triage (trial)
 
 on:
   issues:
-    types: [opened, edited, reopened, labeled]
-  issue_comment:
-    types: [created]
+    types: [opened, reopened]
+
+concurrency:
+  group: simili-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   process:


### PR DESCRIPTION
## Summary

The simili-bot trial workflow is posting duplicate triage reports on issues (visible on #2433 and #2436). Three compounding causes:

- `issue_comment: [created]` fires on every comment on every issue **and every PR** (GitHub treats PRs as issues) — so the bot ran on PR discussions too (e.g. ADR-020, typescript bump, IPC fixes).
- `issues: [edited, labeled]` fires a separate event per label / body tweak, causing 2–4 runs within seconds for a single triage action.
- No `concurrency:` group, so bursts don't coalesce and each run posts a new comment instead of replacing the prior one.

This narrows the trigger to `issues: [opened, reopened]` (the bot's stated purpose is duplicate suggestion on new issues) and adds a per-issue concurrency group that cancels in-flight runs.

Upstream follow-up: `similigh/simili-bot` should ideally edit its `<!-- simili-bot-report -->` marker comment in place rather than appending a new comment — worth raising there separately.

## Test plan

- [ ] Open a new issue → one simili-bot report is posted.
- [ ] Edit the issue body → no additional run fires.
- [ ] Add a label → no additional run fires.
- [ ] Comment on an issue or PR → no additional run fires.
- [ ] Reopen a closed issue → one run fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)