### PR TITLE
ci: fix cross-distro smoke URL resolution

### DIFF
--- a/.changelog/pr-2449.txt
+++ b/.changelog/pr-2449.txt
@@ -1,0 +1,1 @@
+Fix: Resolve AppImage URL for cross-distro smoke tests - by @IsmaelMartinez (#2449)

--- a/.github/workflows/cross-distro-smoke.yml
+++ b/.github/workflows/cross-distro-smoke.yml
@@ -27,12 +27,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use .browser_download_url rather than .url — the API URL returns
-          # JSON metadata unless the request carries
-          # Accept: application/octet-stream, which the curl inside the
-          # container does not set.
+          # gh CLI's release view returns .url as the browser download URL
+          # (unlike the raw REST API, where .url is the API endpoint).
           URL=$(gh release view --repo IsmaelMartinez/teams-for-linux --json assets \
-            --jq '.assets[] | select(.name | test("\\.AppImage$") and (test("-(arm64|armv7l)\\.AppImage$") | not)) | .browser_download_url' | head -1)
+            --jq '.assets[] | select(.name | test("\\.AppImage$") and (test("-(arm64|armv7l)\\.AppImage$") | not)) | .url' | head -1)
           if [ -z "$URL" ]; then
             echo "::error::Could not resolve AppImage URL from latest release"
             exit 1


### PR DESCRIPTION
## Summary
- The cross-distro smoke workflow has been failing on every run since it was added, erroring at the *Resolve latest AppImage URL* step with `Could not resolve AppImage URL from latest release`.
- Root cause: the `jq` filter pulled `.browser_download_url`, but `gh release view --json assets` (unlike the raw GitHub REST API) exposes the browser download URL as `.url`. The filter matched the correct AppImage asset but selected a non-existent field, so `URL` was always empty.
- Switching to `.url` and updating the stale comment restores URL resolution. Kept the `push: branches: [main]` trigger — the smoke script is explicitly designed to run unauthenticated (verifies Electron launches, does not assert navigation).

## Test plan
- [ ] Workflow run on this PR / post-merge succeeds at *Resolve latest AppImage URL*
- [ ] At least one matrix cell (e.g. `ubuntu, x11`) reaches the *Run smoke check* step and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)