### PR TITLE
feat(multi-account): add multiAccount.enabled flag and Intune mutex

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -556,6 +556,14 @@ function extractYargConfig(configObject, appVersion) {
         describe: "Authentication configuration (Intune SSO)",
         type: "object",
       },
+      multiAccount: {
+        default: {
+          enabled: false,
+        },
+        describe:
+          "Multi-account profile switcher configuration (see ADR-020). enabled: opt-in flag for the single-window multi-tenant switcher. Mutually exclusive with auth.intune.enabled; when both are true a startup warning is logged and multi-account is disabled for the session.",
+        type: "object",
+      },
       wayland: {
         default: {
           xwaylandOptimizations: false,

--- a/app/index.js
+++ b/app/index.js
@@ -84,6 +84,17 @@ config.appPath = path.join(__dirname, app.isPackaged ? "../../" : "");
 
 CommandLineManager.addSwitchesAfterConfigLoad(config);
 
+// ADR-020: multi-account is mutually exclusive with Intune MAM.
+// The Linux D-Bus Microsoft Identity Broker has undocumented behavior
+// around concurrent enrollments for different UPNs on one machine, so
+// force multi-account off when both flags are true at startup.
+if (config.multiAccount?.enabled && config.auth?.intune?.enabled) {
+  console.warn(
+    "[MultiAccount] auth.intune.enabled is true; multi-account is not supported in this configuration and will be disabled for this session."
+  );
+  config.multiAccount.enabled = false;
+}
+
 let userStatus = -1;
 let mqttClient = null;
 let mqttMediaStatusService = null;

--- a/app/index.js
+++ b/app/index.js
@@ -87,11 +87,15 @@ CommandLineManager.addSwitchesAfterConfigLoad(config);
 // ADR-020: multi-account is mutually exclusive with Intune MAM.
 // The Linux D-Bus Microsoft Identity Broker has undocumented behavior
 // around concurrent enrollments for different UPNs on one machine, so
-// force multi-account off when both flags are true at startup.
-if (config.multiAccount?.enabled && config.auth?.intune?.enabled) {
-  console.warn(
-    "[MultiAccount] auth.intune.enabled is true; multi-account is not supported in this configuration and will be disabled for this session."
-  );
+// force multi-account off when Intune is enabled via either the current
+// `auth.intune.enabled` or the legacy `ssoInTuneEnabled` flag.
+const intuneEnabled =
+  config.auth?.intune?.enabled || config.ssoInTuneEnabled;
+if (config.multiAccount?.enabled && intuneEnabled) {
+  const warning =
+    "[MultiAccount] Intune SSO is enabled (auth.intune.enabled or ssoInTuneEnabled); multi-account is not supported in this configuration and will be disabled for this session.";
+  console.warn(warning);
+  config.warnings = [...(config.warnings || []), warning];
   config.multiAccount.enabled = false;
 }
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -244,7 +244,7 @@ Opt-in configuration for the single-window multi-tenant account switcher:
 |--------|------|---------|-------------|
 | `multiAccount.enabled` | `boolean` | `false` | Opt-in flag for the multi-account profile switcher. See [ADR-020](development/adr/020-multi-account-profile-switcher) for the full design. |
 
-**Mutual exclusion with Intune SSO:** If both `multiAccount.enabled` and `auth.intune.enabled` are `true` at startup, the app logs a warning and disables multi-account for the session. The Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine, so Phase 1 treats Intune as single-profile-only. Users who need both can track follow-up discussion on the ADR.
+**Mutual exclusion with Intune SSO:** If `multiAccount.enabled` is `true` at startup and Intune SSO is enabled via either `auth.intune.enabled` or the legacy `ssoInTuneEnabled` flag, the app logs a warning, appends it to `config.warnings`, and disables multi-account for the session. The Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine, so Phase 1 treats Intune as single-profile-only. Users who need both can track follow-up discussion on the ADR.
 
 ### Network & Proxy
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -226,6 +226,26 @@ Report-only Content Security Policy headers are automatically stripped for all n
 | `clientCertPath` | `string` | `""` | Custom Client Certs for corporate authentication (certificate must be in pkcs12 format) |
 | `clientCertPassword` | `string` | `""` | Custom Client Certs password for corporate authentication |
 
+### Multi-Account Profile Switcher (Experimental)
+
+> **Status:** Phase 1 MVP scaffolding. The flag is wired through config, but the switcher UI, profile CRUD, and session isolation plumbing land in follow-up PRs tracked in [ADR-020](development/adr/020-multi-account-profile-switcher). Enabling the flag today has no user-visible effect beyond the Intune mutex check described below.
+
+Opt-in configuration for the single-window multi-tenant account switcher:
+
+```json
+{
+  "multiAccount": {
+    "enabled": false
+  }
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `multiAccount.enabled` | `boolean` | `false` | Opt-in flag for the multi-account profile switcher. See [ADR-020](development/adr/020-multi-account-profile-switcher) for the full design. |
+
+**Mutual exclusion with Intune SSO:** If both `multiAccount.enabled` and `auth.intune.enabled` are `true` at startup, the app logs a warning and disables multi-account for the session. The Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine, so Phase 1 treats Intune as single-profile-only. Users who need both can track follow-up discussion on the ADR.
+
 ### Network & Proxy
 
 | Option | Type | Default | Description |


### PR DESCRIPTION
## Summary

First atomic PR in ADR-020's Phase 1 delivery. Adds the opt-in `multiAccount.enabled` config flag (default `false`) and enforces the Intune MAM mutual exclusion at startup. No user-visible behavior change; the flag is wired through config but the switcher UI, ProfilesManager, and session isolation plumbing land in follow-up PRs.

## Changes

- **`app/config/index.js`** — nested `multiAccount` block, following the existing `auth.*` / `graphApi.*` / `mqtt.*` convention.
- **`app/index.js`** — mutex check immediately after config load: if `auth.intune.enabled && multiAccount.enabled` at startup, logs a warning and forces multi-account off for the session (mutates in-memory `config` only).
- **`docs-site/docs/configuration.md`** — documents the flag, the mutex, and links to ADR-020. Marked "Experimental / Phase 1 MVP scaffolding" to set expectations.

## Rationale for the mutex

Per ADR-020 § "Mutual exclusion with \`auth.intune.enabled\`": the Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine. Phase 1 treats Intune as single-profile-only.

## Test plan

- [x] \`npm run lint\` clean
- [x] Node smoke: \`argv(...)\` returns \`{ multiAccount: { enabled: false } }\` by default
- [x] \`npm run test:e2e\` — 10/10 pass
- [x] Manual: dropped \`{\"multiAccount\": {\"enabled\": true}, \"auth\": {\"intune\": {\"enabled\": true}}}\` into a test \`config.json\` and confirmed the \`[MultiAccount]\` warning appears at startup and \`multiAccount.enabled\` is forced to \`false\` for the session

Refs ADR-020.