### PR TITLE
fix(customCSS): swallow expected executeJavaScript rejections

### DIFF
--- a/app/customCSS/index.js
+++ b/app/customCSS/index.js
@@ -55,7 +55,8 @@ function applyCustomCSSToFrame(webFrame, cssLocation) {
 
     data = data.replaceAll("`", String.raw`\u0060`);
 
-    webFrame.executeJavaScript(`
+    webFrame
+      .executeJavaScript(`
 			if(!document.getElementById("${customCssId}")) {
 				const style = document.createElement('style');
 				style.id = "${customCssId}";
@@ -63,6 +64,16 @@ function applyCustomCSSToFrame(webFrame, cssLocation) {
 				style.textContent = ${JSON.stringify(data)};
 				document.head.appendChild(style);
 			}
-		`);
+		`)
+      .catch((err) => {
+        // Sandboxed about:blank frames (Office Online paste) and frames
+        // disposed mid-flight reject here. Both are expected; swallow so
+        // the rejection does not trip the main-process unhandledRejection
+        // handler in app/index.js and terminate the app.
+        console.debug(
+          "[customCSS] executeJavaScript rejected:",
+          err && err.message ? err.message : err
+        );
+      });
   });
 }

--- a/app/customCSS/index.js
+++ b/app/customCSS/index.js
@@ -70,10 +70,7 @@ function applyCustomCSSToFrame(webFrame, cssLocation) {
         // disposed mid-flight reject here. Both are expected; swallow so
         // the rejection does not trip the main-process unhandledRejection
         // handler in app/index.js and terminate the app.
-        console.debug(
-          "[customCSS] executeJavaScript rejected:",
-          err && err.message ? err.message : err
-        );
+        console.debug("[customCSS] executeJavaScript rejected:", err);
       });
   });
 }


### PR DESCRIPTION
## Summary

Suspected fix for the paste-into-Word crash reported in #2530.

`applyCustomCSSToFrame` in `app/customCSS/index.js:58` calls `webFrame.executeJavaScript` without a `.catch()`. Two rejection causes show up in the reports:

- `'Script not run'` when Chromium refuses script execution inside a sandboxed `about:blank` frame (Office Online creates these during paste), reported by @fhwedel-hoe.
- `'Render frame was disposed before WebFrameMain could be accessed'` when the frame disappears mid-flight, reported by @mikedld in the same thread.

Both rejections bubble up to the main-process `unhandledRejection` handler at `app/index.js:61` and `process.exit(1)`. Adding a `.catch()` that logs at debug level keeps the app running. The missed injection is acceptable because the only site that could repro is a transient sandboxed frame or a torn-down frame.

I cannot reproduce the original Office paste flow locally without a real Office Online document, so I have not byte-confirmed the failing path. Worth a tester pass before merging, ideally by @fhwedel-hoe with their original `customCSSLocation` config.

## Test plan

- [ ] @fhwedel-hoe: with `customCSSLocation` set, paste external content into a Word document on OneDrive and confirm the app no longer terminates.
- [ ] @mikedld: run startup with the same `customCSSLocation` config and confirm the random "Render frame was disposed" exits stop.
- [ ] Sanity: lint passes (`npm run lint`).

closes #2530
