### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Thanks for contributing! A few things to include so reviewers can move
+quickly:
+
+  1. Link the issue this PR resolves with `closes #NNN` (or `fixes #NNN` /
+     `resolves #NNN`) so GitHub auto-closes it on merge and release notes
+     surface the original report.
+  2. Describe what changed and how you tested it.
+  3. Call out any docs you updated (or that still need updating).
+
+Delete sections that don't apply.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? -->
+
+closes #
+
+## Testing
+
+<!--
+How did you verify the change? Tick what applies and add notes.
+
+  - [ ] `npm run lint`
+  - [ ] `npm run test:unit`
+  - [ ] `npm run test:e2e`
+  - [ ] Ran the app manually (`npm start`) and exercised the affected path
+  - [ ] Cross-distro / packaging build
+-->
+
+## Documentation
+
+<!--
+List any docs touched in this PR, or note that none were needed.
+
+  - [ ] Updated `docs-site/docs/...`
+  - [ ] Updated module `README.md`
+  - [ ] Ran `npm run generate-ipc-docs` (IPC channel added or changed)
+  - [ ] N/A
+-->
+
+## Notes for reviewers
+
+<!-- Optional: screenshots, follow-up work, anything reviewers should know. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,18 +15,19 @@ Delete sections that don't apply.
 
 <!-- What does this PR change and why? -->
 
-closes #
+closes #NNN
 
 ## Testing
 
 <!--
-How did you verify the change? Tick what applies and add notes.
+How did you verify the change? Tick what applies and add notes. `npm run
+lint` is required before every commit.
 
-  - [ ] `npm run lint`
+  - [ ] `npm run lint` (required)
   - [ ] `npm run test:unit`
   - [ ] `npm run test:e2e`
   - [ ] Ran the app manually (`npm start`) and exercised the affected path
-  - [ ] Cross-distro / packaging build
+  - [ ] Cross-distro / packaging build (`npm run cross-distro`)
 -->
 
 ## Documentation
@@ -36,7 +37,8 @@ List any docs touched in this PR, or note that none were needed.
 
   - [ ] Updated `docs-site/docs/...`
   - [ ] Updated module `README.md`
-  - [ ] Ran `npm run generate-ipc-docs` (IPC channel added or changed)
+  - [ ] Added the new channel to `app/security/ipcValidator.js` and ran `npm run generate-ipc-docs` (IPC channel added or changed)
+  - [ ] No new PII added to logs (see CLAUDE.md "Logging Guidelines")
   - [ ] N/A
 -->
 


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md`, prompting contributors to link the
resolved issue, note testing performed, and call out any documentation
updates.

The roadmap flagged this in Phase 3 --- Dev Experience Quick Wins:

> **PR template.** The codebase review flagged this as missing. A simple
> template ensuring PRs reference issues, describe testing done, and note
> any doc updates.

The `closes #NNN` placeholder makes the project convention (release notes
linking back to the originating bug report) explicit instead of leaving
contributors to find it in the contributing guide.

## Testing

- [x] `npm run lint`
- [x] Rendered the template locally --- sections behave as expected when
      filled out.

## Documentation

- [x] N/A --- the template itself is the contributor-facing documentation
      change.