### PR TITLE
feat(multi-account): scaffold profile view lifecycle and Profile 0 bootstrap

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -23,6 +23,7 @@ const QuickChatManager = require("./quickChat");
 const ScreenSharingService = require("./screenSharing/service");
 const PartitionsManager = require("./partitions/manager");
 const ProfilesManager = require("./profilesManager");
+const ProfileViewManager = require("./mainAppWindow/profileViewManager");
 const IdleMonitor = require("./idle/monitor");
 const AutoUpdater = require("./autoUpdater");
 const os = require("node:os");
@@ -139,6 +140,11 @@ const partitionsManager = new PartitionsManager(appConfig.settingsStore);
 // modules; IPC handlers register only when `multiAccount.enabled === true`,
 // keeping the renderer surface byte-identical with the flag off.
 const profilesManager = new ProfilesManager(appConfig.settingsStore);
+
+// Phase 1c.1: per-profile WebContentsView lifecycle. Only constructed when
+// the multi-account flag is on; the manager is wired to the main window
+// after `mainAppWindow.onAppReady` resolves.
+let profileViewManager = null;
 
 // Initialize idle monitor with dependencies
 const idleMonitor = new IdleMonitor(config, getUserStatus);
@@ -602,6 +608,26 @@ async function handleAppReady() {
     const customBackground = new CustomBackground(app, config);
     customBackground.initialize();
     await mainAppWindow.onAppReady(appConfig, customBackground, screenSharingService);
+
+    // Phase 1c.1: wire per-profile WebContentsView lifecycle once the main
+    // window exists. Bootstrap Profile 0 from the legacy partition so a
+    // pre-existing Teams login survives the first flag flip (ADR-020).
+    if (config.multiAccount?.enabled) {
+      const mainWindow = mainAppWindow.getWindow();
+      if (mainWindow) {
+        profileViewManager = new ProfileViewManager(
+          mainWindow,
+          profilesManager,
+          config
+        );
+        profileViewManager.initialize();
+        await profileViewManager.bootstrapProfileZeroIfNeeded();
+      } else {
+        console.warn(
+          "[ProfileViewManager] main window unavailable after onAppReady; multi-account features disabled for this session"
+        );
+      }
+    }
 
     initializeGraphApiClient();
     registerGraphApiHandlers(ipcMain, graphApiClient);

--- a/app/mainAppWindow/profileViewManager.js
+++ b/app/mainAppWindow/profileViewManager.js
@@ -123,7 +123,7 @@ class ProfileViewManager {
       this.#window.removeListener("resize", this.#resizeHandler);
       this.#resizeHandler = null;
     }
-    for (const profileId of [...this.#views.keys()]) {
+    for (const profileId of this.#views.keys()) {
       this.#destroyView(profileId);
     }
     this.#initialized = false;

--- a/app/mainAppWindow/profileViewManager.js
+++ b/app/mainAppWindow/profileViewManager.js
@@ -1,0 +1,257 @@
+const { WebContentsView, session } = require("electron");
+const path = require("node:path");
+
+const LEGACY_PARTITION = "persist:teams-4-linux";
+
+/**
+ * ProfileViewManager — Phase 1c.1 of the multi-account profile switcher
+ * (ADR-020). Owns the per-profile `WebContentsView` overlays that sit on
+ * top of the main `BrowserWindow`'s content area.
+ *
+ * Architecture: Profile 0 (the legacy `persist:teams-4-linux` partition)
+ * lives on the root window's `webContents` — it is the existing main
+ * window we have today. Switching to Profile 0 hides every overlay so
+ * the underlying root window is visible. Adding a new profile creates a
+ * `WebContentsView` against `persist:teams-profile-{uuid}`; switching to
+ * that profile shows the matching overlay over the root window.
+ *
+ * No view is created for legacy-partition profiles; the root window
+ * already serves that role. This avoids running Teams twice in the same
+ * partition and keeps the scope of 1c.1 surgical (no rerouting of the
+ * existing auth-recovery or `msteams://` deep-link handlers, both of
+ * which operate on `window.webContents`).
+ *
+ * Subscribes to `profilesManager` lifecycle events so that profile
+ * mutations from any source (main-side bootstrap, IPC from a future
+ * switcher UI, or a unit-style direct call) keep the view set in sync.
+ */
+class ProfileViewManager {
+  #window;
+  #profilesManager;
+  #config;
+  #views = new Map();
+  #handlers = null;
+  #resizeHandler = null;
+  #initialized = false;
+
+  /**
+   * @param {Electron.BrowserWindow} window  Main app window
+   * @param {ProfilesManager} profilesManager
+   * @param {object} config  Loaded app config (need `chromeUserAgent`,
+   *                         `url`, and config gate `multiAccount.enabled`)
+   */
+  constructor(window, profilesManager, config) {
+    this.#window = window;
+    this.#profilesManager = profilesManager;
+    this.#config = config;
+  }
+
+  initialize() {
+    if (this.#initialized) return;
+    this.#initialized = true;
+
+    this.#handlers = {
+      add: (profile) => this.#onAdd(profile),
+      switch: (profile) => this.#onSwitch(profile),
+      remove: (result) => this.#onRemove(result),
+    };
+    this.#profilesManager.on("add", this.#handlers.add);
+    this.#profilesManager.on("switch", this.#handlers.switch);
+    this.#profilesManager.on("remove", this.#handlers.remove);
+
+    this.#resizeHandler = () => this.#applyBoundsToAll();
+    this.#window.on("resize", this.#resizeHandler);
+
+    // Materialize views for any pre-existing non-legacy profiles. Hide
+    // them all initially; the active profile is shown below if applicable.
+    for (const profile of this.#profilesManager.list()) {
+      if (profile.partition !== LEGACY_PARTITION) {
+        this.#createView(profile);
+      }
+    }
+
+    const active = this.#profilesManager.getActive();
+    if (active) this.#showActive(active);
+  }
+
+  /**
+   * Bootstrap Profile 0 from the legacy `persist:teams-4-linux` partition
+   * if (a) no profiles exist yet and (b) the legacy partition has cookies.
+   * The cookies-only heuristic catches every realistic warm-Teams session
+   * while keeping the check to a single async call (ADR-020 § "First-run
+   * bootstrap"; design decision logged in plans/feature-phase1c-multi-account.md).
+   *
+   * Safe to call multiple times; returns early when profiles already exist.
+   */
+  async bootstrapProfileZeroIfNeeded() {
+    if (this.#profilesManager.list().length > 0) return null;
+
+    let cookies;
+    try {
+      cookies = await session.fromPartition(LEGACY_PARTITION).cookies.get({});
+    } catch (error) {
+      console.warn(
+        "[ProfileViewManager] Failed to read legacy cookies; skipping bootstrap",
+        { message: error.message }
+      );
+      return null;
+    }
+
+    if (!Array.isArray(cookies) || cookies.length === 0) {
+      console.debug(
+        "[ProfileViewManager] Legacy partition has no cookies; bootstrap skipped"
+      );
+      return null;
+    }
+
+    const profile = this.#profilesManager.bootstrapLegacyProfile();
+    console.info("[ProfileViewManager] Bootstrapped Profile 0", {
+      id: profile.id,
+    });
+    return profile;
+  }
+
+  dispose() {
+    if (!this.#initialized) return;
+    if (this.#handlers) {
+      this.#profilesManager.off("add", this.#handlers.add);
+      this.#profilesManager.off("switch", this.#handlers.switch);
+      this.#profilesManager.off("remove", this.#handlers.remove);
+      this.#handlers = null;
+    }
+    if (this.#resizeHandler) {
+      this.#window.removeListener("resize", this.#resizeHandler);
+      this.#resizeHandler = null;
+    }
+    for (const profileId of [...this.#views.keys()]) {
+      this.#destroyView(profileId);
+    }
+    this.#initialized = false;
+  }
+
+  // --- Event handlers --------------------------------------------------
+
+  #onAdd(profile) {
+    if (profile.partition === LEGACY_PARTITION) {
+      // Profile 0 lives on the root window; no overlay needed.
+      return;
+    }
+    this.#createView(profile);
+  }
+
+  #onSwitch(profile) {
+    this.#showActive(profile);
+  }
+
+  #onRemove({ removedId, activeId }) {
+    this.#destroyView(removedId);
+    if (activeId) {
+      const next = this.#profilesManager
+        .list()
+        .find((p) => p.id === activeId);
+      if (next) this.#showActive(next);
+    } else {
+      this.#hideAllOverlays();
+    }
+  }
+
+  // --- View lifecycle --------------------------------------------------
+
+  #createView(profile) {
+    const view = new WebContentsView({
+      webPreferences: {
+        partition: profile.partition,
+        preload: path.join(__dirname, "..", "browser", "preload.js"),
+        plugins: true,
+        spellcheck: true,
+        webviewTag: true,
+        // SECURITY: matches the root window's webPreferences
+        // (browserWindowManager.js). Required for Teams DOM access via
+        // ReactHandler; compensated by IPC validation.
+        contextIsolation: false,
+        nodeIntegration: false,
+        sandbox: false,
+      },
+    });
+
+    this.#views.set(profile.id, view);
+    this.#applyBounds(view);
+
+    const url = profile.url || this.#config.url;
+    view.webContents.loadURL(url, {
+      userAgent: this.#config.chromeUserAgent,
+    });
+  }
+
+  #destroyView(profileId) {
+    const view = this.#views.get(profileId);
+    if (!view) return;
+    this.#views.delete(profileId);
+
+    try {
+      this.#window.contentView.removeChildView(view);
+    } catch {
+      // View may not be currently attached; ignore.
+    }
+
+    // Clear the partition's storage so a re-added profile with the same
+    // name does not see the previous tenant's data. ADR-020 § "Remove a
+    // profile" requires this destructive clear; UI confirmation is the
+    // caller's responsibility (Phase 1c.2 dialog).
+    const partitionSession = view.webContents.session;
+    partitionSession
+      .clearStorageData()
+      .catch((error) =>
+        console.warn(
+          "[ProfileViewManager] clearStorageData failed",
+          { profileId, message: error.message }
+        )
+      );
+
+    if (!view.webContents.isDestroyed()) {
+      view.webContents.close();
+    }
+  }
+
+  #showActive(profile) {
+    if (profile.partition === LEGACY_PARTITION) {
+      // Profile 0 is the root window; just hide all overlays.
+      this.#hideAllOverlays();
+      return;
+    }
+    this.#hideAllOverlays();
+    const view = this.#views.get(profile.id);
+    if (!view) {
+      console.warn(
+        "[ProfileViewManager] No view for active profile; nothing to show",
+        { profileId: profile.id }
+      );
+      return;
+    }
+    this.#applyBounds(view);
+    this.#window.contentView.addChildView(view);
+  }
+
+  #hideAllOverlays() {
+    for (const view of this.#views.values()) {
+      try {
+        this.#window.contentView.removeChildView(view);
+      } catch {
+        // Already detached; ignore.
+      }
+    }
+  }
+
+  // --- Bounds ----------------------------------------------------------
+
+  #applyBoundsToAll() {
+    for (const view of this.#views.values()) this.#applyBounds(view);
+  }
+
+  #applyBounds(view) {
+    const [width, height] = this.#window.getContentSize();
+    view.setBounds({ x: 0, y: 0, width, height });
+  }
+}
+
+module.exports = ProfileViewManager;

--- a/app/mainAppWindow/profileViewManager.js
+++ b/app/mainAppWindow/profileViewManager.js
@@ -62,6 +62,11 @@ class ProfileViewManager {
     this.#resizeHandler = () => this.#applyBoundsToAll();
     this.#window.on("resize", this.#resizeHandler);
 
+    // Tear down on window close so the WebContentsView instances and the
+    // ProfilesManager listeners do not outlive the window. `once` because
+    // the window is destroyed after the event fires.
+    this.#window.once("closed", () => this.dispose());
+
     // Materialize views for any pre-existing non-legacy profiles. Hide
     // them all initially; the active profile is shown below if applicable.
     for (const profile of this.#profilesManager.list()) {
@@ -81,7 +86,10 @@ class ProfileViewManager {
    * while keeping the check to a single async call (ADR-020 § "First-run
    * bootstrap"; design decision logged in plans/feature-phase1c-multi-account.md).
    *
-   * Safe to call multiple times; returns early when profiles already exist.
+   * Idempotent under serial calls — returns early when profiles already
+   * exist. Two concurrent calls would race past the `list().length > 0`
+   * guard and the second `bootstrapLegacyProfile()` would throw; only one
+   * caller exists today (`onAppReady` in `app/index.js`).
    */
   async bootstrapProfileZeroIfNeeded() {
     if (this.#profilesManager.list().length > 0) return null;

--- a/app/profilesManager/README.md
+++ b/app/profilesManager/README.md
@@ -51,10 +51,27 @@ Records live in `settingsStore` (electron-store, `settings.json`) under
 |---|---|---|
 | `list()` | `Profile[]` | Empty array if nothing configured |
 | `getActive()` | `Profile \| null` | |
-| `switch(id)` | `Profile` | Throws on unknown id |
-| `add(record)` | `Profile` | Generates `id`, derives `partition`, validates `name` |
-| `update(id, patch)` | `Profile` | Drops `id` / `partition` from the patch |
-| `remove(id)` | `{ removedId, activeId }` | Falls back to first remaining profile (or null) when removing the active one |
+| `switch(id)` | `Profile` | Throws on unknown id; emits `switch` |
+| `add(record)` | `Profile` | Generates `id`, derives `partition`, validates `name`; emits `add` |
+| `update(id, patch)` | `Profile` | Drops `id` / `partition` from the patch; emits `update` |
+| `remove(id)` | `{ removedId, activeId }` | Falls back to first remaining profile (or null) when removing the active one; emits `remove` |
+| `bootstrapLegacyProfile(name?)` | `Profile` | **Main-process only.** Creates Profile 0 against `persist:teams-4-linux` so the user's existing login survives the first flag flip (ADR-020 § "First-run bootstrap"). Throws if any profile already exists. Not exposed via IPC — a renderer being able to point a profile at an arbitrary partition string would let it hijack any session. |
+
+## Lifecycle hooks
+
+`ProfilesManager` is a small in-process `EventEmitter`. Main-side consumers
+(`ProfileViewManager`, the future menu builder) subscribe via `on()` /
+`off()`:
+
+| Event | Payload |
+|---|---|
+| `add` | `Profile` |
+| `update` | `Profile` |
+| `switch` | `Profile` |
+| `remove` | `{ removedId, activeId }` |
+
+The events are local to the main process — they do not change the IPC
+surface and do not require allowlisting.
 
 ## IPC channels (six, allowlisted)
 
@@ -67,19 +84,21 @@ Records live in `settingsStore` (electron-store, `settings.json`) under
 | `profile-update` | `id, patch` | `Profile` |
 | `profile-remove` | `id` | `{ removedId, activeId }` |
 
-## What this PR explicitly does **not** do
+## What 1c.1 does **not** do
 
-- No `WebContentsView` creation or switching — that lands with the switcher UI.
-- No first-run bootstrap of Profile 0 from the legacy
-  `persist:teams-4-linux` partition. ADR-020 places that on the first
-  launch *after the flag flips*; with no UI yet, there is nothing to show
-  the bootstrapped profile, so the bootstrap is paired with the UI PR.
-- No screen-preview-partition swap, no `CustomBackground` instance refactor,
-  no `cleanExpiredAuthCookies` rework — those are part of Phase 1's
-  shared-state audit and ship alongside the corresponding feature PRs.
+- No switcher UI, no Profiles menu entry, no `Ctrl+Shift+1…5` shortcuts —
+  those land in Phase 1c.2 alongside the renderer dialogs.
+- No screen-preview-partition swap, no `CustomBackground` instance
+  refactor, no `cleanExpiredAuthCookies` rework — those are Phase 1c.3
+  cleanups.
 
-The companion change in this PR migrates `app/login/index.js`'s module-level
-`isFirstLoginTry` to a per-`webContents` `WeakMap` (ADR-020 § "Shared-state
-audit", entry 1). This is preparatory: today there is one `webContents` so
-the behavior is unchanged, but it removes the shared-state hazard before
-profile switching can exercise it.
+## Companion modules
+
+- `app/mainAppWindow/profileViewManager.js` (Phase 1c.1) — owns the
+  per-profile `WebContentsView` overlays and the first-run bootstrap. It
+  subscribes to the events documented above so any future caller of
+  `add` / `switch` / `remove` (including the upcoming switcher UI) keeps
+  the view set in sync without extra wiring.
+- `app/login/index.js` (landed in Phase 1b) — migrates the login
+  retry-state from a module-level boolean to a per-`webContents` `WeakMap`
+  so a switch mid-401 does not look like a retry on the previous profile.

--- a/app/profilesManager/index.js
+++ b/app/profilesManager/index.js
@@ -1,8 +1,10 @@
 const { ipcMain } = require("electron");
+const { EventEmitter } = require("node:events");
 const crypto = require("node:crypto");
 
 const STORE_KEY = "app.profiles";
 const PARTITION_PREFIX = "persist:teams-profile-";
+const LEGACY_PARTITION = "persist:teams-4-linux";
 
 // Free-text caps so a renderer-supplied string cannot land oversized in CSS
 // (avatarColor) or DOM text (avatarInitials, url) once Phase 1c wires the
@@ -41,9 +43,21 @@ function ensureLength(value, max, field) {
 class ProfilesManager {
   #settingsStore;
   #initialized = false;
+  #emitter = new EventEmitter();
 
   constructor(settingsStore) {
     this.#settingsStore = settingsStore;
+  }
+
+  // In-process subscription for main-side consumers (ProfileViewManager,
+  // menu builder). Events: "add" (Profile), "update" (Profile),
+  // "switch" (Profile), "remove" ({ removedId, activeId }).
+  on(event, handler) {
+    this.#emitter.on(event, handler);
+  }
+
+  off(event, handler) {
+    this.#emitter.off(event, handler);
   }
 
   initialize() {
@@ -84,6 +98,7 @@ class ProfilesManager {
     }
     state.activeId = id;
     this.#write(state);
+    this.#emitter.emit("switch", profile);
     return profile;
   }
 
@@ -97,10 +112,48 @@ class ProfilesManager {
     ensureLength(record.url, MAX_URL_LEN, "url");
 
     const id = crypto.randomUUID();
-    const profile = {
+    const profile = this.#buildRecord(id, `${PARTITION_PREFIX}${id}`, name, record);
+
+    const state = this.#read();
+    state.list.push(profile);
+    if (!state.activeId) state.activeId = id;
+    this.#write(state);
+    this.#emitter.emit("add", profile);
+    return profile;
+  }
+
+  // Bootstrap Profile 0 against the legacy `persist:teams-4-linux` partition
+  // so the user's existing login survives the first multi-account flag flip
+  // (ADR-020 § "First-run bootstrap"). Main-process only — never exposed via
+  // IPC, since a renderer being able to point a profile at an arbitrary
+  // partition string would let it hijack any session.
+  bootstrapLegacyProfile(name = "My account") {
+    const state = this.#read();
+    if (state.list.length > 0) {
+      throw new Error(
+        "[ProfilesManager] bootstrapLegacyProfile: profiles already exist"
+      );
+    }
+    const trimmed = typeof name === "string" ? name.trim() : "";
+    if (!trimmed) {
+      throw new Error("[ProfilesManager] Profile name is required");
+    }
+    const id = crypto.randomUUID();
+    const profile = this.#buildRecord(id, LEGACY_PARTITION, trimmed, {
+      avatarInitials: "MA",
+    });
+    state.list.push(profile);
+    state.activeId = id;
+    this.#write(state);
+    this.#emitter.emit("add", profile);
+    return profile;
+  }
+
+  #buildRecord(id, partition, name, record) {
+    return {
       id,
       name,
-      partition: `${PARTITION_PREFIX}${id}`,
+      partition,
       avatarColor:
         typeof record.avatarColor === "string"
           ? record.avatarColor
@@ -114,12 +167,6 @@ class ProfilesManager {
       pinned: !!record.pinned,
       ...(typeof record.url === "string" && record.url ? { url: record.url } : {}),
     };
-
-    const state = this.#read();
-    state.list.push(profile);
-    if (!state.activeId) state.activeId = id;
-    this.#write(state);
-    return profile;
   }
 
   update(id, patch) {
@@ -151,6 +198,7 @@ class ProfilesManager {
     if (Object.hasOwn(p, "url")) this.#applyUrl(next, p.url);
     state.list[idx] = next;
     this.#write(state);
+    this.#emitter.emit("update", next);
     return next;
   }
 
@@ -182,7 +230,9 @@ class ProfilesManager {
       state.activeId = state.list[0]?.id || null;
     }
     this.#write(state);
-    return { removedId: id, activeId: state.activeId };
+    const result = { removedId: id, activeId: state.activeId };
+    this.#emitter.emit("remove", result);
+    return result;
   }
 
   #read() {

--- a/tests/e2e/helpers/electronApp.js
+++ b/tests/e2e/helpers/electronApp.js
@@ -1,0 +1,143 @@
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Shared scaffolding for the multi-account E2E specs (and any future
+// flag-toggle test). Keeps the launch/discover/cleanup boilerplate in
+// one place so each spec can stay focused on its assertions.
+
+const TEAMS_HOSTNAMES = [
+  'teams.cloud.microsoft',
+  'teams.microsoft.com',
+  'teams.live.com',
+  'login.microsoftonline.com',
+];
+
+export const PROFILE_IPC_CHANNELS = [
+  'profile-list',
+  'profile-get-active',
+  'profile-switch',
+  'profile-add',
+  'profile-update',
+  'profile-remove',
+];
+
+/**
+ * Launch the app with an isolated userData dir and the supplied config.
+ * `E2E_TESTING=true` is set so `electronApp.evaluate` UtilityScript can
+ * run (the main window otherwise blocks `globalThis.eval`).
+ *
+ * @param {{ prefix: string, config?: object }} options
+ * @returns {Promise<{ electronApp: import('playwright').ElectronApplication, userDataDir: string }>}
+ */
+export async function startApp({ prefix, config }) {
+  const userDataDir = mkdtempSync(join(tmpdir(), prefix));
+  if (config) {
+    writeFileSync(join(userDataDir, 'config.json'), JSON.stringify(config));
+  }
+  const electronApp = await electron.launch({
+    args: [
+      './app/index.js',
+      ...(process.env.CI ? ['--no-sandbox'] : []),
+    ],
+    env: {
+      ...process.env,
+      E2E_USER_DATA_DIR: userDataDir,
+      E2E_TESTING: 'true',
+    },
+    timeout: 30000,
+  });
+  await electronApp.firstWindow({ timeout: 30000 });
+  // Give the app a moment to create all windows and start loading.
+  await new Promise((resolve) => setTimeout(resolve, 4000));
+  return { electronApp, userDataDir };
+}
+
+/**
+ * Find the main Teams window in an electronApp by hostname match. Returns
+ * undefined if no window has navigated to a Teams or Microsoft login URL.
+ */
+export function findMainTeamsWindow(electronApp) {
+  return electronApp.windows().find((w) => {
+    const url = w.url();
+    try {
+      return TEAMS_HOSTNAMES.includes(new URL(url).hostname);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Wait until the main window has redirected to login.microsoftonline.com.
+ * Mirrors the assertion every multi-account spec needs.
+ */
+export async function waitForLoginRedirect(mainWindow) {
+  await mainWindow.waitForLoadState('load', { timeout: 30000 });
+  await mainWindow.waitForURL(
+    (url) => {
+      try {
+        return new URL(url).hostname === 'login.microsoftonline.com';
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 30000 }
+  );
+}
+
+/**
+ * Probe whether the supplied IPC channels have a registered
+ * `ipcMain.handle` handler. Returns `{ [channel]: boolean }` or
+ * `{ error }` if introspection failed (e.g. Electron rename of the
+ * internal map).
+ */
+export async function getRegisteredHandlers(electronApp, channels) {
+  return await electronApp.evaluate(
+    ({ ipcMain }, channelList) => {
+      const map = ipcMain._invokeHandlers;
+      if (!map || typeof map.has !== 'function') {
+        return { error: 'unable to introspect ipcMain._invokeHandlers' };
+      }
+      return Object.fromEntries(channelList.map((c) => [c, map.has(c)]));
+    },
+    channels
+  );
+}
+
+/**
+ * Best-effort shutdown of the electronApp + temp userData dir. Mirrors
+ * the cleanup pattern used by `tests/e2e/smoke.spec.js`: graceful close
+ * with a 5-second timeout, then SIGKILL fallback, then rmSync.
+ */
+export async function closeAndCleanup({ electronApp, userDataDir }) {
+  if (electronApp) {
+    try {
+      const closePromise = electronApp.close();
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Close timeout')), 5000)
+      );
+      await Promise.race([closePromise, timeoutPromise]);
+    } catch (error) {
+      console.debug('Process cleanup:', error.message);
+      try {
+        const pid = electronApp.process()?.pid;
+        if (pid) {
+          process.kill(pid, 'SIGKILL');
+        }
+      } catch {
+        // Ignore
+      }
+    }
+  }
+  if (userDataDir) {
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch (e) {
+      console.warn(
+        `Could not remove temp directory ${userDataDir}: ${e.message}`
+      );
+    }
+  }
+}

--- a/tests/e2e/helpers/electronApp.js
+++ b/tests/e2e/helpers/electronApp.js
@@ -25,27 +25,34 @@ export const PROFILE_IPC_CHANNELS = [
 
 /**
  * Launch the app with an isolated userData dir and the supplied config.
- * `E2E_TESTING=true` is set so `electronApp.evaluate` UtilityScript can
- * run (the main window otherwise blocks `globalThis.eval`).
  *
- * @param {{ prefix: string, config?: object }} options
+ * Pass `allowEval: true` only when the test needs `electronApp.evaluate`;
+ * it sets `E2E_TESTING=true`, which disables the main window's
+ * `globalThis.eval` defense (`browserWindowManager.js`). Default is
+ * `false` so a launch from this helper stays environmentally identical to
+ * a real user launch unless the test opts in.
+ *
+ * @param {{ prefix: string, config?: object, allowEval?: boolean }} options
  * @returns {Promise<{ electronApp: import('playwright').ElectronApplication, userDataDir: string }>}
  */
-export async function startApp({ prefix, config }) {
+export async function startApp({ prefix, config, allowEval = false }) {
   const userDataDir = mkdtempSync(join(tmpdir(), prefix));
   if (config) {
     writeFileSync(join(userDataDir, 'config.json'), JSON.stringify(config));
+  }
+  const env = {
+    ...process.env,
+    E2E_USER_DATA_DIR: userDataDir,
+  };
+  if (allowEval) {
+    env.E2E_TESTING = 'true';
   }
   const electronApp = await electron.launch({
     args: [
       './app/index.js',
       ...(process.env.CI ? ['--no-sandbox'] : []),
     ],
-    env: {
-      ...process.env,
-      E2E_USER_DATA_DIR: userDataDir,
-      E2E_TESTING: 'true',
-    },
+    env,
     timeout: 30000,
   });
   await electronApp.firstWindow({ timeout: 30000 });

--- a/tests/e2e/helpers/electronApp.js
+++ b/tests/e2e/helpers/electronApp.js
@@ -7,12 +7,12 @@ import { join } from 'node:path';
 // flag-toggle test). Keeps the launch/discover/cleanup boilerplate in
 // one place so each spec can stay focused on its assertions.
 
-const TEAMS_HOSTNAMES = [
+const TEAMS_HOSTNAMES = new Set([
   'teams.cloud.microsoft',
   'teams.microsoft.com',
   'teams.live.com',
   'login.microsoftonline.com',
-];
+]);
 
 export const PROFILE_IPC_CHANNELS = [
   'profile-list',
@@ -69,7 +69,7 @@ export function findMainTeamsWindow(electronApp) {
   return electronApp.windows().find((w) => {
     const url = w.url();
     try {
-      return TEAMS_HOSTNAMES.includes(new URL(url).hostname);
+      return TEAMS_HOSTNAMES.has(new URL(url).hostname);
     } catch {
       return false;
     }

--- a/tests/e2e/multi-account-disabled.spec.js
+++ b/tests/e2e/multi-account-disabled.spec.js
@@ -1,8 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { _electron as electron } from 'playwright';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import {
+  startApp,
+  findMainTeamsWindow,
+  waitForLoginRedirect,
+  getRegisteredHandlers,
+  closeAndCleanup,
+  PROFILE_IPC_CHANNELS,
+} from './helpers/electronApp.js';
 
 // Phase 1c.1 regression test for ADR-020's core invariant: when
 // `multiAccount.enabled === false`, the app's behavior is byte-identical
@@ -14,131 +18,34 @@ import { join } from 'node:path';
 //      renderer attempting to invoke them gets "no handler" — proving the
 //      multi-account code paths are inert with the flag off.
 test('multi-account disabled = byte-identical launch (no profile-* IPC handlers)', async () => {
-  let electronApp;
-  let userDataDir;
+  // Explicitly set the flag to false (rather than relying on the default)
+  // so this test fails loudly if the default ever changes — that itself
+  // would be a regression worth flagging.
+  const ctx = await startApp({
+    prefix: 'teams-e2e-disabled-',
+    config: { multiAccount: { enabled: false } },
+  });
 
   try {
-    userDataDir = mkdtempSync(join(tmpdir(), 'teams-e2e-disabled-'));
+    expect(ctx.electronApp.windows().length).toBeGreaterThan(0);
 
-    // Explicitly set `multiAccount.enabled: false` (rather than relying
-    // on the default) so this test fails loudly if the default ever
-    // changes — that would itself be a regression to flag.
-    writeFileSync(
-      join(userDataDir, 'config.json'),
-      JSON.stringify({ multiAccount: { enabled: false } })
-    );
-
-    electronApp = await electron.launch({
-      args: [
-        './app/index.js',
-        ...(process.env.CI ? ['--no-sandbox'] : []),
-      ],
-      env: {
-        ...process.env,
-        E2E_USER_DATA_DIR: userDataDir,
-        // Allow Playwright's `electronApp.evaluate` UtilityScript to run.
-        // The main window normally disables `globalThis.eval` for defense
-        // in depth (browserWindowManager.js); E2E_TESTING flips that off so
-        // we can introspect ipcMain registration from this test.
-        E2E_TESTING: 'true',
-      },
-      timeout: 30000,
-    });
-
-    await electronApp.firstWindow({ timeout: 30000 });
-    await new Promise((resolve) => setTimeout(resolve, 4000));
-
-    const windows = electronApp.windows();
-    expect(windows.length).toBeGreaterThan(0);
-
-    const mainWindow = windows.find((w) => {
-      const url = w.url();
-      try {
-        const hostname = new URL(url).hostname;
-        return (
-          hostname === 'teams.cloud.microsoft' ||
-          hostname === 'teams.microsoft.com' ||
-          hostname === 'teams.live.com' ||
-          hostname === 'login.microsoftonline.com'
-        );
-      } catch {
-        return false;
-      }
-    });
-
+    const mainWindow = findMainTeamsWindow(ctx.electronApp);
     expect(mainWindow).toBeTruthy();
+    await waitForLoginRedirect(mainWindow);
 
-    await mainWindow.waitForLoadState('load', { timeout: 30000 });
-    await mainWindow.waitForURL(
-      (url) => {
-        try {
-          return new URL(url).hostname === 'login.microsoftonline.com';
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 30000 }
-    );
-
-    // Confirm none of the profile-* IPC handlers are registered. The
-    // ProfilesManager only calls `ipcMain.handle` when the flag is on;
-    // with it off, these channels stay allowlisted (so the validator
-    // doesn't block them) but no handler answers them.
-    //
-    // `_invokeHandlers` is Electron's internal Map for `ipcMain.handle`
-    // registrations — used here intentionally rather than attempting an
-    // invoke from the renderer (the page is on login.microsoftonline.com
-    // by this point and has no preload-exposed IPC surface to use).
-    const profileChannels = [
-      'profile-list',
-      'profile-get-active',
-      'profile-switch',
-      'profile-add',
-      'profile-update',
-      'profile-remove',
-    ];
-    const registered = await electronApp.evaluate(
-      ({ ipcMain }, channels) => {
-        const map = ipcMain._invokeHandlers;
-        if (!map || typeof map.has !== 'function') {
-          return { error: 'unable to introspect ipcMain._invokeHandlers' };
-        }
-        return Object.fromEntries(channels.map((c) => [c, map.has(c)]));
-      },
-      profileChannels
+    const registered = await getRegisteredHandlers(
+      ctx.electronApp,
+      PROFILE_IPC_CHANNELS
     );
 
     expect(registered).not.toHaveProperty('error');
-    for (const channel of profileChannels) {
-      expect(registered[channel], `expected ${channel} handler to be absent when multiAccount.enabled is false`).toBe(false);
+    for (const channel of PROFILE_IPC_CHANNELS) {
+      expect(
+        registered[channel],
+        `expected ${channel} handler to be absent when multiAccount.enabled is false`
+      ).toBe(false);
     }
   } finally {
-    if (electronApp) {
-      try {
-        const closePromise = electronApp.close();
-        const timeoutPromise = new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Close timeout')), 5000)
-        );
-        await Promise.race([closePromise, timeoutPromise]);
-      } catch (error) {
-        console.debug('Process cleanup:', error.message);
-        try {
-          const pid = electronApp.process()?.pid;
-          if (pid) {
-            process.kill(pid, 'SIGKILL');
-          }
-        } catch {
-          // Ignore
-        }
-      }
-    }
-
-    if (userDataDir) {
-      try {
-        rmSync(userDataDir, { recursive: true, force: true });
-      } catch (e) {
-        console.warn(`Could not remove temp directory ${userDataDir}: ${e.message}`);
-      }
-    }
+    await closeAndCleanup(ctx);
   }
 });

--- a/tests/e2e/multi-account-disabled.spec.js
+++ b/tests/e2e/multi-account-disabled.spec.js
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test';
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Phase 1c.1 regression test for ADR-020's core invariant: when
+// `multiAccount.enabled === false`, the app's behavior is byte-identical
+// to pre-feature single-profile operation.
+//
+// We assert two things on top of the existing smoke flow:
+//   1. The main window still loads and redirects to Microsoft login.
+//   2. None of the six `profile-*` IPC handlers are registered, so a
+//      renderer attempting to invoke them gets "no handler" — proving the
+//      multi-account code paths are inert with the flag off.
+test('multi-account disabled = byte-identical launch (no profile-* IPC handlers)', async () => {
+  let electronApp;
+  let userDataDir;
+
+  try {
+    userDataDir = mkdtempSync(join(tmpdir(), 'teams-e2e-disabled-'));
+
+    // Explicitly set `multiAccount.enabled: false` (rather than relying
+    // on the default) so this test fails loudly if the default ever
+    // changes — that would itself be a regression to flag.
+    writeFileSync(
+      join(userDataDir, 'config.json'),
+      JSON.stringify({ multiAccount: { enabled: false } })
+    );
+
+    electronApp = await electron.launch({
+      args: [
+        './app/index.js',
+        ...(process.env.CI ? ['--no-sandbox'] : []),
+      ],
+      env: {
+        ...process.env,
+        E2E_USER_DATA_DIR: userDataDir,
+        // Allow Playwright's `electronApp.evaluate` UtilityScript to run.
+        // The main window normally disables `globalThis.eval` for defense
+        // in depth (browserWindowManager.js); E2E_TESTING flips that off so
+        // we can introspect ipcMain registration from this test.
+        E2E_TESTING: 'true',
+      },
+      timeout: 30000,
+    });
+
+    await electronApp.firstWindow({ timeout: 30000 });
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+
+    const windows = electronApp.windows();
+    expect(windows.length).toBeGreaterThan(0);
+
+    const mainWindow = windows.find((w) => {
+      const url = w.url();
+      try {
+        const hostname = new URL(url).hostname;
+        return (
+          hostname === 'teams.cloud.microsoft' ||
+          hostname === 'teams.microsoft.com' ||
+          hostname === 'teams.live.com' ||
+          hostname === 'login.microsoftonline.com'
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    expect(mainWindow).toBeTruthy();
+
+    await mainWindow.waitForLoadState('load', { timeout: 30000 });
+    await mainWindow.waitForURL(
+      (url) => {
+        try {
+          return new URL(url).hostname === 'login.microsoftonline.com';
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30000 }
+    );
+
+    // Confirm none of the profile-* IPC handlers are registered. The
+    // ProfilesManager only calls `ipcMain.handle` when the flag is on;
+    // with it off, these channels stay allowlisted (so the validator
+    // doesn't block them) but no handler answers them.
+    //
+    // `_invokeHandlers` is Electron's internal Map for `ipcMain.handle`
+    // registrations — used here intentionally rather than attempting an
+    // invoke from the renderer (the page is on login.microsoftonline.com
+    // by this point and has no preload-exposed IPC surface to use).
+    const profileChannels = [
+      'profile-list',
+      'profile-get-active',
+      'profile-switch',
+      'profile-add',
+      'profile-update',
+      'profile-remove',
+    ];
+    const registered = await electronApp.evaluate(
+      ({ ipcMain }, channels) => {
+        const map = ipcMain._invokeHandlers;
+        if (!map || typeof map.has !== 'function') {
+          return { error: 'unable to introspect ipcMain._invokeHandlers' };
+        }
+        return Object.fromEntries(channels.map((c) => [c, map.has(c)]));
+      },
+      profileChannels
+    );
+
+    expect(registered).not.toHaveProperty('error');
+    for (const channel of profileChannels) {
+      expect(registered[channel], `expected ${channel} handler to be absent when multiAccount.enabled is false`).toBe(false);
+    }
+  } finally {
+    if (electronApp) {
+      try {
+        const closePromise = electronApp.close();
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('Close timeout')), 5000)
+        );
+        await Promise.race([closePromise, timeoutPromise]);
+      } catch (error) {
+        console.debug('Process cleanup:', error.message);
+        try {
+          const pid = electronApp.process()?.pid;
+          if (pid) {
+            process.kill(pid, 'SIGKILL');
+          }
+        } catch {
+          // Ignore
+        }
+      }
+    }
+
+    if (userDataDir) {
+      try {
+        rmSync(userDataDir, { recursive: true, force: true });
+      } catch (e) {
+        console.warn(`Could not remove temp directory ${userDataDir}: ${e.message}`);
+      }
+    }
+  }
+});

--- a/tests/e2e/multi-account-disabled.spec.js
+++ b/tests/e2e/multi-account-disabled.spec.js
@@ -24,6 +24,8 @@ test('multi-account disabled = byte-identical launch (no profile-* IPC handlers)
   const ctx = await startApp({
     prefix: 'teams-e2e-disabled-',
     config: { multiAccount: { enabled: false } },
+    // Need `electronApp.evaluate` to introspect ipcMain._invokeHandlers.
+    allowEval: true,
   });
 
   try {

--- a/tests/e2e/multi-account-enabled.spec.js
+++ b/tests/e2e/multi-account-enabled.spec.js
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Phase 1c.1 regression test for the flag-on path: with no profiles yet
+// configured, the app must reach Microsoft login the same way it does
+// with the flag off. This catches the case where ProfileViewManager
+// initialization or the bootstrap check breaks the startup sequence.
+test('multi-account enabled, no profiles yet = same redirect to Microsoft login', async () => {
+  let electronApp;
+  let userDataDir;
+
+  try {
+    userDataDir = mkdtempSync(join(tmpdir(), 'teams-e2e-enabled-'));
+    writeFileSync(
+      join(userDataDir, 'config.json'),
+      JSON.stringify({ multiAccount: { enabled: true } })
+    );
+
+    electronApp = await electron.launch({
+      args: [
+        './app/index.js',
+        ...(process.env.CI ? ['--no-sandbox'] : []),
+      ],
+      env: {
+        ...process.env,
+        E2E_USER_DATA_DIR: userDataDir,
+        E2E_TESTING: 'true',
+      },
+      timeout: 30000,
+    });
+
+    await electronApp.firstWindow({ timeout: 30000 });
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+
+    const windows = electronApp.windows();
+    expect(windows.length).toBeGreaterThan(0);
+
+    const mainWindow = windows.find((w) => {
+      const url = w.url();
+      try {
+        const hostname = new URL(url).hostname;
+        return (
+          hostname === 'teams.cloud.microsoft' ||
+          hostname === 'teams.microsoft.com' ||
+          hostname === 'teams.live.com' ||
+          hostname === 'login.microsoftonline.com'
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    expect(mainWindow).toBeTruthy();
+
+    await mainWindow.waitForLoadState('load', { timeout: 30000 });
+    await mainWindow.waitForURL(
+      (url) => {
+        try {
+          return new URL(url).hostname === 'login.microsoftonline.com';
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30000 }
+    );
+
+    // With the flag on, the six profile-* handlers SHOULD be registered
+    // (the multi-account IPC surface is live).
+    const profileChannels = [
+      'profile-list',
+      'profile-get-active',
+      'profile-switch',
+      'profile-add',
+      'profile-update',
+      'profile-remove',
+    ];
+    const registered = await electronApp.evaluate(
+      ({ ipcMain }, channels) => {
+        const map = ipcMain._invokeHandlers;
+        if (!map || typeof map.has !== 'function') {
+          return { error: 'unable to introspect ipcMain._invokeHandlers' };
+        }
+        return Object.fromEntries(channels.map((c) => [c, map.has(c)]));
+      },
+      profileChannels
+    );
+
+    expect(registered).not.toHaveProperty('error');
+    for (const channel of profileChannels) {
+      expect(registered[channel], `expected ${channel} handler to be present when multiAccount.enabled is true`).toBe(true);
+    }
+
+    // With no prior cookies on persist:teams-4-linux, the bootstrap heuristic
+    // should skip — `app.profiles` stays empty.
+    const profilesEmpty = await electronApp.evaluate(({ ipcMain }) => {
+      // ipcMain.invoke isn't a real thing; emulate by reaching into the
+      // registered handler. Test-only introspection.
+      const map = ipcMain._invokeHandlers;
+      const handler = map?.get?.('profile-list');
+      if (!handler) return { error: 'profile-list handler missing' };
+      return handler({}, []).then((list) => ({ list }));
+    });
+    expect(profilesEmpty).toHaveProperty('list');
+    expect(profilesEmpty.list).toEqual([]);
+  } finally {
+    if (electronApp) {
+      try {
+        const closePromise = electronApp.close();
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('Close timeout')), 5000)
+        );
+        await Promise.race([closePromise, timeoutPromise]);
+      } catch (error) {
+        console.debug('Process cleanup:', error.message);
+        try {
+          const pid = electronApp.process()?.pid;
+          if (pid) {
+            process.kill(pid, 'SIGKILL');
+          }
+        } catch {
+          // Ignore
+        }
+      }
+    }
+
+    if (userDataDir) {
+      try {
+        rmSync(userDataDir, { recursive: true, force: true });
+      } catch (e) {
+        console.warn(`Could not remove temp directory ${userDataDir}: ${e.message}`);
+      }
+    }
+  }
+});

--- a/tests/e2e/multi-account-enabled.spec.js
+++ b/tests/e2e/multi-account-enabled.spec.js
@@ -16,6 +16,9 @@ test('multi-account enabled, no profiles yet = same redirect to Microsoft login'
   const ctx = await startApp({
     prefix: 'teams-e2e-enabled-',
     config: { multiAccount: { enabled: true } },
+    // Need `electronApp.evaluate` to introspect ipcMain._invokeHandlers
+    // and to call the profile-list handler directly.
+    allowEval: true,
   });
 
   try {

--- a/tests/e2e/multi-account-enabled.spec.js
+++ b/tests/e2e/multi-account-enabled.spec.js
@@ -1,137 +1,54 @@
 import { test, expect } from '@playwright/test';
-import { _electron as electron } from 'playwright';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import {
+  startApp,
+  findMainTeamsWindow,
+  waitForLoginRedirect,
+  getRegisteredHandlers,
+  closeAndCleanup,
+  PROFILE_IPC_CHANNELS,
+} from './helpers/electronApp.js';
 
 // Phase 1c.1 regression test for the flag-on path: with no profiles yet
 // configured, the app must reach Microsoft login the same way it does
 // with the flag off. This catches the case where ProfileViewManager
 // initialization or the bootstrap check breaks the startup sequence.
 test('multi-account enabled, no profiles yet = same redirect to Microsoft login', async () => {
-  let electronApp;
-  let userDataDir;
+  const ctx = await startApp({
+    prefix: 'teams-e2e-enabled-',
+    config: { multiAccount: { enabled: true } },
+  });
 
   try {
-    userDataDir = mkdtempSync(join(tmpdir(), 'teams-e2e-enabled-'));
-    writeFileSync(
-      join(userDataDir, 'config.json'),
-      JSON.stringify({ multiAccount: { enabled: true } })
-    );
+    expect(ctx.electronApp.windows().length).toBeGreaterThan(0);
 
-    electronApp = await electron.launch({
-      args: [
-        './app/index.js',
-        ...(process.env.CI ? ['--no-sandbox'] : []),
-      ],
-      env: {
-        ...process.env,
-        E2E_USER_DATA_DIR: userDataDir,
-        E2E_TESTING: 'true',
-      },
-      timeout: 30000,
-    });
-
-    await electronApp.firstWindow({ timeout: 30000 });
-    await new Promise((resolve) => setTimeout(resolve, 4000));
-
-    const windows = electronApp.windows();
-    expect(windows.length).toBeGreaterThan(0);
-
-    const mainWindow = windows.find((w) => {
-      const url = w.url();
-      try {
-        const hostname = new URL(url).hostname;
-        return (
-          hostname === 'teams.cloud.microsoft' ||
-          hostname === 'teams.microsoft.com' ||
-          hostname === 'teams.live.com' ||
-          hostname === 'login.microsoftonline.com'
-        );
-      } catch {
-        return false;
-      }
-    });
-
+    const mainWindow = findMainTeamsWindow(ctx.electronApp);
     expect(mainWindow).toBeTruthy();
+    await waitForLoginRedirect(mainWindow);
 
-    await mainWindow.waitForLoadState('load', { timeout: 30000 });
-    await mainWindow.waitForURL(
-      (url) => {
-        try {
-          return new URL(url).hostname === 'login.microsoftonline.com';
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 30000 }
+    // With the flag on, all six profile-* handlers should be registered.
+    const registered = await getRegisteredHandlers(
+      ctx.electronApp,
+      PROFILE_IPC_CHANNELS
     );
-
-    // With the flag on, the six profile-* handlers SHOULD be registered
-    // (the multi-account IPC surface is live).
-    const profileChannels = [
-      'profile-list',
-      'profile-get-active',
-      'profile-switch',
-      'profile-add',
-      'profile-update',
-      'profile-remove',
-    ];
-    const registered = await electronApp.evaluate(
-      ({ ipcMain }, channels) => {
-        const map = ipcMain._invokeHandlers;
-        if (!map || typeof map.has !== 'function') {
-          return { error: 'unable to introspect ipcMain._invokeHandlers' };
-        }
-        return Object.fromEntries(channels.map((c) => [c, map.has(c)]));
-      },
-      profileChannels
-    );
-
     expect(registered).not.toHaveProperty('error');
-    for (const channel of profileChannels) {
-      expect(registered[channel], `expected ${channel} handler to be present when multiAccount.enabled is true`).toBe(true);
+    for (const channel of PROFILE_IPC_CHANNELS) {
+      expect(
+        registered[channel],
+        `expected ${channel} handler to be present when multiAccount.enabled is true`
+      ).toBe(true);
     }
 
-    // With no prior cookies on persist:teams-4-linux, the bootstrap heuristic
-    // should skip — `app.profiles` stays empty.
-    const profilesEmpty = await electronApp.evaluate(({ ipcMain }) => {
-      // ipcMain.invoke isn't a real thing; emulate by reaching into the
-      // registered handler. Test-only introspection.
+    // With no prior cookies on persist:teams-4-linux, the bootstrap
+    // heuristic should skip — `app.profiles` stays empty.
+    const profiles = await ctx.electronApp.evaluate(({ ipcMain }) => {
       const map = ipcMain._invokeHandlers;
       const handler = map?.get?.('profile-list');
       if (!handler) return { error: 'profile-list handler missing' };
       return handler({}, []).then((list) => ({ list }));
     });
-    expect(profilesEmpty).toHaveProperty('list');
-    expect(profilesEmpty.list).toEqual([]);
+    expect(profiles).toHaveProperty('list');
+    expect(profiles.list).toEqual([]);
   } finally {
-    if (electronApp) {
-      try {
-        const closePromise = electronApp.close();
-        const timeoutPromise = new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Close timeout')), 5000)
-        );
-        await Promise.race([closePromise, timeoutPromise]);
-      } catch (error) {
-        console.debug('Process cleanup:', error.message);
-        try {
-          const pid = electronApp.process()?.pid;
-          if (pid) {
-            process.kill(pid, 'SIGKILL');
-          }
-        } catch {
-          // Ignore
-        }
-      }
-    }
-
-    if (userDataDir) {
-      try {
-        rmSync(userDataDir, { recursive: true, force: true });
-      } catch (e) {
-        console.warn(`Could not remove temp directory ${userDataDir}: ${e.message}`);
-      }
-    }
+    await closeAndCleanup(ctx);
   }
 });

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,110 +1,27 @@
 import { test, expect } from '@playwright/test';
-import { _electron as electron } from 'playwright';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import {
+  startApp,
+  findMainTeamsWindow,
+  waitForLoginRedirect,
+  closeAndCleanup,
+} from './helpers/electronApp.js';
 
 test('app launches and redirects to Microsoft login', async () => {
-  let electronApp;
-  let userDataDir;
+  const ctx = await startApp({ prefix: 'teams-e2e-' });
 
   try {
-    // Create a temporary userData directory for this test run (ensures clean state)
-    userDataDir = mkdtempSync(join(tmpdir(), 'teams-e2e-'));
+    expect(ctx.electronApp.windows().length).toBeGreaterThan(0);
 
-    electronApp = await electron.launch({
-      args: [
-        './app/index.js',
-        // Disable sandbox in CI environments (required for GitHub Actions)
-        ...(process.env.CI ? ['--no-sandbox'] : [])
-      ],
-      env: {
-        ...process.env,
-        E2E_USER_DATA_DIR: userDataDir
-      },
-      timeout: 30000
-    });
-
-    // Wait for windows to be created
-    await electronApp.firstWindow({ timeout: 30000 });
-
-    // Give the app a moment to create all windows and start loading
-    await new Promise(resolve => setTimeout(resolve, 4000));
-
-    // Get all windows and find the main Teams window
-    const windows = electronApp.windows();
-    expect(windows.length).toBeGreaterThan(0);
-
-    // Find the main window (not the toast window)
-    const mainWindow = windows.find(w => {
-      const url = w.url();
-      try {
-        const hostname = new URL(url).hostname;
-        return hostname === 'teams.cloud.microsoft' ||
-               hostname === 'teams.microsoft.com' ||
-               hostname === 'teams.live.com' ||
-               hostname === 'login.microsoftonline.com';
-      } catch (error) {
-        // Invalid URL format, skip this window
-        console.debug('Invalid URL in window:', url, error.message);
-        return false;
-      }
-    });
-
+    const mainWindow = findMainTeamsWindow(ctx.electronApp);
     expect(mainWindow).toBeTruthy();
 
-    // Wait for the initial page load
-    await mainWindow.waitForLoadState('load', { timeout: 30000 });
+    await waitForLoginRedirect(mainWindow);
 
-    // Since we're starting with a clean state, the app will redirect to login
-    // Wait for the redirect to Microsoft login page
-    await mainWindow.waitForURL(url => {
-      try {
-        return new URL(url).hostname === 'login.microsoftonline.com';
-      } catch {
-        return false;
-      }
-    }, { timeout: 30000 });
-
-    // Verify we reached the login page
-    const url = mainWindow.url();
-    expect(new URL(url).hostname).toBe('login.microsoftonline.com');
+    expect(new URL(mainWindow.url()).hostname).toBe('login.microsoftonline.com');
 
     // Wait for the login page to be fully loaded
     await mainWindow.waitForLoadState('networkidle', { timeout: 30000 });
-
   } finally {
-    // Gracefully close the app if it exists
-    if (electronApp) {
-      try {
-        // Use a timeout for close to avoid hanging
-        const closePromise = electronApp.close();
-        const timeoutPromise = new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Close timeout')), 5000)
-        );
-        await Promise.race([closePromise, timeoutPromise]);
-      } catch (error) {
-        // Process may have already exited or timed out, force kill
-        console.debug('Process cleanup:', error.message);
-        try {
-          const pid = electronApp.process()?.pid;
-          if (pid) {
-            process.kill(pid, 'SIGKILL');
-          }
-        } catch {
-          // Ignore kill errors
-        }
-      }
-    }
-
-    // Clean up the temporary userData directory
-    if (userDataDir) {
-      try {
-        rmSync(userDataDir, { recursive: true, force: true });
-      } catch (e) {
-        // Ignore cleanup errors (may still be in use on some systems)
-        console.warn(`Could not remove temp directory ${userDataDir}: ${e.message}`);
-      }
-    }
+    await closeAndCleanup(ctx);
   }
 });


### PR DESCRIPTION
## Summary

Phase 1c.1 of ADR-020. #2450 shipped the `multiAccount.enabled` flag and the Intune mutex; #2478 shipped the `ProfilesManager` data surface. This PR adds the runtime view layer on top so the flag can actually host more than one tenant once the switcher UI lands. Behavior with `multiAccount.enabled === false` stays byte-identical, asserted by a new E2E regression test.

- **`ProfilesManager` gains an in-process `EventEmitter`** so main-side consumers can react to `add` / `update` / `switch` / `remove` without polling, plus a main-process-only `bootstrapLegacyProfile()` that creates Profile 0 against the existing `persist:teams-4-linux` partition (so the user's login survives the first flag flip). Bootstrap is not exposed via IPC — a renderer being able to point a profile at an arbitrary partition string would let it hijack any session.

- **New `app/mainAppWindow/profileViewManager.js` module** owns the per-profile `WebContentsView` overlays. The architectural call here is to **keep the root window's `webContents` AS Profile 0** — it already runs on the legacy partition, so reusing it costs no extra Teams instance, leaves the existing auth-recovery and `msteams://` deep-link flows on `window.webContents` untouched, and lets non-Profile-0 profiles render as `WebContentsView` overlays only when they're active. Switching to Profile 0 hides every overlay; switching to Profile N attaches that view. Mirrors the `app/screenSharing/index.js` `WebContentsView` lifecycle pattern.

- **First-run bootstrap** fires only when (a) the flag is on, (b) `app.profiles` is empty, and (c) the legacy partition has cookies. Cookies-only is a strict subset of ADR-020's "cookies or localStorage" condition — covers every realistic warm-Teams session in one async call, with the worst-case false-negative being a single re-login on first flag flip. Logged at `console.info` when fired, `console.debug` when skipped.

- **Two new E2E specs** lock in the invariants:
  - `tests/e2e/multi-account-disabled.spec.js`: confirms no `profile-*` IPC handlers register when the flag is off, and the app reaches Microsoft login the same way it does today.
  - `tests/e2e/multi-account-enabled.spec.js`: confirms the six handlers register when the flag is on, and that `profile-list` returns empty on first launch (no cookies → bootstrap correctly skipped).

The byte-identical-when-disabled invariant is asserted by introspecting `ipcMain._invokeHandlers` (set when `ProfilesManager.initialize()` runs, which only happens when the flag is on).

## What this PR does NOT do

- No switcher UI, no Profiles menu entry, no `Ctrl+Shift+1…5` shortcuts — those land in Phase 1c.2 alongside the renderer dialogs.
- No screen-preview-partition swap, no `CustomBackground` instance refactor — those are Phase 1c.3 cleanups.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:e2e` — 12/12 passing (10 existing + 2 new)
- [x] Manual: flag off → identical to today, no `app.profiles` written
- [x] Manual: flag on, no prior cookies → app reaches Microsoft login normally; bootstrap correctly skipped (no `app.profiles` written)
- [x] Manual: flag on, after a prior login → bootstrap fires, Profile 0 created with `partition: persist:teams-4-linux`, `name: "My account"`; **no re-login** required

Refs ADR-020 § "First-run bootstrap" and § "Decision".