### PR TITLE
fix(auth): cover MCAS proxy suffix in cookie-domain matching

### DIFF
--- a/app/browser/tools/reactHandler.js
+++ b/app/browser/tools/reactHandler.js
@@ -296,8 +296,9 @@ class ReactHandler {
     ];
 
     // Handle Microsoft Cloud App Security (MCAS) suffix. eg: teams.cloud.microsoft.mcas.ms
-    if(hostname.endsWith('.mcas.ms')){
-      hostname = hostname.slice(0, -8);
+    const MCAS_SUFFIX = '.mcas.ms';
+    if (hostname.endsWith(MCAS_SUFFIX)) {
+      hostname = hostname.slice(0, -MCAS_SUFFIX.length);
     }
     
     for (const domain of allowedDomains) {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -209,6 +209,19 @@ function createScreenSharePreviewWindow() {
   });
 }
 
+// Microsoft Cloud App Security proxy suffix. Tenants that route Teams
+// through Defender for Cloud Apps (MCAS) load and store cookies at
+// `*.mcas.ms` rather than the underlying Microsoft domain. Strip the
+// suffix before matching against AUTH_DOMAINS / TEAMS_DOMAINS so the
+// proxied flavour is treated the same as the canonical hostname.
+const MCAS_SUFFIX = '.mcas.ms';
+function stripMcasSuffix(hostname) {
+  if (typeof hostname === 'string' && hostname.endsWith(MCAS_SUFFIX)) {
+    return hostname.slice(0, -MCAS_SUFFIX.length);
+  }
+  return hostname;
+}
+
 // Microsoft auth domains whose cookies should be checked/cleaned
 const AUTH_DOMAINS = [
   'login.microsoftonline.com',
@@ -263,7 +276,7 @@ async function cleanExpiredAuthCookies(windowSession, forceCleanAll = false) {
     const nowSeconds = Date.now() / 1000;
 
     const authCookies = allCookies.filter(cookie => {
-      const domain = (cookie.domain || '').replace(/^\./, '');
+      const domain = stripMcasSuffix((cookie.domain || '').replace(/^\./, ''));
       const isAuthDomain = AUTH_DOMAINS.some(d => domain === d || domain.endsWith('.' + d));
       return isAuthDomain && AUTH_COOKIE_NAMES.has(cookie.name);
     });
@@ -735,10 +748,7 @@ const TEAMS_DOMAINS = [
  */
 function isTeamsDomain(url) {
   try {
-    let hostname = new URL(url).hostname;
-    if (hostname.endsWith('.mcas.ms')) {
-      hostname = hostname.slice(0, -8);
-    }
+    const hostname = stripMcasSuffix(new URL(url).hostname);
     return TEAMS_DOMAINS.some(d => hostname === d || hostname.endsWith('.' + d));
   } catch {
     return false;

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -216,10 +216,9 @@ function createScreenSharePreviewWindow() {
 // proxied flavour is treated the same as the canonical hostname.
 const MCAS_SUFFIX = '.mcas.ms';
 function stripMcasSuffix(hostname) {
-  if (typeof hostname === 'string' && hostname.endsWith(MCAS_SUFFIX)) {
-    return hostname.slice(0, -MCAS_SUFFIX.length);
-  }
-  return hostname;
+  return hostname.endsWith(MCAS_SUFFIX)
+    ? hostname.slice(0, -MCAS_SUFFIX.length)
+    : hostname;
 }
 
 // Microsoft auth domains whose cookies should be checked/cleaned


### PR DESCRIPTION
## Summary

- `AUTH_DOMAINS` only listed the canonical Microsoft hostnames, so `cleanExpiredAuthCookies` (and the recovery force-clean) skipped the actual Teams session cookies on tenants routed through Microsoft Defender for Cloud Apps (`teams.cloud.microsoft.mcas.ms`). On MCAS tenants the upstream `*.microsoftonline.com` cookies got cleaned but the proxy-side Teams session cookies stayed, which can leave the app in an odd partial-recovery state.
- Pulls the existing `.mcas.ms` strip out of `isTeamsDomain` into a small shared helper, and applies it in the cookie-cleanup filter too. Behaviour for non-MCAS tenants is unchanged (the helper is a no-op when the hostname does not end with `.mcas.ms`).

This is a speculative coverage fix rather than a confirmed root-cause fix for #2428. The reporter on that issue runs an MCAS tenant and may benefit from this once they share a fresh log; even if not, closing this gap is cheap and worth shipping.

Refs #2428 #1821

## Test plan

- [x] `npm run lint` clean
- [x] CI e2e (covered by Build & Release pipeline)
- [ ] Manual: confirm non-MCAS tenants see no behaviour change in cookie cleanup
- [ ] Optional: ask the #2428 reporter to test once they have a 2.9.0+ build

🤖 Generated with [Claude Code](https://claude.com/claude-code)