### PR TITLE
fix(auth): narrow AUTH_RECOVERY trigger to avoid mid-call reloads

### DIFF
--- a/.changelog/pr-2460.txt
+++ b/.changelog/pr-2460.txt
@@ -1,0 +1,2 @@
+Fix: Prevent mid-call reloads by narrowing auth recovery trigger. - by @IsmaelMartinez (#2460)
+closes: #2428 https://github.com/IsmaelMartinez/teams-for-linux/issues/2428 [Bug]: App refreshes during active calls.

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -441,7 +441,7 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   // When Teams can't refresh tokens silently (e.g., after overnight idle),
   // it logs InteractionRequired. We detect this, clear stale auth state,
   // and reload to force a clean interactive login.
-  const AUTH_FAILURE_PATTERNS = ['InteractionRequired', 'AuthFailed'];
+  const AUTH_FAILURE_PATTERNS = ['InteractionRequired'];
   // Only trust auth failure signals from Teams/Microsoft origins
   const TRUSTED_AUTH_SOURCES = ['teams.cloud.microsoft', 'teams.microsoft.com', 'login.microsoftonline.com'];
   let authRecoveryTriggered = false;
@@ -453,6 +453,9 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
     // Verify the message originates from a trusted Microsoft source
     const sourceId = event.sourceId || '';
     if (sourceId && !TRUSTED_AUTH_SOURCES.some(s => sourceId.includes(s))) return;
+
+    // Worker UPRs are frequently transient; only react to non-worker sources (#2428)
+    if (sourceId.includes('/worker/')) return;
 
     authRecoveryTriggered = true;
     console.info('[AUTH_RECOVERY] Auth failure detected, scheduling recovery');


### PR DESCRIPTION
## Summary

- Remove `AuthFailed` from `AUTH_FAILURE_PATTERNS` in `app/mainAppWindow/index.js`, keeping only the authoritative MSAL `InteractionRequired` signal.
- Ignore console messages whose `sourceId` contains `/worker/`, since Teams workers emit transient unhandled promise rejections that are not fatal.
- Preserve the existing 5-second delay, trusted-source allowlist, `cleanExpiredAuthCookies`, `triggerAuthRecovery`, and the `powerMonitor` resume hook unchanged.

## Root cause

The listener added in #2311 to recover from blank-calendar-on-resume matched the substring `AuthFailed` anywhere in a trusted-origin console message. Teams web workers log `Uncaught Error: UPR: "Error: AuthFailed"` as transient unhandled promise rejections during long calls, which Teams recovers from internally. Our listener treated these as session-dead, waited 5 seconds, then nuked cookies and reloaded, aborting active meetings (reporters hit this roughly one hour into long calls).

`InteractionRequired` is emitted by MSAL from the main renderer when silent SSO actually fails, so the overnight stale-session recovery path from #2311 continues to work.

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run test:unit` passes (142/142).
- [ ] Manual verification by reporters: long meeting no longer aborts with an auth reload roughly one hour in.
- [ ] Manual verification: overnight/resume silent-SSO failure still triggers recovery via `InteractionRequired`.

closes #2428