### PR TITLE
fix(auth): scope worker-source AUTH_RECOVERY suppression to active calls

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -445,6 +445,11 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   // Only trust auth failure signals from Teams/Microsoft origins
   const TRUSTED_AUTH_SOURCES = ['teams.cloud.microsoft', 'teams.microsoft.com', 'login.microsoftonline.com'];
   let authRecoveryTriggered = false;
+  // Worker UPRs are transient during active calls (#2428); suppress them only while
+  // a call is in progress so startup recovery still works for stale-token loops (#2480).
+  let callActive = false;
+  app.on('teams-call-connected', () => { callActive = true; });
+  app.on('teams-call-disconnected', () => { callActive = false; });
   window.webContents.on('console-message', (event) => {
     if (authRecoveryTriggered) return;
     const message = event.message || '';
@@ -454,8 +459,7 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
     const sourceId = event.sourceId || '';
     if (sourceId && !TRUSTED_AUTH_SOURCES.some(s => sourceId.includes(s))) return;
 
-    // Worker UPRs are frequently transient; only react to non-worker sources (#2428)
-    if (sourceId.includes('/worker/')) return;
+    if (sourceId.includes('/worker/') && callActive) return;
 
     authRecoveryTriggered = true;
     console.info('[AUTH_RECOVERY] Auth failure detected, scheduling recovery');

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -450,6 +450,9 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   let callActive = false;
   app.on('teams-call-connected', () => { callActive = true; });
   app.on('teams-call-disconnected', () => { callActive = false; });
+  // Page reload (including renderer crash recovery) resets renderer-side call state,
+  // so clear the flag to avoid getting stuck if 'teams-call-disconnected' was missed.
+  window.webContents.on('did-navigate', () => { callActive = false; });
   window.webContents.on('console-message', (event) => {
     if (authRecoveryTriggered) return;
     const message = event.message || '';


### PR DESCRIPTION
## Summary

- Track active-call state via the existing `teams-call-connected` / `teams-call-disconnected` events from `browserWindowManager`.
- Suppress worker-source `InteractionRequired` UPRs only while a call is in progress, instead of blanket-suppressing every worker source.
- Restores the startup-recovery cookie-wipe path that 2.8.1 lost for users with stale cached tokens, while keeping the #2428 mid-call false-positive guard.

## Background

PR #2460 added `if (sourceId.includes('/worker/')) return;` to fix #2428 (calls aborting ~1h in because Teams workers emit transient `Uncaught Error: UPR: "Error: AuthFailed"` rejections that our broader trigger interpreted as session-dead).

The blanket filter overshoots at startup: in the #2480 reporter's log every `InteractionRequired` and `AuthFailed` line is sourced from `teams.cloud.microsoft/v2/worker/precompiled-web-worker-...js`, so `AUTH_RECOVERY` never fires, the stale-token state is never cleared, and the Sign-in banner loops. v2.8.0 (broader pattern, no worker filter) recovered automatically.

This change scopes the suppression to "while a call is active", which is the only window where the original false positives mattered.

## Test plan

- [x] `npm run lint`
- [ ] Manual: launch with stale cached cookies (simulating the #2480 case) and confirm `AUTH_RECOVERY` fires and cookies are wiped
- [ ] Manual: stay in a call past the previous ~1h reload window and confirm no spurious reload (regression check on #2428)

closes #2480