### PR TITLE
fix(ci): correct SHA pin for release-please-action v4.2.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f8e03db635a # v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Follow-up to #2408. The release-please workflow fails on every push to main with:

```
Unable to resolve action `googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f8e03db635a`,
unable to find version `a02a34c4d625f9be7cb89156071d6f8e03db635a`
```

That SHA does not exist in the upstream repo. The first 28 characters match the real v4.2.0 commit, but the last 12 are mangled. Fixed to the verified SHA for tag `v4.2.0`: `a02a34c4d625f9be7cb89156071d8567266a2445` (confirmed via `gh api repos/googleapis/release-please-action/git/refs/tags`).

## How we know it works

Once merged, the next push to main triggers the release-please workflow. With a valid action pin, it should resolve successfully and create (or update) a Release PR titled `chore(main): release <version>` with version bump, `CHANGELOG.md`, and `appdata.xml` updated via `scripts/update-appdata-xml.js`. That Release PR landing confirms the end-to-end pipeline introduced in #2408.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, `Release Please` workflow run succeeds
- [ ] release-please opens a Release PR for the next version

🤖 Generated with [Claude Code](https://claude.ai/code)