### PR TITLE
feat(downloads): drive taskbar progress bar during downloads (#2512)

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -280,7 +280,7 @@ function extractYargConfig(configObject, appVersion) {
           showProgressBar: true,
         },
         describe:
-          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder). showProgressBar: drive the taskbar progress bar while downloads are in flight. All sub-flags only take effect when enabled is true.",
+          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder). showProgressBar: drive the taskbar progress bar while downloads are in flight and prefix the window title with [N%] as a portable fallback for Linux without libunity. All sub-flags only take effect when enabled is true.",
         type: "object",
       },
       disableNotifications: {

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -277,9 +277,10 @@ function extractYargConfig(configObject, appVersion) {
         default: {
           enabled: false,
           notifyOnDownloadComplete: true,
+          showProgressBar: true,
         },
         describe:
-          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder); only takes effect when enabled is true.",
+          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder). showProgressBar: drive the taskbar progress bar while downloads are in flight. All sub-flags only take effect when enabled is true.",
         type: "object",
       },
       disableNotifications: {

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -278,9 +278,10 @@ function extractYargConfig(configObject, appVersion) {
           enabled: false,
           notifyOnDownloadComplete: true,
           showProgressBar: true,
+          showTitlePrefix: true,
         },
         describe:
-          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder). showProgressBar: drive the taskbar progress bar while downloads are in flight and prefix the window title with [N%] as a portable fallback for Linux without libunity. All sub-flags only take effect when enabled is true.",
+          "Download manager configuration. enabled: master switch for the entire feature, defaults to false while the feature is in early development — set true to opt in. notifyOnDownloadComplete: show a system notification when a file download finishes (click opens the containing folder). showProgressBar: drive the taskbar progress bar and KDE JobView / Unity LauncherEntry signals while downloads are in flight. showTitlePrefix: also prefix the window title with [N%] as a portable fallback for environments where the other progress signals aren't rendered; set to false to keep the title untouched when KDE / Ubuntu already show progress elsewhere. All sub-flags only take effect when enabled is true.",
         type: "object",
       },
       disableNotifications: {

--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -15,7 +15,11 @@ each download as both a taskbar progress bar and system notifications:
   `DownloadItem.getReceivedBytes() / getTotalBytes()`, aggregated across
   concurrent downloads. When the server doesn't advertise a content length
   the progress bar switches to indeterminate mode so the user still sees
-  motion on the taskbar.
+  motion on the taskbar. As a portable fallback (Electron's
+  `setProgressBar` is a no-op on Linux distros without `libunity`, which is
+  most of them — Debian, Fedora, Arch, KDE/GNOME by default), the window
+  title is also prefixed with `[34%]` (or `[downloading]` for unknown-size
+  downloads) so every WM/DE shows the progress in its taskbar tooltip.
 - **Completed:** notification "Download complete" with the filename. Clicking
   the notification opens the containing folder via `shell.showItemInFolder()`.
 - **Cancelled / interrupted:** notification "Download did not finish" with

--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -59,7 +59,8 @@ been created by the main window.
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the entire feature. While download UX is in early development this is opt-in; set `true` to turn the manager on. The sub-flags only take effect once this is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a download finishes |
-| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar from active download progress |
+| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar, KDE JobView and Unity LauncherEntry while downloads are in flight |
+| `download.showTitlePrefix` | `boolean` | `true` | Also prefix the window title with `[N%]` (or `[downloading]`). Set to `false` on KDE / Ubuntu where the JobView / LauncherEntry already shows progress and the title churn is redundant. |
 
 Add this to `~/.config/teams-for-linux/config.json` to turn the feature on:
 
@@ -71,7 +72,7 @@ Add this to `~/.config/teams-for-linux/config.json` to turn the feature on:
 }
 ```
 
-With `enabled: true`, set either sub-flag to `false` to opt out of that piece
-of feedback (notification or progress bar). The global `disableNotifications`
-flag also suppresses the completion / failure toasts (but does not affect the
-progress bar).
+With `enabled: true`, set any sub-flag to `false` to opt out of that piece of
+feedback (notification, progress bar, title prefix). The global
+`disableNotifications` flag also suppresses the completion / failure toasts
+(but does not affect the progress bar or title prefix).

--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -8,25 +8,31 @@ and no "show in folder" affordance — making downloads invisible to the user
 
 ## DownloadManager Class
 
-Registers a `will-download` listener on the Teams browser session and shows a
-system notification when each download finishes:
+Registers a `will-download` listener on the Teams browser session and surfaces
+each download as both a taskbar progress bar and system notifications:
 
+- **In flight:** drives `BrowserWindow.setProgressBar()` from
+  `DownloadItem.getReceivedBytes() / getTotalBytes()`, aggregated across
+  concurrent downloads. When the server doesn't advertise a content length
+  the progress bar switches to indeterminate mode so the user still sees
+  motion on the taskbar.
 - **Completed:** notification "Download complete" with the filename. Clicking
   the notification opens the containing folder via `shell.showItemInFolder()`.
-- **Cancelled / interrupted:** notification "Download did not finish" with the
-  filename and reason, so users know the file was not saved.
+- **Cancelled / interrupted:** notification "Download did not finish" with
+  the filename and reason, so users know the file was not saved.
 
-Per-item progress UI (in-app downloads list, tray badge while active) is
-intentionally out of scope. The aim is parity with the bare-minimum browser
-behaviour; richer UI can be added later if requested.
+Per-item UI (in-app downloads list, tray badge while active) is intentionally
+out of scope. The aim is parity with the bare-minimum browser behaviour;
+richer UI can be added later if requested.
 
 **Dependencies:**
-- `config` - Application configuration (only `config.download.notifyOnDownloadComplete` is read)
+- `config` - Application configuration (`config.download.*` keys are read)
+- `mainAppWindow` - Main window module exposing `getWindow()` for taskbar progress updates
 
 **Usage:**
 ```javascript
 const DownloadManager = require("./downloadManager");
-const downloadManager = new DownloadManager(config);
+const downloadManager = new DownloadManager(config, mainAppWindow);
 downloadManager.initialize(session.fromPartition(config.partition));
 ```
 
@@ -40,6 +46,7 @@ been created by the main window.
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the entire feature. While download UX is in early development this is opt-in; set `true` to turn the manager on. The sub-flags only take effect once this is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a download finishes |
+| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar from active download progress |
 
 Add this to `~/.config/teams-for-linux/config.json` to turn the feature on:
 
@@ -51,5 +58,7 @@ Add this to `~/.config/teams-for-linux/config.json` to turn the feature on:
 }
 ```
 
-Set `download.notifyOnDownloadComplete` to `false` to suppress the notification
-while keeping the feature otherwise active.
+With `enabled: true`, set either sub-flag to `false` to opt out of that piece
+of feedback (notification or progress bar). The global `disableNotifications`
+flag also suppresses the completion / failure toasts (but does not affect the
+progress bar).

--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -9,34 +9,43 @@ and no "show in folder" affordance — making downloads invisible to the user
 ## DownloadManager Class
 
 Registers a `will-download` listener on the Teams browser session and surfaces
-each download as both a taskbar progress bar and system notifications:
+each download through three independent feedback channels:
 
-- **In flight:** drives `BrowserWindow.setProgressBar()` from
+- **Taskbar progress bar:** drives `BrowserWindow.setProgressBar()` from
   `DownloadItem.getReceivedBytes() / getTotalBytes()`, aggregated across
-  concurrent downloads. When the server doesn't advertise a content length
-  the progress bar switches to indeterminate mode so the user still sees
-  motion on the taskbar. As a portable fallback (Electron's
-  `setProgressBar` is a no-op on Linux distros without `libunity`, which is
-  most of them — Debian, Fedora, Arch, KDE/GNOME by default), the window
-  title is also prefixed with `[34%]` (or `[downloading]` for unknown-size
-  downloads) so every WM/DE shows the progress in its taskbar tooltip.
+  concurrent downloads. Indeterminate mode kicks in when the server doesn't
+  advertise a content length. Note: on most modern Linux setups
+  `setProgressBar` is a silent no-op because Electron gates it on the Unity
+  launcher protocol owning `com.canonical.Unity` (no DE has done that since
+  Unity was discontinued in 2017). It still works on macOS / Windows.
+- **KDE Plasma notification widget (per-download JobView):** uses the
+  `org.kde.JobViewServer` D-Bus service — the same protocol Firefox /
+  Dolphin / KIO use — so every download shows up as a row in Plasma's
+  notification widget with filename, percent, and bytes processed.
+  Degrades to no-op on systems without that service (non-KDE setups).
+- **Window-title fallback:** prefixes the main window title with `[34%]`
+  (or `[downloading]` for unknown-size downloads) while a download is in
+  flight. Every WM/DE renders the window title in its taskbar tooltip /
+  Alt-Tab list, so this works even when the taskbar progress bar and the
+  JobView protocol are both unavailable.
 - **Completed:** notification "Download complete" with the filename. Clicking
   the notification opens the containing folder via `shell.showItemInFolder()`.
 - **Cancelled / interrupted:** notification "Download did not finish" with
   the filename and reason, so users know the file was not saved.
 
-Per-item UI (in-app downloads list, tray badge while active) is intentionally
-out of scope. The aim is parity with the bare-minimum browser behaviour;
-richer UI can be added later if requested.
+Per-item UI beyond the above (in-app downloads list, tray badge while active)
+is intentionally out of scope.
 
 **Dependencies:**
 - `config` - Application configuration (`config.download.*` keys are read)
-- `mainAppWindow` - Main window module exposing `getWindow()` for taskbar progress updates
+- `mainAppWindow` - Main window module exposing `getWindow()` for taskbar progress updates and window-title prefix
+- `jobViewEmitter` (Linux only) - Optional sibling module talking to `org.kde.JobViewServer`
 
 **Usage:**
 ```javascript
 const DownloadManager = require("./downloadManager");
-const downloadManager = new DownloadManager(config, mainAppWindow);
+const jobEmitter = require("./downloadManager/jobViewEmitter"); // Linux only
+const downloadManager = new DownloadManager(config, mainAppWindow, jobEmitter);
 downloadManager.initialize(session.fromPartition(config.partition));
 ```
 

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -1,5 +1,15 @@
 const { Notification, shell } = require("electron");
 
+// Matches the leading progress prefix this manager applies to window titles
+// (e.g. `[34%] ` or `[downloading] `). Anchored to the start so we only strip
+// our own prefix and never touch a legitimate page title that happens to
+// contain bracketed numbers later in the string.
+const TITLE_PREFIX_RE = /^\[(\d{1,3}%|downloading)\]\s/;
+
+function stripDownloadPrefix(title) {
+  return title.replace(TITLE_PREFIX_RE, "");
+}
+
 /**
  * DownloadManager surfaces Electron `DownloadItem` lifecycle as user-visible
  * feedback. Without a `will-download` handler, Electron silently saves files
@@ -9,8 +19,13 @@ const { Notification, shell } = require("electron");
  * Scope:
  *   - Taskbar progress bar via `BrowserWindow.setProgressBar`, aggregated
  *     across concurrent downloads. Indeterminate mode kicks in when the
- *     server doesn't advertise a content length so the user still gets
- *     feedback that *something* is happening.
+ *     server doesn't advertise a content length.
+ *   - Window-title fallback: a `[34%] ` (or `[downloading] `) prefix on the
+ *     window title. Linux distros without `libunity` (Debian, Fedora, Arch,
+ *     KDE/GNOME by default) get nothing from `setProgressBar` because
+ *     Electron loads libunity via `dlopen` at runtime; the title prefix is
+ *     a portable fallback that every WM/DE renders in its taskbar tooltip
+ *     or window list.
  *   - System notification on completion; click opens the containing folder
  *     via `shell.showItemInFolder()`.
  *   - System notification on cancellation / interruption.
@@ -148,6 +163,7 @@ class DownloadManager {
 
     if (this.#activeItems.size === 0) {
       window.setProgressBar(-1);
+      this.#clearTitlePrefix(window);
       return;
     }
 
@@ -167,11 +183,58 @@ class DownloadManager {
 
     if (hasUnknownTotal || knownTotal <= 0) {
       window.setProgressBar(2, { mode: "indeterminate" });
+      this.#applyTitlePrefix(window, null);
       return;
     }
 
     const fraction = Math.max(0, Math.min(1, knownReceived / knownTotal));
     window.setProgressBar(fraction);
+    this.#applyTitlePrefix(window, fraction);
+  }
+
+  /**
+   * Update the window title with a progress prefix, keeping a fallback path
+   * for environments where Electron's `setProgressBar` is a no-op (Linux
+   * without `libunity` — Debian, Fedora, Arch, etc. by default).
+   *
+   * The title flow on Linux looks like:
+   *   1. Teams DOM updates `document.title` -> Chromium fires
+   *      `page-title-updated`, which we don't preventDefault on, so the
+   *      window title gets set to the new page title (overwriting our
+   *      prefix).
+   *   2. The next `DownloadItem.on('updated')` fires (~500ms cadence) and
+   *      re-applies the prefix here.
+   *
+   * The brief no-prefix window between (1) and (2) is acceptable; the upside
+   * is no need to listen to `page-title-updated` and risk fighting the
+   * existing title pipeline.
+   *
+   * @param {Electron.BrowserWindow} window
+   * @param {number|null} fraction - 0..1, or null for indeterminate.
+   */
+  #applyTitlePrefix(window, fraction) {
+    const currentTitle = window.getTitle();
+    const baseTitle = stripDownloadPrefix(currentTitle);
+    const prefix = fraction === null
+      ? "[downloading] "
+      : `[${Math.round(fraction * 100)}%] `;
+    const next = prefix + baseTitle;
+    if (next !== currentTitle) {
+      window.setTitle(next);
+    }
+  }
+
+  /**
+   * Reset the window title to its un-prefixed form once no downloads remain.
+   *
+   * @param {Electron.BrowserWindow} window
+   */
+  #clearTitlePrefix(window) {
+    const currentTitle = window.getTitle();
+    const baseTitle = stripDownloadPrefix(currentTitle);
+    if (baseTitle !== currentTitle) {
+      window.setTitle(baseTitle);
+    }
   }
 
   /**

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -69,14 +69,20 @@ class DownloadManager {
 
     console.debug(`[DownloadManager] Download started: ${item.getFilename()}`);
 
+    let onUpdated = null;
     if (showProgress) {
       this.#activeItems.add(item);
-      item.on("updated", () => this.#updateProgressBar());
+      onUpdated = () => this.#updateProgressBar();
+      item.on("updated", onUpdated);
       this.#updateProgressBar();
     }
 
     item.once("done", (_doneEvent, state) => {
       if (showProgress) {
+        // Explicitly drop the `updated` listener so we don't keep references
+        // to the item (or its closures) past completion, even if the
+        // DownloadItem outlives the manager's tracking set.
+        if (onUpdated) item.removeListener("updated", onUpdated);
         this.#activeItems.delete(item);
         this.#updateProgressBar();
       }

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -1,10 +1,16 @@
 const { Notification, shell } = require("electron");
 
 // Matches the leading progress prefix this manager applies to window titles
-// (e.g. `[34%] ` or `[downloading] `). Anchored to the start so we only strip
-// our own prefix and never touch a legitimate page title that happens to
-// contain bracketed numbers later in the string.
-const TITLE_PREFIX_RE = /^\[(\d{1,3}%|downloading)\]\s/;
+// (e.g. `[34%] `, `[34%, 78%] `, `[downloading] `, `[50%, downloading] `).
+// Anchored to the start so we only strip our own prefix and never touch a
+// legitimate page title that happens to contain bracketed numbers later in
+// the string. Each part is either `\d{1,3}%` or `downloading`, separated by
+// a comma + optional space, the whole group wrapped in `[…] ` plus a
+// trailing space.
+const TITLE_PREFIX_PART = /(?:\d{1,3}%|downloading)/;
+const TITLE_PREFIX_RE = new RegExp(
+  String.raw`^\[${TITLE_PREFIX_PART.source}(?:,\s*${TITLE_PREFIX_PART.source})*\]\s`,
+);
 
 function stripDownloadPrefix(title) {
   return title.replace(TITLE_PREFIX_RE, "");
@@ -197,6 +203,10 @@ class DownloadManager {
       return;
     }
 
+    // Per-item fractions for the window-title prefix (so users with
+    // multiple concurrent downloads see e.g. `[34%, 78%]` rather than a
+    // single aggregate that hides whether one item is stalled).
+    const itemFractions = [];
     let knownTotal = 0;
     let knownReceived = 0;
     let hasUnknownTotal = false;
@@ -205,26 +215,31 @@ class DownloadManager {
       const received = item.getReceivedBytes?.() ?? 0;
       if (!total || total <= 0) {
         hasUnknownTotal = true;
+        itemFractions.push(null);
         continue;
       }
       knownTotal += total;
       knownReceived += received;
+      itemFractions.push(Math.max(0, Math.min(1, received / total)));
     }
 
-    if (hasUnknownTotal || knownTotal <= 0) {
+    if (hasUnknownTotal && knownTotal <= 0) {
+      // Every active item has unknown total: indeterminate.
       window.setProgressBar(2, { mode: "indeterminate" });
-      // The LauncherEntry protocol has no indeterminate state; the closest
-      // signal is "active but unknown progress". Hide the bar and let the
-      // window-title fallback carry the indeterminate cue.
       this.#launcherEmitter?.update({ progressVisible: false });
-      this.#applyTitlePrefix(window, null);
+      this.#applyTitlePrefix(window, itemFractions);
       return;
     }
 
-    const fraction = Math.max(0, Math.min(1, knownReceived / knownTotal));
-    window.setProgressBar(fraction);
-    this.#launcherEmitter?.update({ progress: fraction, progressVisible: true });
-    this.#applyTitlePrefix(window, fraction);
+    // setProgressBar and LauncherEntry are single-value protocols, so they
+    // get the byte-weighted aggregate. The window title surfaces the
+    // per-item breakdown.
+    const aggregate = knownTotal > 0
+      ? Math.max(0, Math.min(1, knownReceived / knownTotal))
+      : 0;
+    window.setProgressBar(aggregate);
+    this.#launcherEmitter?.update({ progress: aggregate, progressVisible: true });
+    this.#applyTitlePrefix(window, itemFractions);
   }
 
   /**
@@ -299,15 +314,19 @@ class DownloadManager {
    * existing title pipeline.
    *
    * @param {Electron.BrowserWindow} window
-   * @param {number|null} fraction - 0..1, or null for indeterminate.
+   * @param {Array<number|null>} fractions - one entry per active download:
+   *   a 0..1 number for known progress, or null for an item with an
+   *   unknown total size. Examples: `[0.34]` -> `[34%]`, `[0.34, 0.78]`
+   *   -> `[34%, 78%]`, `[0.5, null]` -> `[50%, downloading]`,
+   *   `[null]` -> `[downloading]`.
    */
-  #applyTitlePrefix(window, fraction) {
+  #applyTitlePrefix(window, fractions) {
     const currentTitle = window.getTitle();
     const baseTitle = stripDownloadPrefix(currentTitle);
-    const prefix = fraction === null
-      ? "[downloading] "
-      : `[${Math.round(fraction * 100)}%] `;
-    const next = prefix + baseTitle;
+    const parts = fractions.map((fraction) =>
+      fraction === null ? "downloading" : `${Math.round(fraction * 100)}%`,
+    );
+    const next = `[${parts.join(", ")}] ${baseTitle}`;
     if (next !== currentTitle) {
       window.setTitle(next);
     }

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -20,11 +20,15 @@ function stripDownloadPrefix(title) {
  *   - Taskbar progress bar via `BrowserWindow.setProgressBar`, aggregated
  *     across concurrent downloads. Indeterminate mode kicks in when the
  *     server doesn't advertise a content length.
+ *   - KDE / freedesktop JobView (per-item progress in Plasma's notification
+ *     widget — the same place users see Firefox / Dolphin / KIO download
+ *     progress). Driven via `org.kde.JobViewServer` if available; degrades
+ *     to no-op on systems without it.
  *   - Window-title fallback: a `[34%] ` (or `[downloading] `) prefix on the
- *     window title. Linux distros without `libunity` (Debian, Fedora, Arch,
- *     KDE/GNOME by default) get nothing from `setProgressBar` because
- *     Electron loads libunity via `dlopen` at runtime; the title prefix is
- *     a portable fallback that every WM/DE renders in its taskbar tooltip
+ *     window title. Electron's `setProgressBar` is a no-op on most Linux
+ *     setups (Unity launcher protocol gated on `com.canonical.Unity` name
+ *     ownership, which no modern DE provides), so the title prefix is a
+ *     portable fallback that every WM/DE renders in its taskbar tooltip
  *     or window list.
  *   - System notification on completion; click opens the containing folder
  *     via `shell.showItemInFolder()`.
@@ -35,6 +39,8 @@ function stripDownloadPrefix(title) {
 class DownloadManager {
   #config;
   #mainAppWindow;
+  #jobEmitter;
+  #launcherEmitter;
   #session = null;
   // Hold strong references to live `Notification` instances so the V8 garbage
   // collector doesn't reap them — and their click/close listeners — between
@@ -43,10 +49,32 @@ class DownloadManager {
   #activeNotifications = new Set();
   // Active downloads tracked for the taskbar progress bar. Removed in `done`.
   #activeItems = new Set();
+  // Per-item JobView handle promises. The emitter's `start()` is async (one
+  // DBus round-trip to `requestView`); subsequent `update()` / `finish()`
+  // calls `.then()` onto the stored promise so events that arrive before
+  // requestView resolves are applied as soon as the handle exists.
+  #itemJobs = new Map();
 
-  constructor(config, mainAppWindow) {
+  /**
+   * @param {object} config - Application configuration.
+   * @param {object} mainAppWindow - Module exposing `getWindow()` for the main BrowserWindow.
+   * @param {{start: (Object) => Promise<{update: Function, finish: Function}>}} [jobEmitter] -
+   *   Optional desktop job-view emitter (KDE's `org.kde.JobViewServer` —
+   *   the protocol Plasma's notification widget uses to render progress
+   *   for Firefox / Dolphin / KIO downloads). Tests omit this so DBus
+   *   traffic never happens during unit tests.
+   * @param {{update: (props: object) => void}} [launcherEmitter] -
+   *   Optional Unity LauncherEntry emitter (`com.canonical.Unity
+   *   .LauncherEntry.Update` D-Bus broadcast). Ubuntu Dock and Dash-to-Dock
+   *   subscribe to this signal to render progress on the running app's dock
+   *   icon — covers the GNOME/Ubuntu majority of the Linux audience that
+   *   Electron's `setProgressBar` no longer reaches. Tests omit this.
+   */
+  constructor(config, mainAppWindow, jobEmitter = null, launcherEmitter = null) {
     this.#config = config;
     this.#mainAppWindow = mainAppWindow;
+    this.#jobEmitter = jobEmitter;
+    this.#launcherEmitter = launcherEmitter;
   }
 
   /**
@@ -87,7 +115,11 @@ class DownloadManager {
     let onUpdated = null;
     if (showProgress) {
       this.#activeItems.add(item);
-      onUpdated = () => this.#updateProgressBar();
+      this.#startJob(item);
+      onUpdated = () => {
+        this.#updateProgressBar();
+        this.#updateJob(item);
+      };
       item.on("updated", onUpdated);
       this.#updateProgressBar();
     }
@@ -99,6 +131,7 @@ class DownloadManager {
         // DownloadItem outlives the manager's tracking set.
         if (onUpdated) item.removeListener("updated", onUpdated);
         this.#activeItems.delete(item);
+        this.#finishJob(item, state);
         this.#updateProgressBar();
       }
       if (!notify) return;
@@ -159,6 +192,7 @@ class DownloadManager {
 
     if (this.#activeItems.size === 0) {
       window.setProgressBar(-1);
+      this.#launcherEmitter?.update({ progressVisible: false });
       this.#clearTitlePrefix(window);
       return;
     }
@@ -179,13 +213,72 @@ class DownloadManager {
 
     if (hasUnknownTotal || knownTotal <= 0) {
       window.setProgressBar(2, { mode: "indeterminate" });
+      // The LauncherEntry protocol has no indeterminate state; the closest
+      // signal is "active but unknown progress". Hide the bar and let the
+      // window-title fallback carry the indeterminate cue.
+      this.#launcherEmitter?.update({ progressVisible: false });
       this.#applyTitlePrefix(window, null);
       return;
     }
 
     const fraction = Math.max(0, Math.min(1, knownReceived / knownTotal));
     window.setProgressBar(fraction);
+    this.#launcherEmitter?.update({ progress: fraction, progressVisible: true });
     this.#applyTitlePrefix(window, fraction);
+  }
+
+  /**
+   * Open a per-item JobView (KDE notification-widget progress) for the
+   * given DownloadItem. Records the resulting handle promise so subsequent
+   * `update`/`finish` calls can chain onto it even if they fire before the
+   * `requestView` round-trip resolves.
+   *
+   * @param {Electron.DownloadItem} item
+   */
+  #startJob(item) {
+    if (!this.#jobEmitter) return;
+    const filename = item.getFilename?.();
+    const totalBytes = item.getTotalBytes?.();
+    const promise = Promise.resolve(
+      this.#jobEmitter.start({
+        filename,
+        totalBytes: typeof totalBytes === "number" && totalBytes > 0 ? totalBytes : undefined,
+      }),
+    ).catch((error) => {
+      console.warn("[DownloadManager] JobView start failed", { message: error?.message });
+      return null;
+    });
+    this.#itemJobs.set(item, promise);
+  }
+
+  /**
+   * Forward the latest receivedBytes/totalBytes to the per-item JobView.
+   * No-op when the emitter wasn't supplied or the item has no live job.
+   *
+   * @param {Electron.DownloadItem} item
+   */
+  #updateJob(item) {
+    const promise = this.#itemJobs.get(item);
+    if (!promise) return;
+    const receivedBytes = item.getReceivedBytes?.() ?? 0;
+    const totalBytes = item.getTotalBytes?.() ?? 0;
+    promise.then((handle) => handle?.update?.({ receivedBytes, totalBytes }));
+  }
+
+  /**
+   * Terminate the per-item JobView and forget the handle. KDE removes the
+   * row from the notification widget when the view terminates; passing a
+   * non-empty `error` string surfaces it as a job failure.
+   *
+   * @param {Electron.DownloadItem} item
+   * @param {string} state - DownloadItem.state passed by Electron's `done` event.
+   */
+  #finishJob(item, state) {
+    const promise = this.#itemJobs.get(item);
+    if (!promise) return;
+    this.#itemJobs.delete(item);
+    const error = state === "completed" ? "" : `Download ${state}`;
+    promise.then((handle) => handle?.finish?.({ error }));
   }
 
   /**

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -6,24 +6,32 @@ const { Notification, shell } = require("electron");
  * to the default download directory with no progress UI, so a Teams download
  * looks like nothing happened (issue #2512).
  *
- * Scope: a system notification on completion, click opens the containing
- * folder via `shell.showItemInFolder()`. A separate notification is shown if
- * the download is cancelled or interrupted so users know it didn't finish.
+ * Scope:
+ *   - Taskbar progress bar via `BrowserWindow.setProgressBar`, aggregated
+ *     across concurrent downloads. Indeterminate mode kicks in when the
+ *     server doesn't advertise a content length so the user still gets
+ *     feedback that *something* is happening.
+ *   - System notification on completion; click opens the containing folder
+ *     via `shell.showItemInFolder()`.
+ *   - System notification on cancellation / interruption.
  *
- * Per-item progress UI (in-app downloads list, tray badge while active) is
- * intentionally out of scope here; it can be layered on later if requested.
+ * Richer UI (in-app downloads list, per-item tray badge) is out of scope.
  */
 class DownloadManager {
   #config;
+  #mainAppWindow;
   #session = null;
   // Hold strong references to live `Notification` instances so the V8 garbage
   // collector doesn't reap them — and their click/close listeners — between
   // `show()` and the user actually interacting with the toast. Entries are
   // removed on `click` or `close`.
   #activeNotifications = new Set();
+  // Active downloads tracked for the taskbar progress bar. Removed in `done`.
+  #activeItems = new Set();
 
-  constructor(config) {
+  constructor(config, mainAppWindow) {
     this.#config = config;
+    this.#mainAppWindow = mainAppWindow;
   }
 
   /**
@@ -55,11 +63,25 @@ class DownloadManager {
   }
 
   #onWillDownload(_event, item) {
-    if (!this.#shouldNotify()) return;
+    const notify = this.#shouldNotify();
+    const showProgress = this.#shouldShowProgress();
+    if (!notify && !showProgress) return;
 
     console.debug(`[DownloadManager] Download started: ${item.getFilename()}`);
 
+    if (showProgress) {
+      this.#activeItems.add(item);
+      item.on("updated", () => this.#updateProgressBar());
+      this.#updateProgressBar();
+    }
+
     item.once("done", (_doneEvent, state) => {
+      if (showProgress) {
+        this.#activeItems.delete(item);
+        this.#updateProgressBar();
+      }
+      if (!notify) return;
+
       // Read filename from the item inside `done` rather than capturing it at
       // start: if the item is renamed mid-flight (e.g. via a `Save As` dialog
       // attached by another handler) the final name is what the user will see
@@ -95,6 +117,55 @@ class DownloadManager {
       return false;
     }
     return true;
+  }
+
+  #shouldShowProgress() {
+    const downloadConfig = this.#config?.download;
+    if (downloadConfig && downloadConfig.showProgressBar === false) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Recompute the taskbar progress bar from the active-downloads set:
+   *
+   * - No active downloads: clear (`setProgressBar(-1)`).
+   * - Any item without a known total size: indeterminate mode, so the user
+   *   still sees motion on the taskbar.
+   * - Otherwise: byte-weighted average across all active items so a single
+   *   bar represents the whole batch.
+   */
+  #updateProgressBar() {
+    const window = this.#mainAppWindow?.getWindow?.();
+    if (!window || window.isDestroyed()) return;
+
+    if (this.#activeItems.size === 0) {
+      window.setProgressBar(-1);
+      return;
+    }
+
+    let knownTotal = 0;
+    let knownReceived = 0;
+    let hasUnknownTotal = false;
+    for (const item of this.#activeItems) {
+      const total = item.getTotalBytes?.() ?? 0;
+      const received = item.getReceivedBytes?.() ?? 0;
+      if (!total || total <= 0) {
+        hasUnknownTotal = true;
+        continue;
+      }
+      knownTotal += total;
+      knownReceived += received;
+    }
+
+    if (hasUnknownTotal || knownTotal <= 0) {
+      window.setProgressBar(2, { mode: "indeterminate" });
+      return;
+    }
+
+    const fraction = Math.max(0, Math.min(1, knownReceived / knownTotal));
+    window.setProgressBar(fraction);
   }
 
   /**

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -141,11 +141,7 @@ class DownloadManager {
   }
 
   #shouldShowProgress() {
-    const downloadConfig = this.#config?.download;
-    if (downloadConfig && downloadConfig.showProgressBar === false) {
-      return false;
-    }
-    return true;
+    return this.#config?.download?.showProgressBar !== false;
   }
 
   /**

--- a/app/downloadManager/index.js
+++ b/app/downloadManager/index.js
@@ -183,6 +183,15 @@ class DownloadManager {
     return this.#config?.download?.showProgressBar !== false;
   }
 
+  // The title-prefix path always fires on every Linux setup — `setProgressBar`
+  // and the D-Bus emitters fail closed on unsupported environments, but
+  // `window.setTitle` always succeeds. Users who already see KDE JobView
+  // rows or Ubuntu LauncherEntry badges can opt out of the title churn by
+  // setting this sub-flag to false.
+  #shouldShowTitlePrefix() {
+    return this.#config?.download?.showTitlePrefix !== false;
+  }
+
   /**
    * Recompute the taskbar progress bar from the active-downloads set:
    *
@@ -196,10 +205,12 @@ class DownloadManager {
     const window = this.#mainAppWindow?.getWindow?.();
     if (!window || window.isDestroyed()) return;
 
+    const showTitlePrefix = this.#shouldShowTitlePrefix();
+
     if (this.#activeItems.size === 0) {
       window.setProgressBar(-1);
       this.#launcherEmitter?.update({ progressVisible: false });
-      this.#clearTitlePrefix(window);
+      if (showTitlePrefix) this.#clearTitlePrefix(window);
       return;
     }
 
@@ -227,7 +238,7 @@ class DownloadManager {
       // Every active item has unknown total: indeterminate.
       window.setProgressBar(2, { mode: "indeterminate" });
       this.#launcherEmitter?.update({ progressVisible: false });
-      this.#applyTitlePrefix(window, itemFractions);
+      if (showTitlePrefix) this.#applyTitlePrefix(window, itemFractions);
       return;
     }
 
@@ -239,7 +250,7 @@ class DownloadManager {
       : 0;
     window.setProgressBar(aggregate);
     this.#launcherEmitter?.update({ progress: aggregate, progressVisible: true });
-    this.#applyTitlePrefix(window, itemFractions);
+    if (showTitlePrefix) this.#applyTitlePrefix(window, itemFractions);
   }
 
   /**

--- a/app/downloadManager/jobViewEmitter.js
+++ b/app/downloadManager/jobViewEmitter.js
@@ -1,0 +1,191 @@
+/**
+ * KDE / freedesktop JobView emitter.
+ *
+ * Reports download progress to the desktop's "job tracker" service so it
+ * shows up in KDE Plasma's notification widget (the same place users see
+ * Firefox / Dolphin / Discover / kio job progress). Bypasses Electron's
+ * Unity LauncherEntry path entirely — that protocol depends on the user
+ * having a Task Manager applet *and* on KDE's libtaskmanager actually
+ * rendering it, neither of which can be assumed.
+ *
+ * The JobView protocol (`org.kde.JobViewServer` on the session bus):
+ *   - `requestView(appName, appIconName, capabilities) → object_path`
+ *   - on the returned path, methods on `org.kde.JobViewV2`:
+ *       `setInfoMessage(string)`           — short status line
+ *       `setTotalAmount(uint64, string)`   — total work, e.g. (size, "bytes")
+ *       `setProcessedAmount(uint64, string)` — done so far in same units
+ *       `setPercent(uint32)`               — 0..100
+ *       `setDescriptionField(uint32 number, string label, string value)`
+ *       `terminate(string errorMessage)`   — empty string = success
+ *
+ * `org.kde.JobViewServer` is implemented by KDE's Plasma notification
+ * manager; if it isn't on the bus (e.g. GNOME without an extension that
+ * provides it, sway, etc.) `requestView` fails and the emitter degrades
+ * to no-op. The window-title fallback in `DownloadManager` still gives
+ * those users feedback.
+ */
+
+const dbus = require("@homebridge/dbus-native");
+
+const SERVICE = "org.kde.JobViewServer";
+const SERVER_PATH = "/JobViewServer";
+const SERVER_IFACE = "org.kde.JobViewServer";
+const VIEW_IFACE = "org.kde.JobViewV2";
+
+let bus = null;
+let busDisabled = false;
+
+function getBus() {
+  if (busDisabled) return null;
+  if (!bus) {
+    try {
+      bus = dbus.sessionBus();
+    } catch (error) {
+      console.warn("[DownloadManager] dbus sessionBus unavailable", {
+        message: error.message,
+      });
+      busDisabled = true;
+      return null;
+    }
+  }
+  return bus;
+}
+
+/**
+ * Open a JobView for a single download. Calls the JobView server's
+ * `requestView` method and resolves with a handle that exposes
+ * `update({ receivedBytes, totalBytes })` and `finish({ error? })`.
+ *
+ * If the JobView server is unavailable the returned handle's methods are
+ * no-ops, so callers can use the same code path on every Linux setup.
+ *
+ * @param {{appName?: string, appIconName?: string, filename: string, totalBytes?: number}} options
+ * @returns {Promise<{update: (Object) => void, finish: (Object) => void}>}
+ */
+async function start(options) {
+  const sessionBus = getBus();
+  if (!sessionBus) return noopHandle();
+
+  const appName = options.appName ?? "Teams for Linux";
+  const appIconName = options.appIconName ?? "teams-for-linux";
+
+  const viewPath = await invoke(sessionBus, {
+    destination: SERVICE,
+    path: SERVER_PATH,
+    interface: SERVER_IFACE,
+    member: "requestView",
+    signature: "ssi",
+    body: [appName, appIconName, 0],
+  }).catch((error) => {
+    // Most common failure: JobViewServer isn't on the bus (no Plasma /
+    // notification daemon). Disable for the rest of the process so we
+    // don't keep retrying the request.
+    console.warn("[DownloadManager] JobViewServer unavailable", {
+      message: error?.message ?? String(error),
+    });
+    busDisabled = true;
+    return null;
+  });
+
+  if (!viewPath) return noopHandle();
+
+  if (options.filename) {
+    invoke(sessionBus, {
+      destination: SERVICE,
+      path: viewPath,
+      interface: VIEW_IFACE,
+      member: "setInfoMessage",
+      signature: "s",
+      body: [`Downloading ${options.filename}`],
+    }).catch(noopReject);
+    invoke(sessionBus, {
+      destination: SERVICE,
+      path: viewPath,
+      interface: VIEW_IFACE,
+      member: "setDescriptionField",
+      signature: "uss",
+      body: [0, "File", options.filename],
+    }).catch(noopReject);
+  }
+
+  if (typeof options.totalBytes === "number" && options.totalBytes > 0) {
+    invoke(sessionBus, {
+      destination: SERVICE,
+      path: viewPath,
+      interface: VIEW_IFACE,
+      member: "setTotalAmount",
+      signature: "ts",
+      body: [options.totalBytes, "bytes"],
+    }).catch(noopReject);
+  }
+
+  let finished = false;
+  return {
+    update({ receivedBytes, totalBytes }) {
+      if (finished) return;
+      const total = typeof totalBytes === "number" ? totalBytes : 0;
+      const received = typeof receivedBytes === "number" ? receivedBytes : 0;
+
+      if (total > 0) {
+        const percent = Math.max(0, Math.min(100, Math.round((received * 100) / total)));
+        invoke(sessionBus, {
+          destination: SERVICE,
+          path: viewPath,
+          interface: VIEW_IFACE,
+          member: "setPercent",
+          signature: "u",
+          body: [percent],
+        }).catch(noopReject);
+        invoke(sessionBus, {
+          destination: SERVICE,
+          path: viewPath,
+          interface: VIEW_IFACE,
+          member: "setProcessedAmount",
+          signature: "ts",
+          body: [received, "bytes"],
+        }).catch(noopReject);
+      }
+    },
+    finish({ error } = {}) {
+      if (finished) return;
+      finished = true;
+      invoke(sessionBus, {
+        destination: SERVICE,
+        path: viewPath,
+        interface: VIEW_IFACE,
+        member: "terminate",
+        signature: "s",
+        body: [error ?? ""],
+      }).catch(noopReject);
+    },
+  };
+}
+
+function noopHandle() {
+  return {
+    update() {},
+    finish() {},
+  };
+}
+
+function noopReject() {
+  // Each invoke is fire-and-forget; swallow per-method errors so a single
+  // dropped DBus call doesn't tear the manager down.
+}
+
+/**
+ * Promise wrapper around `bus.invoke`.
+ *
+ * @param {object} sessionBus
+ * @param {object} message
+ */
+function invoke(sessionBus, message) {
+  return new Promise((resolve, reject) => {
+    sessionBus.invoke(message, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+module.exports = { start };

--- a/app/downloadManager/jobViewEmitter.js
+++ b/app/downloadManager/jobViewEmitter.js
@@ -23,6 +23,15 @@
  * provides it, sway, etc.) `requestView` fails and the emitter degrades
  * to no-op. The window-title fallback in `DownloadManager` still gives
  * those users feedback.
+ *
+ * The `appIconName` reported to KDE follows the running packaging:
+ *   - deb / rpm / source: `teams-for-linux` (matches the .desktop ID).
+ *   - Flatpak: the Flatpak app id from `FLATPAK_ID` (e.g.
+ *     `com.github.IsmaelMartinez.teams_for_linux`).
+ *   - Snap: the snap instance name from `SNAP_INSTANCE_NAME` / `SNAP_NAME`.
+ * Plasma resolves the name against the running session's icon theme; an
+ * unmatched name renders the JobView row with no icon, which is cosmetic
+ * but not a failure.
  */
 
 const dbus = require("@homebridge/dbus-native");
@@ -34,6 +43,18 @@ const VIEW_IFACE = "org.kde.JobViewV2";
 
 let bus = null;
 let busDisabled = false;
+
+function detectAppIconName() {
+  // Flatpak: the runtime sets FLATPAK_ID to the app id, which is also the
+  // canonical name of the bundled icon file.
+  if (process.env.FLATPAK_ID) return process.env.FLATPAK_ID;
+  // Snap: SNAP_INSTANCE_NAME is the parallel-install-aware name; SNAP_NAME
+  // is the bare package name. Both have a matching icon in the snap
+  // meta/gui directory.
+  if (process.env.SNAP_INSTANCE_NAME) return process.env.SNAP_INSTANCE_NAME;
+  if (process.env.SNAP_NAME) return process.env.SNAP_NAME;
+  return "teams-for-linux";
+}
 
 function getBus() {
   if (busDisabled) return null;
@@ -67,8 +88,14 @@ async function start(options) {
   if (!sessionBus) return noopHandle();
 
   const appName = options.appName ?? "Teams for Linux";
-  const appIconName = options.appIconName ?? "teams-for-linux";
+  const appIconName = options.appIconName ?? detectAppIconName();
 
+  // `capabilities` is a bitfield: 1 = Cancelable, 2 = Suspendable. We pass
+  // 0 deliberately — DownloadItem.cancel() / .pause() are not currently
+  // wired to IPC, so advertising those buttons in Plasma's notification
+  // widget would mislead the user. If we ever expose them, change this
+  // to 3 and bind the JobView's `cancelRequested` / `suspendRequested`
+  // signals to the matching DownloadItem methods.
   const viewPath = await invoke(sessionBus, {
     destination: SERVICE,
     path: SERVER_PATH,

--- a/app/downloadManager/launcherEntryEmitter.js
+++ b/app/downloadManager/launcherEntryEmitter.js
@@ -1,0 +1,124 @@
+/**
+ * Unity LauncherEntry emitter (aggregate progress on the dock / taskbar entry).
+ *
+ * Emits `com.canonical.Unity.LauncherEntry.Update` D-Bus broadcast signals so
+ * that Linux launchers subscribed to that interface render progress on the
+ * application's icon. The Unity launcher itself was discontinued in 2017,
+ * but the protocol it defined is what Ubuntu Dock (default GNOME extension
+ * shipped on Ubuntu since 17.10) and the popular Dash-to-Dock GNOME extension
+ * use today — so emitting these signals covers the single largest Linux DE
+ * audience (GNOME / Ubuntu).
+ *
+ * Why we emit the signal directly instead of relying on `BrowserWindow
+ * .setProgressBar()`: Electron gates that call on the `com.canonical.Unity`
+ * D-Bus name owner, which no modern DE registers, so `setProgressBar` is a
+ * silent no-op on every modern Linux setup. Emitting the broadcast signal
+ * ourselves bypasses Electron's dead probe — receivers (Ubuntu Dock,
+ * Dash-to-Dock, etc.) match the signal by interface and the desktop URI in
+ * its arguments, regardless of who owns any well-known name.
+ *
+ * The protocol:
+ *   - Interface: `com.canonical.Unity.LauncherEntry`
+ *   - Signal:    `Update`
+ *   - Path:      `/com/canonical/unity/launcherentry/<numeric-id>`
+ *                (path is informational; receivers match on args)
+ *   - Args:      `(s: desktop_entry_uri, a{sv}: properties)`
+ *   - Properties of interest:
+ *       progress         (double 0..1)
+ *       progress-visible (boolean)
+ *       count            (int64)
+ *       count-visible    (boolean)
+ *       urgent           (boolean)
+ *
+ * Unlike `jobViewEmitter`, this is *aggregate* — one running app icon, one
+ * progress value. `DownloadManager` calls `update({ progress, progressVisible })`
+ * with the byte-weighted average of all active downloads, and
+ * `update({ progressVisible: false })` once the queue drains.
+ */
+
+const dbus = require("@homebridge/dbus-native");
+
+const DESKTOP_URI = "application://teams-for-linux.desktop";
+const PATH_ID = simpleHash(DESKTOP_URI);
+const SIGNAL_PATH = `/com/canonical/unity/launcherentry/${PATH_ID}`;
+const INTERFACE = "com.canonical.Unity.LauncherEntry";
+const MEMBER = "Update";
+
+let bus = null;
+let busDisabled = false;
+
+function getBus() {
+  if (busDisabled) return null;
+  if (!bus) {
+    try {
+      bus = dbus.sessionBus();
+    } catch (error) {
+      console.warn("[DownloadManager] dbus sessionBus unavailable", {
+        message: error.message,
+      });
+      busDisabled = true;
+      return null;
+    }
+  }
+  return bus;
+}
+
+/**
+ * Emit a LauncherEntry Update broadcast signal.
+ *
+ * @param {object} props - Subset of {progress, progressVisible, count, countVisible, urgent}
+ */
+function update(props = {}) {
+  const sessionBus = getBus();
+  if (!sessionBus) return;
+
+  const properties = [];
+  if (typeof props.progress === "number") {
+    properties.push(["progress", ["d", props.progress]]);
+  }
+  if (typeof props.progressVisible === "boolean") {
+    properties.push(["progress-visible", ["b", props.progressVisible]]);
+  }
+  if (typeof props.count === "number") {
+    properties.push(["count", ["x", Math.trunc(props.count)]]);
+  }
+  if (typeof props.countVisible === "boolean") {
+    properties.push(["count-visible", ["b", props.countVisible]]);
+  }
+  if (typeof props.urgent === "boolean") {
+    properties.push(["urgent", ["b", props.urgent]]);
+  }
+
+  try {
+    // dbus-native's bus.sendSignal() builds the message with the right
+    // serial counter and pushes it through `connection.message()` which
+    // buffers pre-handshake and writes post-handshake. (A previous attempt
+    // that set the serial manually crashed with "Missing or invalid serial"
+    // when the message was marshalled during the handshake window.)
+    sessionBus.sendSignal(SIGNAL_PATH, INTERFACE, MEMBER, "sa{sv}", [
+      DESKTOP_URI,
+      properties,
+    ]);
+  } catch (error) {
+    console.warn("[DownloadManager] Failed to emit LauncherEntry signal", {
+      message: error.message,
+    });
+  }
+}
+
+/**
+ * Lightweight string-to-uint hash. Not cryptographic; used only to derive a
+ * stable numeric id for the DBus object path.
+ *
+ * @param {string} input
+ * @returns {number}
+ */
+function simpleHash(input) {
+  let h = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    h = (h * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+module.exports = { update };

--- a/app/downloadManager/launcherEntryEmitter.js
+++ b/app/downloadManager/launcherEntryEmitter.js
@@ -115,8 +115,8 @@ function update(props = {}) {
  */
 function simpleHash(input) {
   let h = 0;
-  for (let i = 0; i < input.length; i += 1) {
-    h = (h * 31 + input.charCodeAt(i)) >>> 0;
+  for (const codePoint of input) {
+    h = (h * 31 + codePoint.codePointAt(0)) >>> 0;
   }
   return h;
 }

--- a/app/index.js
+++ b/app/index.js
@@ -160,7 +160,33 @@ const customNotificationManager = new CustomNotificationManager(config, mainAppW
 // itself attaches to the Teams session inside handleAppReady once the main
 // window has been created (the partition is provisioned at that point).
 // `mainAppWindow` is passed so the manager can drive the taskbar progress bar.
-const downloadManager = new DownloadManager(config, mainAppWindow);
+// On Linux, wire in two D-Bus emitters that complement each other:
+//   - `jobViewEmitter`: per-download progress in KDE Plasma's notification
+//     widget (same surface users see for Firefox / Dolphin / KIO).
+//   - `launcherEntryEmitter`: aggregate progress on the dock icon for
+//     GNOME/Ubuntu users running Ubuntu Dock or Dash-to-Dock (the largest
+//     Linux DE audience). Bypasses Electron's `setProgressBar` Linux gate.
+// Both degrade to no-op if their respective service isn't on the bus, so
+// non-KDE / non-GNOME setups fall back to the window-title `[N%]` prefix.
+let jobEmitter = null;
+let launcherEmitter = null;
+if (os.platform() === "linux") {
+  try {
+    jobEmitter = require("./downloadManager/jobViewEmitter");
+  } catch (error) {
+    console.warn("[DownloadManager] JobView emitter unavailable", {
+      message: error.message,
+    });
+  }
+  try {
+    launcherEmitter = require("./downloadManager/launcherEntryEmitter");
+  } catch (error) {
+    console.warn("[DownloadManager] LauncherEntry emitter unavailable", {
+      message: error.message,
+    });
+  }
+}
+const downloadManager = new DownloadManager(config, mainAppWindow, jobEmitter, launcherEmitter);
 
 if (isMac) {
   requestMediaAccess();

--- a/app/index.js
+++ b/app/index.js
@@ -159,7 +159,8 @@ const customNotificationManager = new CustomNotificationManager(config, mainAppW
 // feedback unless `session.on('will-download', …)` is wired up. The manager
 // itself attaches to the Teams session inside handleAppReady once the main
 // window has been created (the partition is provisioned at that point).
-const downloadManager = new DownloadManager(config);
+// `mainAppWindow` is passed so the manager can drive the taskbar progress bar.
+const downloadManager = new DownloadManager(config, mainAppWindow);
 
 if (isMac) {
   requestMediaAccess();

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -138,7 +138,7 @@ Place your `config.json` file in the appropriate location based on your installa
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the download feedback feature. Opt-in while in early development; set to `true` to enable the manager. The sub-flags only take effect when `enabled` is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a file download finishes (click opens the containing folder). Set to `false` to suppress. |
-| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar (`BrowserWindow.setProgressBar`) while downloads are in flight. Indeterminate mode is used when the server doesn't advertise a content length. |
+| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar (`BrowserWindow.setProgressBar`) while downloads are in flight, and prefix the window title with `[34%]` as a portable fallback for Linux setups without `libunity` (Debian/Fedora/Arch/KDE-GNOME default). Indeterminate mode is used when the server doesn't advertise a content length. |
 
 ### Idle & Activity Detection
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -138,6 +138,7 @@ Place your `config.json` file in the appropriate location based on your installa
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the download feedback feature. Opt-in while in early development; set to `true` to enable the manager. The sub-flags only take effect when `enabled` is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a file download finishes (click opens the containing folder). Set to `false` to suppress. |
+| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar (`BrowserWindow.setProgressBar`) while downloads are in flight. Indeterminate mode is used when the server doesn't advertise a content length. |
 
 ### Idle & Activity Detection
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -138,7 +138,7 @@ Place your `config.json` file in the appropriate location based on your installa
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the download feedback feature. Opt-in while in early development; set to `true` to enable the manager. The sub-flags only take effect when `enabled` is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a file download finishes (click opens the containing folder). Set to `false` to suppress. |
-| `download.showProgressBar` | `boolean` | `true` | Drive the taskbar progress bar (`BrowserWindow.setProgressBar`) while downloads are in flight, and prefix the window title with `[34%]` as a portable fallback for Linux setups without `libunity` (Debian/Fedora/Arch/KDE-GNOME default). Indeterminate mode is used when the server doesn't advertise a content length. |
+| `download.showProgressBar` | `boolean` | `true` | Drive in-flight feedback through up to four channels: `BrowserWindow.setProgressBar` (macOS / Windows; effectively no-op on Linux), a `com.canonical.Unity.LauncherEntry` D-Bus broadcast that Ubuntu Dock and Dash-to-Dock subscribe to (GNOME / Ubuntu users), an `org.kde.JobViewServer` per-download view rendered in KDE Plasma's notification widget, and a portable `[34%]` window-title prefix that every WM/DE shows in the taskbar tooltip / Alt-Tab. |
 
 ### Idle & Activity Detection
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -138,7 +138,8 @@ Place your `config.json` file in the appropriate location based on your installa
 |--------|------|---------|-------------|
 | `download.enabled` | `boolean` | `false` | Master switch for the download feedback feature. Opt-in while in early development; set to `true` to enable the manager. The sub-flags only take effect when `enabled` is `true`. |
 | `download.notifyOnDownloadComplete` | `boolean` | `true` | Show a system notification when a file download finishes (click opens the containing folder). Set to `false` to suppress. |
-| `download.showProgressBar` | `boolean` | `true` | Drive in-flight feedback through up to four channels: `BrowserWindow.setProgressBar` (macOS / Windows; effectively no-op on Linux), a `com.canonical.Unity.LauncherEntry` D-Bus broadcast that Ubuntu Dock and Dash-to-Dock subscribe to (GNOME / Ubuntu users), an `org.kde.JobViewServer` per-download view rendered in KDE Plasma's notification widget, and a portable `[34%]` window-title prefix that every WM/DE shows in the taskbar tooltip / Alt-Tab. |
+| `download.showProgressBar` | `boolean` | `true` | Drive in-flight feedback through `BrowserWindow.setProgressBar` (macOS / Windows; effectively no-op on Linux), a `com.canonical.Unity.LauncherEntry` D-Bus broadcast that Ubuntu Dock and Dash-to-Dock subscribe to (GNOME / Ubuntu users), and an `org.kde.JobViewServer` per-download view rendered in KDE Plasma's notification widget. The window-title prefix is a separate sub-flag (`showTitlePrefix`). |
+| `download.showTitlePrefix` | `boolean` | `true` | Also prefix the main window title with `[34%]` (or `[downloading]`) while a download is in flight. Every WM/DE renders the window title in its taskbar tooltip / Alt-Tab, so this is a portable fallback for environments where the other channels are unavailable. Set to `false` on KDE / Ubuntu where the JobView / LauncherEntry already shows progress and the title churn is redundant. |
 
 ### Idle & Activity Detection
 

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -666,4 +666,55 @@ describe('DownloadManager', () => {
 
 		assert.strictEqual(launcherEmitter._calls.at(-1).progressVisible, false);
 	});
+
+	it('shows per-download percentages in the title for concurrent downloads', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const a = makeFakeDownloadItem('a', '/p/a', { totalBytes: 100, receivedBytes: 0 });
+		const b = makeFakeDownloadItem('b', '/p/b', { totalBytes: 100, receivedBytes: 0 });
+		fakeSession.emit('will-download', {}, a);
+		fakeSession.emit('will-download', {}, b);
+		a.setSizes({ receivedBytes: 34 });
+		b.setSizes({ receivedBytes: 78 });
+		a.emit('updated');
+
+		assert.strictEqual(mainAppWindow._title, '[34%, 78%] Microsoft Teams');
+	});
+
+	it('mixes `downloading` and percent in the title when one item lacks a total', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const a = makeFakeDownloadItem('a', '/p/a', { totalBytes: 100, receivedBytes: 50 });
+		const b = makeFakeDownloadItem('b', '/p/b', { totalBytes: 0 });
+		fakeSession.emit('will-download', {}, a);
+		fakeSession.emit('will-download', {}, b);
+
+		assert.strictEqual(mainAppWindow._title, '[50%, downloading] Microsoft Teams');
+	});
+
+	it('strips the multi-part prefix when re-applying so the title does not stack', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const a = makeFakeDownloadItem('a', '/p/a', { totalBytes: 100, receivedBytes: 10 });
+		const b = makeFakeDownloadItem('b', '/p/b', { totalBytes: 100, receivedBytes: 20 });
+		fakeSession.emit('will-download', {}, a);
+		fakeSession.emit('will-download', {}, b);
+		a.setSizes({ receivedBytes: 50 });
+		b.setSizes({ receivedBytes: 90 });
+		a.emit('updated');
+
+		assert.strictEqual(mainAppWindow._title, '[50%, 90%] Microsoft Teams');
+	});
 });

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -500,6 +500,28 @@ describe('DownloadManager', () => {
 		assert.strictEqual(mainAppWindow._title, 'Microsoft Teams');
 	});
 
+	it('leaves the window title untouched when showTitlePrefix is false', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(
+			enabledConfig({ download: { showTitlePrefix: false } }),
+			mainAppWindow,
+		);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100, receivedBytes: 25 });
+		fakeSession.emit('will-download', {}, item);
+		item.setSizes({ receivedBytes: 50 });
+		item.emit('updated');
+		item.emit('done', {}, 'completed');
+
+		// Title is never prefixed, and the progress bar still receives updates
+		// — the title-prefix flag does not gate the other progress channels.
+		assert.strictEqual(mainAppWindow._title, 'Microsoft Teams');
+		assert.ok(mainAppWindow._calls.length > 0);
+	});
+
 	it('survives a destroyed main window during progress updates', () => {
 		const DownloadManager = require(downloadManagerPath);
 		const mainAppWindow = makeFakeMainAppWindow();

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -56,10 +56,13 @@ function makeFakeSession() {
 	return emitter;
 }
 
-function makeFakeDownloadItem(filename, savePath) {
+function makeFakeDownloadItem(filename, savePath, sizes = {}) {
 	const emitter = new EventEmitter();
 	emitter.getFilename = () => filename;
 	emitter.getSavePath = () => savePath;
+	emitter.getTotalBytes = () => sizes.totalBytes ?? 0;
+	emitter.getReceivedBytes = () => sizes.receivedBytes ?? 0;
+	emitter.setSizes = (next) => Object.assign(sizes, next);
 	return emitter;
 }
 
@@ -72,6 +75,21 @@ function enabledConfig(extra = {}) {
 	return {
 		...rest,
 		download: { enabled: true, ...download },
+	};
+}
+
+function makeFakeMainAppWindow() {
+	const calls = [];
+	let destroyed = false;
+	const window = {
+		isDestroyed: () => destroyed,
+		setProgressBar: (...args) => calls.push(args),
+		_destroy: () => { destroyed = true; },
+	};
+	return {
+		getWindow: () => window,
+		_calls: calls,
+		_window: window,
 	};
 }
 
@@ -246,6 +264,128 @@ describe('DownloadManager', () => {
 		const DownloadManager = require(downloadManagerPath);
 		const manager = new DownloadManager(enabledConfig());
 		assert.doesNotThrow(() => manager.initialize(null));
+	});
+
+	it('drives the taskbar progress bar from receivedBytes / totalBytes', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/home/user/Downloads/big.zip',
+			{ totalBytes: 100, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+
+		item.setSizes({ receivedBytes: 25 });
+		item.emit('updated');
+		item.setSizes({ receivedBytes: 50 });
+		item.emit('updated');
+
+		// Initial call on will-download is 0/100, then 0.25, then 0.50.
+		const fractions = mainAppWindow._calls.map(c => c[0]);
+		assert.deepStrictEqual(fractions, [0, 0.25, 0.5]);
+	});
+
+	it('uses indeterminate mode when total size is unknown', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'unknown.bin',
+			'/home/user/Downloads/unknown.bin',
+			{ totalBytes: 0, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+
+		const [first, options] = mainAppWindow._calls.at(-1);
+		assert.strictEqual(first, 2);
+		assert.deepStrictEqual(options, { mode: 'indeterminate' });
+	});
+
+	it('aggregates progress across concurrent downloads', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const a = makeFakeDownloadItem('a', '/p/a', { totalBytes: 100, receivedBytes: 0 });
+		const b = makeFakeDownloadItem('b', '/p/b', { totalBytes: 300, receivedBytes: 0 });
+		fakeSession.emit('will-download', {}, a);
+		fakeSession.emit('will-download', {}, b);
+
+		// 50/100 + 150/300 = 200/400 = 0.5 (byte-weighted).
+		a.setSizes({ receivedBytes: 50 });
+		b.setSizes({ receivedBytes: 150 });
+		a.emit('updated');
+
+		const lastFraction = mainAppWindow._calls.at(-1)[0];
+		assert.strictEqual(lastFraction, 0.5);
+	});
+
+	it('clears the progress bar when all downloads finish', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/home/user/Downloads/big.zip',
+			{ totalBytes: 100, receivedBytes: 100 },
+		);
+		fakeSession.emit('will-download', {}, item);
+		item.emit('done', {}, 'completed');
+
+		assert.strictEqual(mainAppWindow._calls.at(-1)[0], -1);
+	});
+
+	it('does not drive progress when showProgressBar is false', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(
+			enabledConfig({ download: { showProgressBar: false } }),
+			mainAppWindow,
+		);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/home/user/Downloads/big.zip',
+			{ totalBytes: 100, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+		item.setSizes({ receivedBytes: 50 });
+		item.emit('updated');
+
+		assert.strictEqual(mainAppWindow._calls.length, 0);
+	});
+
+	it('survives a destroyed main window during progress updates', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/home/user/Downloads/big.zip',
+			{ totalBytes: 100, receivedBytes: 50 },
+		);
+		fakeSession.emit('will-download', {}, item);
+
+		mainAppWindow._window._destroy();
+		assert.doesNotThrow(() => item.emit('updated'));
 	});
 
 	it('does nothing when download.enabled is not set (opt-in default)', () => {

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -78,18 +78,23 @@ function enabledConfig(extra = {}) {
 	};
 }
 
-function makeFakeMainAppWindow() {
+function makeFakeMainAppWindow(initialTitle = 'Microsoft Teams') {
 	const calls = [];
 	let destroyed = false;
+	let title = initialTitle;
 	const window = {
 		isDestroyed: () => destroyed,
 		setProgressBar: (...args) => calls.push(args),
+		getTitle: () => title,
+		setTitle: (next) => { title = next; },
 		_destroy: () => { destroyed = true; },
 	};
 	return {
 		getWindow: () => window,
 		_calls: calls,
 		_window: window,
+		get _title() { return title; },
+		set _title(v) { title = v; },
 	};
 }
 
@@ -373,7 +378,7 @@ describe('DownloadManager', () => {
 	it("removes the 'updated' listener from the item once the download finishes", () => {
 		const DownloadManager = require(downloadManagerPath);
 		const mainAppWindow = makeFakeMainAppWindow();
-		const manager = new DownloadManager({}, mainAppWindow);
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
 		const fakeSession = makeFakeSession();
 		manager.initialize(fakeSession);
 
@@ -387,6 +392,88 @@ describe('DownloadManager', () => {
 		assert.strictEqual(item.listenerCount('updated'), 1);
 		item.emit('done', {}, 'completed');
 		assert.strictEqual(item.listenerCount('updated'), 0);
+	});
+
+	it('prefixes the window title with progress while a download is in flight', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Chats - Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/p/big.zip',
+			{ totalBytes: 1000, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+		item.setSizes({ receivedBytes: 340 });
+		item.emit('updated');
+
+		assert.strictEqual(mainAppWindow._title, '[34%] Chats - Microsoft Teams');
+	});
+
+	it('uses an indeterminate marker in the title when total size is unknown', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('unknown.bin', '/p/unknown.bin', { totalBytes: 0 });
+		fakeSession.emit('will-download', {}, item);
+
+		assert.strictEqual(mainAppWindow._title, '[downloading] Microsoft Teams');
+	});
+
+	it('strips its own prefix when re-applying so title does not stack', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100, receivedBytes: 10 });
+		fakeSession.emit('will-download', {}, item);
+		item.setSizes({ receivedBytes: 50 });
+		item.emit('updated');
+		item.setSizes({ receivedBytes: 90 });
+		item.emit('updated');
+
+		assert.strictEqual(mainAppWindow._title, '[90%] Microsoft Teams');
+	});
+
+	it('preserves a Teams-set page title when re-applying the prefix', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100, receivedBytes: 10 });
+		fakeSession.emit('will-download', {}, item);
+
+		// Simulate Teams updating the page title mid-download (which would
+		// normally fire `page-title-updated` and overwrite our prefix).
+		mainAppWindow._title = 'New chat - Microsoft Teams';
+		item.setSizes({ receivedBytes: 50 });
+		item.emit('updated');
+
+		assert.strictEqual(mainAppWindow._title, '[50%] New chat - Microsoft Teams');
+	});
+
+	it('clears the title prefix when all downloads finish', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow('Microsoft Teams');
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100, receivedBytes: 0 });
+		fakeSession.emit('will-download', {}, item);
+		item.emit('done', {}, 'completed');
+
+		assert.strictEqual(mainAppWindow._title, 'Microsoft Teams');
 	});
 
 	it('survives a destroyed main window during progress updates', () => {

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -98,6 +98,30 @@ function makeFakeMainAppWindow(initialTitle = 'Microsoft Teams') {
 	};
 }
 
+function makeFakeJobEmitter() {
+	const calls = { starts: [], updates: [], finishes: [] };
+	return {
+		_calls: calls,
+		start(opts) {
+			const handle = {
+				update(props) { calls.updates.push(props); },
+				finish(props) { calls.finishes.push(props); },
+			};
+			calls.starts.push(opts);
+			return handle;
+		},
+	};
+}
+
+function makeFakeLauncherEmitter() {
+	const calls = [];
+	return {
+		_calls: calls,
+		update(props) { calls.push(props); },
+	};
+}
+
+
 describe('DownloadManager', () => {
 	let originalConsoleDebug;
 	let originalConsoleWarn;
@@ -519,5 +543,127 @@ describe('DownloadManager', () => {
 		manager.initialize(fakeSession);
 
 		assert.strictEqual(fakeSession._onCalls.length, 0);
+	});
+
+	it('starts a JobView per download with filename + totalBytes', async () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const jobEmitter = makeFakeJobEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, jobEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/p/big.zip',
+			{ totalBytes: 10000, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+
+		assert.strictEqual(jobEmitter._calls.starts.length, 1);
+		assert.deepStrictEqual(jobEmitter._calls.starts[0], {
+			filename: 'big.zip',
+			totalBytes: 10000,
+		});
+	});
+
+	it('updates the JobView on item.updated and finishes on done(completed)', async () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const jobEmitter = makeFakeJobEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, jobEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/p/big.zip',
+			{ totalBytes: 1000, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+		item.setSizes({ receivedBytes: 250 });
+		item.emit('updated');
+
+		// Promise chain in the manager defers update; let the microtask run.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepStrictEqual(jobEmitter._calls.updates.at(-1), {
+			receivedBytes: 250,
+			totalBytes: 1000,
+		});
+
+		item.emit('done', {}, 'completed');
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.deepStrictEqual(jobEmitter._calls.finishes.at(-1), { error: '' });
+	});
+
+	it("reports the JobView with a non-empty error on cancelled / interrupted", async () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const jobEmitter = makeFakeJobEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, jobEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100 });
+		fakeSession.emit('will-download', {}, item);
+		item.emit('done', {}, 'cancelled');
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.match(jobEmitter._calls.finishes.at(-1).error, /cancelled/);
+	});
+
+	it('emits LauncherEntry progress aggregated across downloads', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const launcherEmitter = makeFakeLauncherEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, null, launcherEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const a = makeFakeDownloadItem('a', '/p/a', { totalBytes: 100, receivedBytes: 0 });
+		const b = makeFakeDownloadItem('b', '/p/b', { totalBytes: 300, receivedBytes: 0 });
+		fakeSession.emit('will-download', {}, a);
+		fakeSession.emit('will-download', {}, b);
+		a.setSizes({ receivedBytes: 50 });
+		b.setSizes({ receivedBytes: 150 });
+		a.emit('updated');
+
+		const last = launcherEmitter._calls.at(-1);
+		assert.strictEqual(last.progressVisible, true);
+		assert.strictEqual(last.progress, 0.5);
+	});
+
+	it('hides the LauncherEntry progress when all downloads finish', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const launcherEmitter = makeFakeLauncherEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, null, launcherEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('big.zip', '/p/big.zip', { totalBytes: 100, receivedBytes: 0 });
+		fakeSession.emit('will-download', {}, item);
+		item.emit('done', {}, 'completed');
+
+		assert.strictEqual(launcherEmitter._calls.at(-1).progressVisible, false);
+	});
+
+	it('hides LauncherEntry progress in indeterminate state (unknown total)', () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const launcherEmitter = makeFakeLauncherEmitter();
+		const manager = new DownloadManager(enabledConfig(), mainAppWindow, null, launcherEmitter);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem('unknown.bin', '/p/unknown.bin', { totalBytes: 0 });
+		fakeSession.emit('will-download', {}, item);
+
+		assert.strictEqual(launcherEmitter._calls.at(-1).progressVisible, false);
 	});
 });

--- a/tests/unit/downloadManager.test.js
+++ b/tests/unit/downloadManager.test.js
@@ -370,6 +370,25 @@ describe('DownloadManager', () => {
 		assert.strictEqual(mainAppWindow._calls.length, 0);
 	});
 
+	it("removes the 'updated' listener from the item once the download finishes", () => {
+		const DownloadManager = require(downloadManagerPath);
+		const mainAppWindow = makeFakeMainAppWindow();
+		const manager = new DownloadManager({}, mainAppWindow);
+		const fakeSession = makeFakeSession();
+		manager.initialize(fakeSession);
+
+		const item = makeFakeDownloadItem(
+			'big.zip',
+			'/home/user/Downloads/big.zip',
+			{ totalBytes: 100, receivedBytes: 0 },
+		);
+		fakeSession.emit('will-download', {}, item);
+
+		assert.strictEqual(item.listenerCount('updated'), 1);
+		item.emit('done', {}, 'completed');
+		assert.strictEqual(item.listenerCount('updated'), 0);
+	});
+
 	it('survives a destroyed main window during progress updates', () => {
 		const DownloadManager = require(downloadManagerPath);
 		const mainAppWindow = makeFakeMainAppWindow();


### PR DESCRIPTION
## Summary

Follow-up to #2513 that adds in-flight feedback through every Linux taskbar/dock signal Electron exposes, plus a portable window-title fallback.

In-flight progress is driven through four channels (all gated on `download.showProgressBar`, except the title prefix which has its own sub-flag):

- **`BrowserWindow.setProgressBar(fraction)`** — taskbar progress bar; Electron renders this on macOS and Windows, and on Linux only when `com.canonical.Unity` owns the bus name (no modern DE does). Byte-weighted aggregate across concurrent downloads.
- **`com.canonical.Unity.LauncherEntry`** — D-Bus broadcast that Ubuntu Dock and Dash-to-Dock subscribe to. Covers the GNOME / Ubuntu majority that `setProgressBar` no longer reaches. Same byte-weighted aggregate.
- **`org.kde.JobViewServer`** — per-download JobView in KDE Plasma's notification widget (the same protocol Firefox / Dolphin / KIO use). Each download gets its own row with filename, percent, and bytes processed. `appIconName` is derived from `FLATPAK_ID` / `SNAP_INSTANCE_NAME` / `SNAP_NAME` so the icon resolves for sandboxed packagings. `capabilities=0` deliberately — we don't expose `DownloadItem.cancel()` / `.pause()` over IPC.
- **Window-title prefix** — `[34%] ` (or `[34%, 78%] ` for concurrent downloads, `[downloading] ` for unknown-size items). Every WM/DE renders the window title in its taskbar tooltip / Alt-Tab list, so this is the universal fallback. Gated on the new `download.showTitlePrefix` sub-flag (default `true`) so KDE / Ubuntu users who already get JobView / LauncherEntry feedback can opt out.

Falls back to indeterminate mode on `setProgressBar` when the server doesn't advertise a content length. Clears the bar (`setProgressBar(-1)`) and the title prefix once no downloads are active.

New nested config flags (all default `true`; only take effect when `download.enabled` is `true`):

- `download.showProgressBar` — gate the taskbar / Unity / JobView channels.
- `download.showTitlePrefix` — gate the window-title prefix independently.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (215 tests, including coverage for: byte-weighted aggregate, indeterminate mode, concurrent downloads, completion clears the bar, opt-out flags, destroyed window safety, JobView start/update/finish, LauncherEntry progress + visibility, per-item title format, title-prefix opt-out, listener cleanup on `done`)
- [ ] Manual end-to-end: download a large file from a Teams chat, confirm a progress indicator appears on the KDE / Unity / GNOME taskbar and clears on completion.

closes #2512
