### PR TITLE
feat: add desktopName to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "app/index.js",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/IsmaelMartinez/teams-for-linux",
+  "desktopName": "teams-for-linux.desktop",
   "keywords": [
     "Teams",
     "Microsoft Teams"


### PR DESCRIPTION
With the release of electron 41, there was a slight change to how the desktop name of the application is configured. Before electron 41, the default was {name}.dektop. However, this default was removed in electron/electron#49988. Therefore, it is now necessary to explicitly set desktopName in package.json

I am using teams-for-linux on NixOS, where the package is currently broken as a result of the above, see NixOS/nixpkgs#512444