### PR TITLE
feat(multi-account): Profiles menu with Switch-to submenu

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -607,7 +607,7 @@ async function handleAppReady() {
 
     const customBackground = new CustomBackground(app, config);
     customBackground.initialize();
-    await mainAppWindow.onAppReady(appConfig, customBackground, screenSharingService);
+    await mainAppWindow.onAppReady(appConfig, customBackground, screenSharingService, profilesManager);
 
     // Phase 1c.1: wire per-profile WebContentsView lifecycle once the main
     // window exists. Bootstrap Profile 0 from the legacy partition so a

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -30,6 +30,9 @@ const DEFAULT_SCREEN_SHARING_THUMBNAIL_CONFIG = {
 let iconChooser;
 let intune;
 let isControlPressed = false;
+// Phase 1c.2: ProfilesManager handle threaded through onAppReady so the
+// Menus instance can build the Profiles submenu and react to its events.
+let profilesManagerRef = null;
 // Counter for tracking about:blank navigation attempts to handle authentication flows.
 // Teams sometimes navigates to about:blank during SSO/auth redirects, and we need to
 // intercept these and handle them in a hidden window to complete the auth process.
@@ -343,11 +346,12 @@ async function triggerAuthRecovery() {
   window.loadURL(config.url, { userAgent: config.chromeUserAgent });
 }
 
-exports.onAppReady = async function onAppReady(configGroup, customBackground, sharingService) {
+exports.onAppReady = async function onAppReady(configGroup, customBackground, sharingService, profilesManager = null) {
   appConfig = configGroup;
   config = configGroup.startupConfig;
   customBackgroundService = customBackground;
   screenSharingService = sharingService;
+  profilesManagerRef = profilesManager;
 
   // Support both new (auth.intune.*) and deprecated (ssoInTune*) config options
   const intuneEnabled = config.auth?.intune?.enabled || config.ssoInTuneEnabled;
@@ -427,7 +431,7 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   connectionManager = new ConnectionManager();
 
   if (iconChooser) {
-    menus = new Menus(window, configGroup, iconChooser.getFile(), connectionManager);
+    menus = new Menus(window, configGroup, iconChooser.getFile(), connectionManager, profilesManagerRef);
     menus.onSpellCheckerLanguageChanged = onSpellCheckerLanguageChanged;
   }
 

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -1,4 +1,5 @@
 const { shell } = require("electron");
+const buildProfilesMenu = require("./profilesMenu");
 
 exports = module.exports = (Menus) => ({
   label: "Teams for Linux",
@@ -64,6 +65,9 @@ exports = module.exports = (Menus) => ({
     getSettingsMenu(Menus),
     getPreferencesMenu(),
     getNotificationsMenu(Menus),
+    ...(Menus.configGroup.startupConfig.multiAccount?.enabled
+      ? [buildProfilesMenu(Menus)].filter(Boolean)
+      : []),
     {
       type: "separator",
     },

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -20,12 +20,14 @@ const autoUpdaterModule = require("../autoUpdater");
 let _Menus_onSpellCheckerLanguageChanged = new WeakMap();
 class Menus {
   #preJoinUrl = null;
+  #profileChangeHandler = null;
 
-  constructor(window, configGroup, iconPath, connectionManager) {
+  constructor(window, configGroup, iconPath, connectionManager, profilesManager = null) {
     this.window = window;
     this.iconPath = iconPath;
     this.configGroup = configGroup;
     this.connectionManager = connectionManager;
+    this.profilesManager = profilesManager;
     this.allowQuit = false;
     this.documentationWindow = new DocumentationWindow();
     this.gpuInfoWindow = new GpuInfoWindow();
@@ -143,6 +145,22 @@ class Menus {
 
     this.initializeEventHandlers();
 
+    // Phase 1c.2: rebuild the menu when ProfilesManager state changes
+    // (add/remove/switch/update) so the Profiles submenu and the active-
+    // profile checkmark stay in sync. Listener subscription is gated on
+    // the multi-account flag — with the flag off, ProfilesManager events
+    // would never fire and the Profiles submenu is not in the template.
+    if (
+      this.profilesManager &&
+      this.configGroup.startupConfig.multiAccount?.enabled
+    ) {
+      this.#profileChangeHandler = () => this.updateMenu();
+      this.profilesManager.on("add", this.#profileChangeHandler);
+      this.profilesManager.on("remove", this.#profileChangeHandler);
+      this.profilesManager.on("switch", this.#profileChangeHandler);
+      this.profilesManager.on("update", this.#profileChangeHandler);
+    }
+
     if (this.configGroup.startupConfig.trayIconEnabled) {
       this.tray = new Tray(
         this.window,
@@ -200,6 +218,36 @@ class Menus {
         message: "Settings file not found. Using default settings.",
         title: "Restore settings",
         type: "warning",
+      });
+    }
+  }
+
+  // Phase 1c.2 placeholder: real Add-profile dialog ships in a follow-up
+  // commit on this same branch. Surfacing a `dialog.showMessageBox` is
+  // the simplest honest signal until the real form lands; otherwise
+  // clicking the menu item would do nothing visible and leave the user
+  // wondering whether the click registered.
+  addProfile() {
+    dialog.showMessageBox(this.window, {
+      type: "info",
+      title: "Add profile",
+      message: "Add-profile dialog is coming next.",
+      detail:
+        "This menu entry is wired up; the form lands in a follow-up commit on this branch. Until then, profiles can only be created via the `profile-add` IPC channel.",
+    });
+  }
+
+  // Switch the active profile via ProfilesManager. The emitter then fires
+  // `switch` and the menu rebuilds via the listener wired in initialize().
+  // ProfileViewManager's own listener (in app/mainAppWindow/profileViewManager.js)
+  // handles the actual WebContentsView visibility swap.
+  switchProfile(id) {
+    try {
+      this.profilesManager.switch(id);
+    } catch (error) {
+      console.error("[Menus] switchProfile failed", {
+        id,
+        message: error.message,
       });
     }
   }

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -159,6 +159,22 @@ class Menus {
       this.profilesManager.on("remove", this.#profileChangeHandler);
       this.profilesManager.on("switch", this.#profileChangeHandler);
       this.profilesManager.on("update", this.#profileChangeHandler);
+
+      // Detach the listeners when the window is destroyed so the
+      // long-lived ProfilesManager (a process-wide singleton) does not
+      // hold references into a stale Menus instance if the window is
+      // ever recreated. `once` because the window is destroyed exactly
+      // once. Mirrors `ProfileViewManager.initialize`'s `mainWindow.once(
+      // 'closed', () => this.dispose())` pattern from PR #2483.
+      this.window.once("closed", () => {
+        if (this.#profileChangeHandler) {
+          this.profilesManager.off("add", this.#profileChangeHandler);
+          this.profilesManager.off("remove", this.#profileChangeHandler);
+          this.profilesManager.off("switch", this.#profileChangeHandler);
+          this.profilesManager.off("update", this.#profileChangeHandler);
+          this.#profileChangeHandler = null;
+        }
+      });
     }
 
     if (this.configGroup.startupConfig.trayIconEnabled) {

--- a/app/menus/profilesMenu.js
+++ b/app/menus/profilesMenu.js
@@ -1,0 +1,42 @@
+// Phase 1c.2 of ADR-020. Builds the "Profiles" submenu shown when
+// `multiAccount.enabled === true`. The Add-profile and Manage-profiles
+// dialogs are stubs in this PR; the click handlers in `app/menus/index.js`
+// surface a "coming next" message until the dialog modules land.
+//
+// Active profile gets a radio checkmark in the Switch-to list. When the
+// list is empty (flag freshly flipped on, before bootstrap or any add),
+// the submenu shows a disabled placeholder so Electron's platform-
+// specific empty-submenu rendering doesn't surface as a UX glitch.
+
+function buildProfilesMenu(menus) {
+  const pm = menus.profilesManager;
+  if (!pm) return null;
+
+  const list = pm.list();
+  const activeId = pm.getActive()?.id ?? null;
+
+  return {
+    label: "Profiles",
+    submenu: [
+      {
+        label: "Add profile…",
+        click: () => menus.addProfile(),
+      },
+      { type: "separator" },
+      {
+        label: "Switch to",
+        submenu:
+          list.length === 0
+            ? [{ label: "(no profiles configured)", enabled: false }]
+            : list.map((p) => ({
+                label: p.name,
+                type: "radio",
+                checked: p.id === activeId,
+                click: () => menus.switchProfile(p.id),
+              })),
+      },
+    ],
+  };
+}
+
+module.exports = buildProfilesMenu;


### PR DESCRIPTION
## Summary

First chunk of Phase 1c.2 (ADR-020). #2483 shipped the per-profile `WebContentsView` lifecycle and the first-run Profile 0 bootstrap; this PR layers a minimal in-app surface on top so users can actually *use* the multi-account flag without crafting raw IPC calls.

- **New `Profiles` submenu** (under "Teams for Linux") shown only when `multiAccount.enabled === true`.
  - `Add profile…` opens a placeholder dialog explaining the form lands in a follow-up PR — clicking the menu item shouldn't be a silent no-op.
  - `Switch to →` is dynamically built from `ProfilesManager.list()`; active profile gets a radio checkmark; empty state shows `"(no profiles configured)"` disabled rather than Electron's platform-specific empty-submenu rendering.
- **`Menus` class** now subscribes to `ProfilesManager`'s `add` / `remove` / `switch` / `update` events when the flag is on and calls `updateMenu()`, so the Switch-to list and active-radio stay in sync as profiles change.
- **Threading**: `Menus` constructor takes `profilesManager` (default arg `null` so existing test callers stay green); `mainAppWindow.onAppReady` accepts and forwards it.

## What this PR does NOT do

Deliberately out of scope to keep review focused — each lands as its own follow-up PR on the Phase 1c.2 roadmap:

- Add-profile dialog form (`BrowserWindow` + preload, mirroring `joinMeetingDialog/`)
- Manage-profiles dialog
- Top-right switcher chrome overlay (the visible pill ADR-020 commits to)
- `Ctrl+Shift+1…5` shortcuts for pinned profiles

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:e2e` — 12/12 passing
- [x] Manual: flag off → byte-identical to today, no Profiles menu (existing `multi-account-disabled.spec.js` covers this regression in CI)
- [x] Manual: flag on, no profiles → Profiles menu shows Add + greyed Switch-to
- [x] Manual: flag on, after Teams login + relaunch → bootstrap fires, menu rebuilds with "My account" radio
- [x] Manual: two profiles seeded via \`settings.json\` (Add dialog ships in next PR), Switch-to works both directions with both sessions warm — no re-login on either, sub-second swap
- [x] Manual: flag flipped off after profiles exist → Profiles menu disappears, \`app.profiles\` data preserved

Refs ADR-020 § "Profiles menu bar entry" and § "Switch between profiles" (mouse-via-menu path). Refs #2483 (1c.1 foundation).