### PR TITLE
docs(roadmap): capture 2026-05-07 ozone-platform default reset session

### DIFF
--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -686,7 +686,7 @@ The configuration file can include Electron CLI flags that will be added when th
 > For options that require a value, provide them as an array where the first element is the flag and the second is its value. If no value is needed, you can use a simple string.
 
 > [!WARNING]
-> The `ozone-platform` flag **cannot** be set via `electronCLIFlags` because it must be applied before the Electron process starts (before any JavaScript executes). To override the default X11 mode, pass `--ozone-platform=wayland` or `--ozone-platform=auto` as a command-line argument when launching the app, or edit the `Exec=` line in your `.desktop` file. See [Troubleshooting: Wayland / Display Issues](troubleshooting.md#wayland--display-issues) for details.
+> The `ozone-platform` flag **cannot** be set via `electronCLIFlags` because it must be applied before the Electron process starts (before any JavaScript executes). The default is `--ozone-platform=auto`, which lets Chromium pick the backend based on the session. To force a specific backend, pass `--ozone-platform=x11` or `--ozone-platform=wayland` as a command-line argument when launching the app, or edit the `Exec=` line in your `.desktop` file. See [Troubleshooting: Wayland / Display Issues](troubleshooting.md#wayland--display-issues) for details.
 
 #### Custom Feature Flags (enable-features / disable-features)
 

--- a/docs-site/docs/development/plan/roadmap.md
+++ b/docs-site/docs/development/plan/roadmap.md
@@ -1,8 +1,8 @@
 # Development Roadmap
 
-**Last Updated:** 2026-04-24
-**Current Version:** v2.8.0 shipped (Electron 41.2.1, Chromium 146, Node.js 24)
-**Status:** Living Document --- v2.8.0 released with Electron 41 upgrade; cross-distro tests passing 9/9; FIDO2 beta queued for 2.8.2 or 2.9.0; next focus remains bug fixes and dev experience
+**Last Updated:** 2026-05-07
+**Current Version:** v2.8.0 shipped (Electron 41.2.1, Chromium 146, Node.js 24); release-please PR [#2505](https://github.com/IsmaelMartinez/teams-for-linux/pull/2505) accumulating changes for v2.10.0
+**Status:** Living Document --- ozone-platform default reset queued for v2.10.x ([PR #2506](https://github.com/IsmaelMartinez/teams-for-linux/pull/2506), tracking [#2508](https://github.com/IsmaelMartinez/teams-for-linux/issues/2508)); FIDO2 beta still queued for 2.8.2 or 2.9.0; next focus remains bug fixes, Wayland validation, and dev experience
 
 This document outlines the development direction for Teams for Linux. It focuses on themes and priorities rather than individual PRs. For live tracking see [GitHub Issues](https://github.com/IsmaelMartinez/teams-for-linux/issues), [Pull Requests](https://github.com/IsmaelMartinez/teams-for-linux/pulls), and [Releases](https://github.com/IsmaelMartinez/teams-for-linux/releases).
 
@@ -46,6 +46,8 @@ Longer-standing camera issues ([#2169](https://github.com/IsmaelMartinez/teams-f
 
 Wayland support is improving incrementally. Screen source selection has been simplified for better Wayland compatibility, and short Teams deep links now work across all link types. Idle status on Wayland ([#1827](https://github.com/IsmaelMartinez/teams-for-linux/issues/1827)) remains blocked on Electron's `powerMonitor` API not supporting Wayland idle detection natively. A forced idle override option is now available as a workaround.
 
+The X11 default added in 2.7.4 to mask Electron 38 era Wayland regressions is now under review. [PR #2506](https://github.com/IsmaelMartinez/teams-for-linux/pull/2506) switches the deb / rpm / AppImage / snap default from `--ozone-platform=x11` to `--ozone-platform=auto`, letting Chromium pick the appropriate backend per session. [Tracking issue #2508](https://github.com/IsmaelMartinez/teams-for-linux/issues/2508) is gathering community test results across compositor, GPU, and packaging combinations before the change ships. Open Wayland-related bugs that may flip state with this change are tracked there: [#2486](https://github.com/IsmaelMartinez/teams-for-linux/issues/2486) (screen sharing on Wayland) and [#2345](https://github.com/IsmaelMartinez/teams-for-linux/issues/2345) (SIGILL crash on incoming call) are candidates the change may resolve, while [#2383](https://github.com/IsmaelMartinez/teams-for-linux/issues/2383) (appTitle / appIcon under Wayland) is a regression risk if the upstream Chromium fix has not landed in our Electron yet.
+
 ### MQTT Integration
 
 The MQTT integration is mature for presence status, media state, inbound commands, and screen sharing status ([#2107](https://github.com/IsmaelMartinez/teams-for-linux/issues/2107)). Phase 2 extended status (granular WebRTC camera/mic monitoring for reliable mute state) is parked until users confirm they need it. A feature request for incoming call MQTT topics ([#2370](https://github.com/IsmaelMartinez/teams-for-linux/issues/2370)) has been filed.
@@ -59,6 +61,16 @@ The notification lifecycle is now stable ([#2248](https://github.com/IsmaelMarti
 Cross-distro testing shipped in v2.7.9 with Docker-based environments supporting 9 configurations (3 distros x 3 display servers). Authenticated Playwright tests landed in v2.7.10. The infrastructure works well for Ubuntu (7/7 tests pass on X11 and XWayland, 6/6 on Wayland) but Fedora and Debian remain unvalidated. The current focus is closing these gaps and connecting cross-distro testing to the CI pipeline so it gates builds rather than running as a separate manual workflow.
 
 ---
+
+## 2026-05-07 Session Outcomes and Next Up
+
+### Ozone-platform default reset queued for v2.10.x
+
+[PR #2506](https://github.com/IsmaelMartinez/teams-for-linux/pull/2506) opened to switch the deb / rpm / AppImage / snap default from `--ozone-platform=x11` back to `--ozone-platform=auto`, with troubleshooting and configuration docs updated to match. The runtime XWayland detection in `app/startup/commandLine.js` is intentionally unchanged so users who explicitly opt into `--ozone-platform=x11` still hit the `wayland.xwaylandOptimizations` path.
+
+[Tracking issue #2508](https://github.com/IsmaelMartinez/teams-for-linux/issues/2508) opened to coordinate community testing across compositor, GPU, and packaging combinations. Targeted pings posted to four existing threads pointing at the tracker: [#2486](https://github.com/IsmaelMartinez/teams-for-linux/issues/2486) (Fransiro and azureskytech, both already validated `=auto` / `=wayland` for screen sharing), [#2345](https://github.com/IsmaelMartinez/teams-for-linux/issues/2345) (ariel-rivo, X11 fixed the SIGILL crash but they want Wayland), [#2383](https://github.com/IsmaelMartinez/teams-for-linux/issues/2383) (ssh-sato, SlyOrion, Srylax, regression risk for appTitle / appIcon) and [#2094](https://github.com/IsmaelMartinez/teams-for-linux/issues/2094) (dannytrunk, who flagged the upstream Chromium fix landing). The three open issues now carry `awaiting user feedback`.
+
+Decision criteria for shipping the default in 2.10.x: positive confirmation on screen sharing without manual flags from at least the two #2486 reporters, and either a positive or "still reproduces" answer from #2345. Regression risk on #2383 is the main hold; if the upstream Chromium fix is not in our Electron yet, defer the default change to 2.11.x and ship documentation only in 2.10.x.
 
 ## 2026-04-24 Session Outcomes and Next Up
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -269,20 +269,20 @@ Since v2.7.13, report-only CSP headers are automatically stripped for all non-Te
 ### Wayland / Display Issues
 
 :::info Default Behavior
-Since v2.7.4, Teams for Linux forces X11 mode (`--ozone-platform=x11`) by default on all Linux packaging formats. This avoids widespread regressions introduced in Electron 38+ when running as a native Wayland client.
+Teams for Linux launches with `--ozone-platform=auto` by default on all Linux packaging formats, letting Chromium pick the best backend for your session (Wayland on a Wayland session, X11 otherwise). If you hit Wayland-specific regressions, you can override this on the command line or in your `.desktop` file with `--ozone-platform=x11`.
 :::
 
 #### Issue: Blank or black window on Wayland
 
-**Description:** The application window appears blank, black, or white when running on a Wayland session. This is caused by Electron 38+ defaulting to native Wayland mode, which has known regressions.
+**Description:** The application window appears blank, black, or white when running on a Wayland session. This is caused by Electron 38+ regressions in native Wayland mode.
 
 **Solutions/Workarounds:**
 
-1. **Upgrade to v2.7.4+** — X11 is now forced by default, which resolves this for most users.
-2. **For older versions:** Launch with `--ozone-platform=x11`:
+1. **Force X11 mode** by launching with `--ozone-platform=x11`:
     ```bash
     teams-for-linux --ozone-platform=x11
     ```
+2. **Edit your `.desktop` file** to make the override permanent — replace `--ozone-platform=auto` with `--ozone-platform=x11` in the `Exec=` line.
 
 **Related GitHub Issues:** [#1604](https://github.com/IsmaelMartinez/teams-for-linux/issues/1604), [#1494](https://github.com/IsmaelMartinez/teams-for-linux/issues/1494), [#519](https://github.com/IsmaelMartinez/teams-for-linux/issues/519), [#504](https://github.com/IsmaelMartinez/teams-for-linux/issues/504)
 
@@ -292,16 +292,16 @@ Since v2.7.4, Teams for Linux forces X11 mode (`--ozone-platform=x11`) by defaul
 
 **Solutions/Workarounds:**
 
-1. **Upgrade to v2.7.4+** — Forcing X11 mode resolves Wayland window management regressions.
+1. **Force X11 mode** with `--ozone-platform=x11` to avoid Wayland window management regressions.
 
 **Related GitHub Issues:** [#2094](https://github.com/IsmaelMartinez/teams-for-linux/issues/2094)
 
 #### Issue: Blurry UI or fonts with fractional scaling on Wayland
 
-**Description:** Text and UI elements appear blurry when using fractional display scaling (e.g., 125%) on Wayland.
+**Description:** Text and UI elements appear blurry when using fractional display scaling (e.g., 125%) on Wayland while running under XWayland (X11 mode).
 
 **Potential Causes:**
-* X11 mode (the new default) does not handle Wayland fractional scaling natively.
+* X11 mode does not handle Wayland fractional scaling natively.
 
 **Solutions/Workarounds:**
 
@@ -309,7 +309,7 @@ Since v2.7.4, Teams for Linux forces X11 mode (`--ozone-platform=x11`) by defaul
     ```bash
     teams-for-linux --ozone-platform=wayland
     ```
-2. **Edit your `.desktop` file** to make the override permanent — replace `--ozone-platform=x11` with `--ozone-platform=wayland` in the `Exec=` line.
+2. **Edit your `.desktop` file** to make the override permanent — replace `--ozone-platform=auto` with `--ozone-platform=wayland` in the `Exec=` line.
 
 **Related GitHub Issues:** [#1787](https://github.com/IsmaelMartinez/teams-for-linux/issues/1787)
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "synopsis": "Teams for Linux",
       "description": "Unofficial Microsoft Teams client for Linux using Electron. It uses the Web App and wraps it as a standalone application using Electron.",
       "executableArgs": [
-        "--ozone-platform=x11"
+        "--ozone-platform=auto"
       ],
       "desktop": {
         "entry": {
@@ -142,7 +142,7 @@
       "grade": "stable",
       "base": "core22",
       "executableArgs": [
-        "--ozone-platform=x11"
+        "--ozone-platform=auto"
       ],
       "plugs": [
         "default",


### PR DESCRIPTION
## Summary
- Bump the roadmap's `Last Updated` to 2026-05-07 and refresh the status line so it mentions release-please PR #2505 (v2.10.0) and the ozone-platform default reset queued behind PR #2506.
- Extend the `Wayland Compatibility` section with a paragraph on PR #2506, the new tracking issue #2508, and the three open issues whose state may flip with the change (#2486 candidate fix, #2345 candidate fix, #2383 regression risk).
- Add a `2026-05-07 Session Outcomes` block above the existing 2026-04-24 block, capturing today's PR, tracker, four targeted pings (#2486, #2345, #2383, #2094), and the decision criteria for shipping the default in 2.10.x vs deferring to 2.11.x.

Documentation only. No code changes.

## Test plan
- [ ] CI green
- [ ] Roadmap renders correctly on the docs site preview (no broken links, headings nest as expected).
