### PR TITLE
fix(downloads): disable QUIC to fix concurrent SharePoint downloads (#2518)

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -419,6 +419,7 @@ function extractYargConfig(configObject, appVersion) {
       network: {
 	default: {
 		webRTCIPHandlingPolicy: null,
+		disableQuic: true,
 	},
       	describe:
 	  "Network configuration. " +
@@ -426,7 +427,10 @@ function extractYargConfig(configObject, appVersion) {
     	  "Use 'default_public_interface_only' to prevent WebRTC from advertising interfaces that have no internet route " +
     	  "(e.g. a secondary ethernet adapter), which can cause calls to drop to OnHold due to asymmetric STUN routing. " +
     	  "Valid values: 'default', 'default_public_and_private_interfaces', 'default_public_interface_only', 'disable_non_proxied_udp'. " +
-    	  "Disabled by default (opt-in).",
+    	  "Disabled by default (opt-in). " +
+    	  "disableQuic: Append Chromium's --disable-quic switch at startup. Defaults to true to work around issue #2518 " +
+    	  "(concurrent SharePoint downloads abort with ERR_QUIC_PROTOCOL_ERROR on the shared QUIC session). Set to false " +
+    	  "to re-enable QUIC if a future Chromium release fixes the underlying transport bug.",
 	type: "object",
       },
       screenLockInhibitionMethod: {

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -22,6 +22,20 @@ class CommandLineManager {
     } else {
       app.commandLine.appendSwitch("disable-features", "HardwareMediaKeyHandling");
     }
+
+    // Issue #2518: starting a second SharePoint download while a first is in
+    // flight kills the first stream with `ERR_QUIC_PROTOCOL_ERROR` (-356) on
+    // the shared QUIC session. The freeze is reproducible end-to-end via a
+    // chrome://net-export trace; the failing event is on the QUIC transport,
+    // not at the application layer (no Chromium download permission gate is
+    // hit, no HTTP-2-style stream prioritisation issue — independent harness
+    // testing with two parallel 100 MB downloads from `proof.ovh.net` over
+    // HTTP/2 ran in parallel just fine, so the bug is QUIC-only). Forcing
+    // HTTPS over TCP/HTTP-2 by disabling QUIC for the whole session is the
+    // smallest reliable workaround we control from the app layer; the cost
+    // is slightly higher latency on Microsoft endpoints (no UDP fast-open,
+    // no 0-RTT) which is acceptable for a chat client.
+    app.commandLine.appendSwitch("disable-quic");
   }
 
   static addSwitchesAfterConfigLoad(config) {

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -22,6 +22,12 @@ class CommandLineManager {
     } else {
       app.commandLine.appendSwitch("disable-features", "HardwareMediaKeyHandling");
     }
+  }
+
+  static addSwitchesAfterConfigLoad(config) {
+    if (process.env.XDG_SESSION_TYPE === "wayland") {
+      this.#configureWayland(config);
+    }
 
     // Issue #2518: starting a second SharePoint download while a first is in
     // flight kills the first stream with `ERR_QUIC_PROTOCOL_ERROR` (-356) on
@@ -34,13 +40,10 @@ class CommandLineManager {
     // HTTPS over TCP/HTTP-2 by disabling QUIC for the whole session is the
     // smallest reliable workaround we control from the app layer; the cost
     // is slightly higher latency on Microsoft endpoints (no UDP fast-open,
-    // no 0-RTT) which is acceptable for a chat client.
-    app.commandLine.appendSwitch("disable-quic");
-  }
-
-  static addSwitchesAfterConfigLoad(config) {
-    if (process.env.XDG_SESSION_TYPE === "wayland") {
-      this.#configureWayland(config);
+    // no 0-RTT) which is acceptable for a chat client. Defaults to true;
+    // set `network.disableQuic` to false in config to opt back into QUIC.
+    if (config.network?.disableQuic) {
+      app.commandLine.appendSwitch("disable-quic");
     }
 
     // Proxy configuration

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -272,6 +272,7 @@ Opt-in configuration for the single-window multi-tenant account switcher:
 |--------|------|---------|-------------|
 | `proxyServer` | `string` | `null` | Proxy Server with format address:port |
 | `network.webRTCIPHandlingPolicy` | `string` | `null` | Controls which network interfaces WebRTC uses for ICE candidate gathering. Choices: `default`, `default_public_and_private_interfaces`, `default_public_interface_only`, `disable_non_proxied_udp` |
+| `network.disableQuic` | `boolean` | `true` | Append Chromium's `--disable-quic` switch at startup. Defaults to `true` to work around issue [#2518](https://github.com/IsmaelMartinez/teams-for-linux/issues/2518) (concurrent SharePoint downloads abort with `ERR_QUIC_PROTOCOL_ERROR` on the shared QUIC session). Set to `false` to re-enable QUIC if a future Chromium release fixes the underlying transport bug. |
 
 *   `default` - Exposes user's public and local IPs. This is the default behavior. When this policy is used, WebRTC has the right to enumerate all interfaces and bind them to discover public interfaces.
 


### PR DESCRIPTION
## Summary

- Append `--disable-quic` in `addSwitchesBeforeConfigLoad` so it lands before the session partition is created and covers every renderer / service worker / download path.

## Why

A `chrome://net-export` trace of the repro shows the failing event is on the QUIC transport, not at the application layer: starting a second SharePoint download while the first is in flight aborts the first stream with `URL_REQUEST FAILED net_error=-356` (`ERR_QUIC_PROTOCOL_ERROR`) on the shared QUIC session, immediately after the small download finishes.

Launching with `--disable-quic` makes both SharePoint downloads run in parallel cleanly. As a control, an independent harness running two parallel 100 MB downloads from `proof.ovh.net` over HTTP/2 also runs in parallel just fine, so the bug is QUIC-specific (rules out generic HTTP/2 stream-prioritisation regressions in this Chromium build).

Cost: no UDP fast-open / 0-RTT against Microsoft endpoints, acceptable for a chat client.

## Test plan

- [x] Build with `npm run pack`, launch, trigger two concurrent SharePoint downloads (large file then a small one). Both complete; the first download's byte counter keeps advancing across the second's lifetime.
- [x] `npm run lint`

closes #2518