### PR TITLE
fix(power): bind enableWakeLockOnWindowRestore on the restore listener

### DIFF
--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -111,7 +111,7 @@ class BrowserWindowManager {
     // Handle screen sharing source selection from user
     ipcMain.on("select-source", this.assignSelectSourceHandler());
     if (this.screenLockInhibitionMethod === "WakeLockSentinel") {
-      this.window.on("restore", this.enableWakeLockOnWindowRestore);
+      this.window.on("restore", this.enableWakeLockOnWindowRestore.bind(this));
     }
     // Handle incoming call notification created
     ipcMain.handle(

--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -111,7 +111,11 @@ class BrowserWindowManager {
     // Handle screen sharing source selection from user
     ipcMain.on("select-source", this.assignSelectSourceHandler());
     if (this.screenLockInhibitionMethod === "WakeLockSentinel") {
-      this.window.on("restore", this.enableWakeLockOnWindowRestore.bind(this));
+      // Wake Lock auto-releases when document.visibilityState becomes 'hidden',
+      // which happens on both minimise and tray-hide. Re-acquire on both events.
+      const reAcquireWakeLock = this.enableWakeLockOnWindowRestore.bind(this);
+      this.window.on("restore", reAcquireWakeLock);
+      this.window.on("show", reAcquireWakeLock);
     }
     // Handle incoming call notification created
     ipcMain.handle(


### PR DESCRIPTION
## Summary

- One-line fix: `.bind(this)` on the `restore` event listener for the WakeLockSentinel branch of `screenLockInhibitionMethod`.
- Without the bind, Electron invokes the handler with `this` set to the `BrowserWindow`, so `this.isOnCall` and `this.window.webContents.send` reference the wrong object and the handler silently no-ops. Result: on the non-default WakeLockSentinel path, minimise + restore during a call leaves the display free to sleep mid-call.
- The bind was previously present and was dropped as collateral in PR #2068 (commit `c2a458e`), not by design.

## Test plan

- [x] `npm run lint`
- [x] Manual: with `screenSharing.lockInhibitionMethod: "WakeLockSentinel"` (or legacy `screenLockInhibitionMethod: "WakeLockSentinel"`) in config, start a call, minimise and restore the window, and confirm the wake lock re-engages (display does not sleep).

## Why bind, not arrow class field

The original ticket offered both. `.bind(this)` is more consistent with the rest of `browserWindowManager.js`, which uses regular methods throughout (no arrow class fields).

closes #2463