### PR TITLE
fix: restore --ozone-platform=x11 default (revert #2509 package.json hunk)

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "synopsis": "Teams for Linux",
       "description": "Unofficial Microsoft Teams client for Linux using Electron. It uses the Web App and wraps it as a standalone application using Electron.",
       "executableArgs": [
-        "--ozone-platform=auto"
+        "--ozone-platform=x11"
       ],
       "desktop": {
         "entry": {
@@ -142,7 +142,7 @@
       "grade": "stable",
       "base": "core22",
       "executableArgs": [
-        "--ozone-platform=auto"
+        "--ozone-platform=x11"
       ],
       "plugs": [
         "default",


### PR DESCRIPTION
## Summary

Hot-fix: restore `--ozone-platform=x11` in `package.json` so main is releasable again.

PR #2509 ("docs(roadmap): capture 2026-05-07 ozone-platform default reset session") accidentally bundled a `package.json` hunk that flipped both `executableArgs` blocks from `=x11` to `=auto`. `=auto` is not a valid value for `--ozone-platform`. Chromium's `ui/ozone/platform_selection.cc:46` rejects unknown platform names with `FATAL:ui/ozone/platform_selection.cc:46] Invalid ozone platform: auto`, so every build cut from main since 2026-05-07 is unlaunchable on every distro and every packaging format. Two testers (`@dannytrunk`, `@farajaahdaf`) hit it on the PR #2506 build and surfaced it.

`v2.9.0` (released 2026-05-06, predates the regression) is unaffected. Only main and any release-please PR built from main since 2026-05-07 are at risk.

## Why this and not the proper fix

The longer-term direction (remove the flag entirely and let Chromium auto-detect per session, since Chromium 140+ defaults `--ozone-platform-hint` to `auto`) is on PR #2506. That PR also picks up cross-distro test infrastructure changes and doc updates, so it is not the smallest possible patch. This PR is the smallest possible patch: revert the four characters that broke main, nothing else.

## Test plan

- [x] `npm run lint` clean
- [x] AppImage / deb / rpm / snap build artifacts launch on Wayland and X11 sessions without `Invalid ozone platform` FATAL
- [x] Cross-distro smoke matrix runs green on all 9 entries

## Tracking

closes nothing on its own; the tracking conversation lives on #2508 and the longer-term fix lives on #2506.
