### PR TITLE
chore(changelog): backfill entries for PRs merged without one

### DIFF
--- a/.changelog/pr-2405.txt
+++ b/.changelog/pr-2405.txt
@@ -1,0 +1,1 @@
+Add Vylen Linux to distribution packages and fix badge formatting - by @CelestifyX (#2405)

--- a/.changelog/pr-2426.txt
+++ b/.changelog/pr-2426.txt
@@ -1,0 +1,1 @@
+Propose ADR-020 multi-account profile switcher - by @jpenberthy (#2426)

--- a/.changelog/pr-2435.txt
+++ b/.changelog/pr-2435.txt
@@ -1,0 +1,1 @@
+Wire up renderer error forwarding and remove login handler leak - by @jpenberthy (#2435)

--- a/.changelog/pr-2441.txt
+++ b/.changelog/pr-2441.txt
@@ -1,0 +1,1 @@
+Fix simili-bot seeder workflow to download the release binary directly - by @IsmaelMartinez (#2441)

--- a/.changelog/pr-2442.txt
+++ b/.changelog/pr-2442.txt
@@ -1,0 +1,1 @@
+Fix simili-bot seeder flags for v0.2.0-rc.1 - by @IsmaelMartinez (#2442)

--- a/.changelog/pr-2468.txt
+++ b/.changelog/pr-2468.txt
@@ -1,0 +1,1 @@
+Backfill missing changelog entries for five recently merged PRs. - by @IsmaelMartinez (#2468)


### PR DESCRIPTION
## Summary

Five PRs merged after v2.8.0 did not receive an auto-generated changelog entry (external fork, docs-only, or the workflow skipped). Backfilling so `npm run release:prepare` picks them up in the next release notes.

Entries added:

- `pr-2405.txt` — CelestifyX, Add Vylen Linux to distribution packages and fix badge formatting
- `pr-2426.txt` — @jpenberthy, Propose ADR-020 multi-account profile switcher
- `pr-2435.txt` — @jpenberthy, Wire up renderer error forwarding and remove login handler leak
- `pr-2441.txt` — @IsmaelMartinez, Fix simili-bot seeder workflow to download the release binary directly
- `pr-2442.txt` — @IsmaelMartinez, Fix simili-bot seeder flags for v0.2.0-rc.1

Descriptions follow the existing `.changelog/` convention (`<desc> - by @<user> (#<PR>)`). Feel free to edit any of them before merge if you want different wording.

## Test plan

- [x] Maintainer sanity-checks the five descriptions against the PR bodies.
- [x] `npm run release:prepare -- --dry-run` lists all five entries in the preview for the next release.