### PR TITLE
chore(simili): use explicit steps list to enforce similarity-only mode

### DIFF
--- a/.github/simili.yaml
+++ b/.github/simili.yaml
@@ -8,7 +8,22 @@
 #   QDRANT_URL       Qdrant Cloud instance URL (https://...)
 #   QDRANT_API_KEY   Qdrant Cloud API key
 
-workflow: similarity-only
+# Use an explicit `steps:` list instead of `workflow: similarity-only`.
+# The pinned simili-bot version reads cfg.Workflow from this file but never
+# applies it — the process command's --workflow flag wins and defaults to
+# `issue-triage`, which is why the first trial weeks saw duplicate callouts,
+# quality scores, and 72-hour auto-close countdowns despite the trial plan
+# calling for similarity-only output. cfg.Steps is checked first by
+# ResolveSteps, so listing the steps directly bypasses the broken workflow
+# handling. Kept in sync with the upstream `similarity-only` preset:
+#   https://github.com/similigh/simili-bot/blob/main/internal/core/pipeline/registry.go
+steps:
+  - gatekeeper
+  - vectordb_prep
+  - similarity_search
+  - response_builder
+  - action_executor
+  - indexer
 
 qdrant:
   url: "${QDRANT_URL}"


### PR DESCRIPTION
## Summary

The simili-bot trial on this repo has been emitting the full `issue-triage` report (Quality Score, Possible Duplicate callout, 72-hour auto-close countdown) despite `.github/simili.yaml` specifying `workflow: similarity-only`. Root cause: the pinned simili-bot version's `process` command reads its CLI `--workflow` flag (default `issue-triage`) instead of `cfg.Workflow` from the yaml, and `action.yml` has no input that plumbs through to that flag. The `cfg.Steps` field, however, is read first by `ResolveSteps` and takes priority.

This PR replaces the silently-ignored `workflow:` field with an explicit `steps:` list mirroring upstream's [`similarity-only` preset](https://github.com/similigh/simili-bot/blob/main/internal/core/pipeline/registry.go) — `gatekeeper`, `vectordb_prep`, `similarity_search`, `response_builder`, `action_executor`, `indexer`. The dropped steps (`duplicate_detector`, `quality_checker`, `triage`, `llm_router`, `transfer_check`, `pending_action_scheduler`) are what populate the metadata that `response_builder` uses to render the duplicate callout, quality section, and label suggestions; with them gone, the comment collapses to the "Similar Threads" table only.

## Why

Trial plan: [`docs/plans/2026-04-16-simili-bot-trial.md`](https://github.com/IsmaelMartinez/github-issue-triage-bot/blob/main/docs/plans/2026-04-16-simili-bot-trial.md) (line 37 — "Configure in similarity-only mode (no auto-close, no auto-label)").

30-day mid-trial review: of 7 duplicate flags simili-bot raised on this repo, only 1 was correct (#2433, accepted by the OP). The other 6 produced explicit "this is not a duplicate / ignore the auto-close / apologies for the noise" maintainer replies on the public thread:

- #2399
- #2436
- #2447
- #2453
- #2457
- #2465

Observed precision ~14% vs the trial's >60% target; observed noise ~31% vs the <20% target. The "Similar Threads" table itself has been useful — that is what this PR keeps.

## Test plan

- [ ] Merge and watch the next 1-2 newly-opened issues. The simili-bot comment should collapse to header + Classification (Labels: None) + Similar Threads only — no Quality Score, no Possible Duplicate callout, no 72-hour countdown.
- [ ] If the next 1-2 issues still show the duplicate or quality sections, escalate (config still being misread → drop the bot rather than fork).
- [ ] Follow-up review in 7-14 days to confirm the reconfiguration stuck and decide on trial outcome.