### PR TITLE
feat(notifications): add notifications.timeoutType opt-in

### DIFF
--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -304,8 +304,11 @@ function createCustomNotification(title, options) {
     options.icon = options.icon || ICON_BASE64;
     options.title = options.title || title;
     options.type = options.type || "new-message";
-    // Explicitly set false for Ubuntu Unity DE auto-close. Others are unaffected.
-    options.requireInteraction = false;
+    // Default to false for Ubuntu Unity DE auto-close. Users on GNOME and
+    // similar can opt into persistent notifications via
+    // `notifications.requireInteraction` (issue #2411).
+    options.requireInteraction =
+      notificationConfig?.notifications?.requireInteraction === true;
 
     // Default to "web" if config not loaded yet
     const method = notificationConfig?.notificationMethod || "web";

--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -304,11 +304,14 @@ function createCustomNotification(title, options) {
     options.icon = options.icon || ICON_BASE64;
     options.title = options.title || title;
     options.type = options.type || "new-message";
-    // Default to false for Ubuntu Unity DE auto-close. Users on GNOME and
-    // similar can opt into persistent notifications via
-    // `notifications.requireInteraction` (issue #2411).
-    options.requireInteraction =
-      notificationConfig?.notifications?.requireInteraction === true;
+    // Default Ubuntu Unity DE auto-closes. Users on GNOME and similar can opt
+    // into persistent notifications via `notifications.timeoutType: "never"`
+    // (issue #2411). Mirrors Electron's Notification timeoutType.
+    options.timeoutType =
+      notificationConfig?.notifications?.timeoutType === "never"
+        ? "never"
+        : "default";
+    options.requireInteraction = options.timeoutType === "never";
 
     // Default to "web" if config not loaded yet
     const method = notificationConfig?.notificationMethod || "web";

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -297,10 +297,10 @@ function extractYargConfig(configObject, appVersion) {
       },
       notifications: {
         default: {
-          requireInteraction: false,
+          timeoutType: "default",
         },
         describe:
-          "Notification behaviour. requireInteraction: keep notifications persistent in the system notification center until the user dismisses them. Useful on GNOME and other desktops that auto-remove notifications from the center on timeout. May not be honoured by every notification daemon.",
+          "Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon.",
         type: "object",
       },
       disableBadgeCount: {

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -295,6 +295,14 @@ function extractYargConfig(configObject, appVersion) {
           "A flag indicates whether to disable window flashing when there is a notification",
         type: "boolean",
       },
+      notifications: {
+        default: {
+          requireInteraction: false,
+        },
+        describe:
+          "Notification behaviour. requireInteraction: keep notifications persistent in the system notification center until the user dismisses them. Useful on GNOME and other desktops that auto-remove notifications from the center on timeout. May not be honoured by every notification daemon.",
+        type: "object",
+      },
       disableBadgeCount: {
         default: false,
         describe:

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -69,14 +69,11 @@ class NotificationService {
         body: options.body,
       });
 
-      // Electron's native Notification uses timeoutType rather than
-      // requireInteraction to control persistence on Linux and Windows, so
-      // translate the web-shaped flag here.
       const notificationConfig = {
         title: options.title,
         body: options.body,
         urgency: this.#config.defaultNotificationUrgency,
-        timeoutType: options.requireInteraction ? "never" : "default",
+        timeoutType: options.timeoutType === "never" ? "never" : "default",
       };
 
       // Only add icon if provided to avoid errors with null/undefined

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -69,11 +69,14 @@ class NotificationService {
         body: options.body,
       });
 
-      // Create notification config
+      // Electron's native Notification uses timeoutType rather than
+      // requireInteraction to control persistence on Linux and Windows, so
+      // translate the web-shaped flag here.
       const notificationConfig = {
         title: options.title,
         body: options.body,
         urgency: this.#config.defaultNotificationUrgency,
+        timeoutType: options.requireInteraction ? "never" : "default",
       };
 
       // Only add icon if provided to avoid errors with null/undefined

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -118,7 +118,7 @@ Place your `config.json` file in the appropriate location based on your installa
 | `notificationMethod` | `string` | `"web"` | Notification method. Choices: `web`, `electron`, `custom` |
 | `customNotification` | `object` | `{ toastDuration: 5000 }` | Configuration for custom in-app toast notifications (used when `notificationMethod` is `custom`) |
 | `defaultNotificationUrgency` | `string` | `"normal"` | Default urgency for new notifications. Choices: `low`, `normal`, `critical` |
-| `notifications.requireInteraction` | `boolean` | `false` | Keep notifications persistent in the system notification center until the user dismisses them. Useful on GNOME and other desktops that auto-remove notifications from the center on timeout. May not be honoured by every notification daemon. |
+| `notifications.timeoutType` | `string` | `"default"` | How long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification `timeoutType`. May not be honoured by every notification daemon. |
 
 ### Incoming Call Handling
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -118,6 +118,7 @@ Place your `config.json` file in the appropriate location based on your installa
 | `notificationMethod` | `string` | `"web"` | Notification method. Choices: `web`, `electron`, `custom` |
 | `customNotification` | `object` | `{ toastDuration: 5000 }` | Configuration for custom in-app toast notifications (used when `notificationMethod` is `custom`) |
 | `defaultNotificationUrgency` | `string` | `"normal"` | Default urgency for new notifications. Choices: `low`, `normal`, `critical` |
+| `notifications.requireInteraction` | `boolean` | `false` | Keep notifications persistent in the system notification center until the user dismisses them. Useful on GNOME and other desktops that auto-remove notifications from the center on timeout. May not be honoured by every notification daemon. |
 
 ### Incoming Call Handling
 


### PR DESCRIPTION
## Summary

Follow-up to #2414. Adds an opt-in `notifications.requireInteraction` config flag for users (e.g. on GNOME 49) whose notification daemon auto-removes notifications from the centre on timeout. Translates to Electron's native `timeoutType: 'never' | 'default'` on the main side so the same flag works for both `web` and `electron` notification methods.

Nested under a new `notifications` parent rather than added flat at the top level, since the flat option list is already large and the prior iteration on #2414 made the same option flat (which read oddly). Existing flat notification options stay where they are for backwards compatibility.

Refs #2411 — the GNOME-49 reporter on that issue is the natural tester for whether `requireInteraction` actually changes behaviour. The PR build artifact is attached below for them to grab.

## Test plan

- [x] `npm run lint` clean
- [x] Reporter on #2411 grabs the rpm from this PR's build artifact, sets `{ "notifications": { "requireInteraction": true } }` in their config, and confirms whether notifications now stay in the GNOME 49 notification centre after the toast times out
- [x] Default behaviour unchanged when the flag is absent or `false`

## Files changed

- `app/config/index.js` — new `notifications` nested object with `requireInteraction: false` default
- `app/browser/preload.js` — reads `notificationConfig?.notifications?.requireInteraction === true`
- `app/notifications/service.js` — translates `options.requireInteraction` to `timeoutType` on the native Notification
- `docs-site/docs/configuration.md` — adds the new option to the Notification System table