### PR TITLE
ci: gate packaging jobs on e2e_tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           retention-days: 7
 
   linux_x64:
-    needs: [lint_and_audit]
+    needs: [lint_and_audit, e2e_tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -118,7 +118,7 @@ jobs:
           compression-level: 6
 
   linux_arm64:
-    needs: [lint_and_audit]
+    needs: [lint_and_audit, e2e_tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -160,7 +160,7 @@ jobs:
           compression-level: 6
 
   linux_arm:
-    needs: [lint_and_audit]
+    needs: [lint_and_audit, e2e_tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -202,7 +202,7 @@ jobs:
           compression-level: 6
 
   dmg:
-    needs: [lint_and_audit]
+    needs: [lint_and_audit, e2e_tests]
     runs-on: macos-latest
     permissions:
       contents: write
@@ -240,7 +240,7 @@ jobs:
           compression-level: 6
 
   exe:
-    needs: [lint_and_audit]
+    needs: [lint_and_audit, e2e_tests]
     runs-on: windows-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Adds `e2e_tests` to the `needs:` array of all five packaging jobs
(`linux_x64`, `linux_arm64`, `linux_arm`, `dmg`, `exe`) so an E2E failure
prevents the build/release artifacts from being produced or published.

The roadmap calls this out in Phase 2 --- CI Integration:

> **Gate builds on E2E tests.** Currently `linux_x64` packaging depends only
> on `lint_and_audit`. The `e2e_tests` job runs but failures don't block
> packaging or merges. Add `e2e_tests` to the `needs` list for packaging
> jobs.

Before this change, the `e2e_tests` job ran on every push/PR but its result
was advisory only --- a green packaging artifact could be published from a
commit where the E2E suite was red. After this change the dependency edge
is enforced and packaging is skipped if E2E fails.

## Testing

- [x] Reviewed the YAML diff --- only the `needs:` field on the five
      packaging jobs is touched; nothing else in the workflow changes.
- [x] CI will exercise the new dependency on this PR itself.

## Documentation

- [x] N/A --- no user-facing or developer-facing docs change. The roadmap
      already documented the desired state.