### PR TITLE
test(preload): guard modulesRequiringIpc against regression (#1902)

### DIFF
--- a/tests/e2e/preload-modules.spec.js
+++ b/tests/e2e/preload-modules.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import {
+  startApp,
+  findMainTeamsWindow,
+  waitForLoginRedirect,
+  closeAndCleanup,
+} from './helpers/electronApp.js';
+
+// Integration regression check for issue #1902 (CLAUDE.md "Modules
+// Requiring IPC Initialization"). The static guard in
+// `tests/unit/preloadModules.test.js` asserts that `trayIconRenderer`
+// stays in the `modulesRequiringIpc` Set in `app/browser/preload.js`.
+// This test exercises the runtime consequence end-to-end: if the module
+// is not initialised with `ipcRenderer`, `this.ipcRenderer` is undefined
+// and the `unread-count` event handler throws before any IPC is sent.
+//
+// `count: 0` hits the early-return branch in
+// `trayIconRenderer.updateActivityCount`, which sends a `tray-update`
+// IPC without exercising canvas rendering --- the cheapest signal that
+// `init(config, ipcRenderer)` ran correctly.
+
+test('preload passes ipcRenderer to trayIconRenderer (regression #1902)', async () => {
+  // `allowEval: true` sets E2E_TESTING=true so `electronApp.evaluate`
+  // can install an ipcMain listener on the main process. Same pattern
+  // as `multi-account-disabled.spec.js`.
+  const ctx = await startApp({
+    prefix: 'teams-e2e-preload-tray-',
+    allowEval: true,
+  });
+
+  try {
+    const mainWindow = findMainTeamsWindow(ctx.electronApp);
+    expect(mainWindow).toBeTruthy();
+    await waitForLoginRedirect(mainWindow);
+
+    // Capture `tray-update` payloads on the main process. `ipcMain.on`
+    // permits multiple listeners, so this coexists with the app's
+    // production handler.
+    await ctx.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__capturedTrayUpdates = [];
+      ipcMain.on('tray-update', (_event, payload) => {
+        globalThis.__capturedTrayUpdates.push(payload);
+      });
+    });
+
+    await mainWindow.evaluate(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent('unread-count', { detail: { number: 0 } })
+      );
+    });
+
+    // The renderer dispatches synchronously, but the IPC hop is async.
+    // Poll for up to 5 s rather than guessing a fixed delay.
+    const captured = await ctx.electronApp.evaluate(async () => {
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        if (globalThis.__capturedTrayUpdates.length > 0) {
+          return globalThis.__capturedTrayUpdates;
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return globalThis.__capturedTrayUpdates;
+    });
+
+    expect(
+      captured.length,
+      'trayIconRenderer should send a `tray-update` IPC when `unread-count` fires. ' +
+        'If this fails, check that `modulesRequiringIpc` in `app/browser/preload.js` ' +
+        'still includes "trayIconRenderer" (CLAUDE.md / issue #1902).'
+    ).toBeGreaterThan(0);
+    expect(captured[0]).toMatchObject({ count: 0 });
+  } finally {
+    await closeAndCleanup(ctx);
+  }
+});

--- a/tests/e2e/preload-modules.spec.js
+++ b/tests/e2e/preload-modules.spec.js
@@ -50,9 +50,10 @@ test('preload passes ipcRenderer to trayIconRenderer (regression #1902)', async 
     });
 
     // The renderer dispatches synchronously, but the IPC hop is async.
-    // Poll for up to 5 s rather than guessing a fixed delay.
+    // Poll up to 15 s --- successful runs return on the first iteration;
+    // the generous deadline only matters on slow CI runners.
     const captured = await ctx.electronApp.evaluate(async () => {
-      const deadline = Date.now() + 5000;
+      const deadline = Date.now() + 15000;
       while (Date.now() < deadline) {
         if (globalThis.__capturedTrayUpdates.length > 0) {
           return globalThis.__capturedTrayUpdates;

--- a/tests/unit/preloadModules.test.js
+++ b/tests/unit/preloadModules.test.js
@@ -43,11 +43,12 @@ describe('preload.js modulesRequiringIpc Set', () => {
 		);
 	});
 
+	// Extract each quoted string from the Set's argument list. Regex over
+	// split(',') is robust against inline comments, trailing commas, and
+	// whitespace formatting changes inside the array literal.
 	const declaredNames = match
-		? match[1]
-			.split(',')
-			.map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
-			.filter(Boolean)
+		? (match[1].match(/"[^"]*"|'[^']*'/g) || [])
+			.map((s) => s.slice(1, -1))
 		: [];
 
 	for (const name of REQUIRED_MODULES) {

--- a/tests/unit/preloadModules.test.js
+++ b/tests/unit/preloadModules.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+// Regression guard for issue #1902 and the CLAUDE.md "Modules Requiring IPC
+// Initialization" rule. The `modulesRequiringIpc` Set in
+// `app/browser/preload.js` controls which browser-side modules receive
+// `ipcRenderer` during `init`. Dropping `trayIconRenderer` or
+// `mqttStatusMonitor` from this Set is a silent regression --- the modules
+// load fine, then crash later inside their handlers with
+// `TypeError: Cannot read properties of undefined (reading 'send')`.
+// CLAUDE.md notes the fix has been "accidentally removed multiple times
+// in git history".
+//
+// `preload.js` is an Electron preload script that can't be `require`d in
+// a plain Node test without stubbing the `electron` runtime. Parsing it
+// as text keeps the test fast, deterministic, and free of mocks --- the
+// Set declaration is a stable invariant the rule depends on.
+
+const PRELOAD_PATH = join(__dirname, '..', '..', 'app', 'browser', 'preload.js');
+const REQUIRED_MODULES = ['settings', 'theme', 'trayIconRenderer', 'mqttStatusMonitor', 'webauthnOverride'];
+
+describe('preload.js modulesRequiringIpc Set', () => {
+	const source = readFileSync(PRELOAD_PATH, 'utf8');
+
+	// Match: const modulesRequiringIpc = new Set([ "a", "b", ... ]);
+	// across whitespace and either single or double quotes, but require the
+	// `new Set` form so a future refactor to an array (or different name)
+	// fails the test loudly rather than silently passing.
+	const match = source.match(
+		/const\s+modulesRequiringIpc\s*=\s*new\s+Set\(\s*\[([\s\S]*?)\]\s*\)/
+	);
+
+	it('is declared as a new Set([...]) literal', () => {
+		assert.ok(
+			match,
+			'Could not find `const modulesRequiringIpc = new Set([...])` in app/browser/preload.js. ' +
+				'If the declaration was refactored, update this test --- the Set membership rule ' +
+				'(CLAUDE.md, issue #1902) still applies.'
+		);
+	});
+
+	const declaredNames = match
+		? match[1]
+			.split(',')
+			.map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+			.filter(Boolean)
+		: [];
+
+	for (const name of REQUIRED_MODULES) {
+		it(`includes "${name}"`, () => {
+			assert.ok(
+				declaredNames.includes(name),
+				`"${name}" missing from \`modulesRequiringIpc\` in app/browser/preload.js. ` +
+					'This module needs `ipcRenderer` during init or its IPC calls throw silently. ' +
+					'See CLAUDE.md "Modules Requiring IPC Initialization" and issue #1902.'
+			);
+		});
+	}
+});


### PR DESCRIPTION
## Summary

Adds a paired unit + E2E regression guard for the rule documented in the
project's contributor instructions under "Modules Requiring IPC
Initialization":

> The \`trayIconRenderer\` and \`mqttStatusMonitor\` modules **MUST** be
> included in the list of modules that receive \`ipcRenderer\` during
> initialization in \`app/browser/preload.js\`.
>
> [...]
>
> This fix has been accidentally removed multiple times in git history,
> causing recurring issues. Most recently addressed in issue #1902.

A regression silently breaks tray badge counts and MQTT status publishing
--- modules load fine, then \`this.ipcRenderer.send(...)\` throws inside a
handler that nothing in CI exercises today.

Two complementary tests:

- **\`tests/unit/preloadModules.test.js\` (primary guard).** Parses
  \`app/browser/preload.js\` as text and asserts the
  \`modulesRequiringIpc = new Set([...])\` declaration is intact and
  contains each required module name. Six assertions, ~2 ms,
  deterministic, no Electron launch required. This catches the exact
  refactor that has regressed in history.
- **\`tests/e2e/preload-modules.spec.js\` (runtime cross-check).**
  Dispatches the renderer-side \`unread-count\` event with \`count: 0\`
  (hits the early-return branch in \`trayIconRenderer.updateActivityCount\`
  that sends \`tray-update\` without canvas work) and asserts the IPC
  reaches the main process via a \`ipcMain.on('tray-update', ...)\`
  listener installed from the test. \`ipcMain.on\` permits multiple
  listeners, so the test coexists with the app's production handler.

The unit test is the primary signal --- a multi-AI review of the initial
implementation pointed out that a Playwright launch is overkill for a
Set-membership invariant, and that a similar E2E test for
\`mqttStatusMonitor\` would not catch the same regression because the
module's init logs before it touches \`ipcRenderer\`. The E2E only covers
\`trayIconRenderer\`, where the runtime path actually does fail if
\`ipcRenderer\` is missing.

Roadmap context: \`docs-site/docs/development/plan/roadmap.md\` "Phase 1
--- Cross-Distro Testing Hardening":

> The features that actually break during Electron upgrades
> (notifications, media permissions, SSO recovery) are untested. Add
> tests [...].

The notification stub interface is already well covered in
\`tests/e2e/notifications.spec.js\`. The "permission check handler"
mentioned in the roadmap doesn't currently exist on \`main\` (the PR for
#2221 never landed), so testing it would be premature. The preload
module initialisation regression is the most concrete recurring gap.

## Testing

- [x] \`npm run lint\` (required)
- [x] \`npm run test:unit\` --- 221 tests pass, including the 6 new
      assertions in \`preloadModules.test.js\`.
- [x] Simulated the regression locally by removing \`trayIconRenderer\`
      and \`mqttStatusMonitor\` from the Set in preload.js: the unit test
      fails with the documented "missing from \`modulesRequiringIpc\`"
      message that points back at the contributor instructions and issue
      #1902. Restored after verification.
- [x] E2E spec syntax and imports match the existing
      \`tests/e2e/multi-account-disabled.spec.js\` style; haven't run the
      Playwright spec locally because the runner needs an X server, but
      CI will exercise it via xvfb.

## Documentation

- [x] N/A --- the tests reference the contributor instructions inline,
      where the rule is already documented.