### PR TITLE
chore(deps): bump electron from 41.5.0 to 41.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.60.0",
-        "electron": "41.5.0",
+        "electron": "41.6.1",
         "electron-builder": "^26.8.1",
         "eslint": "^10.3.0",
         "globals": "^17.6.0",
@@ -2859,9 +2859,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz",
-      "integrity": "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==",
+      "version": "41.6.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.6.1.tgz",
+      "integrity": "sha512-3y1Q0AkPnqwaJJZV146KlZ63VIVlQVlWdLiArkwnGUOxZAZD5cvag4TMUsu/gN+FZhkkpelgvdTXPZvTb34I8A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "electron": "41.5.0",
+    "electron": "41.6.1",
     "@playwright/test": "1.60.0",
     "electron-builder": "^26.8.1",
     "eslint": "^10.3.0",


### PR DESCRIPTION
## Summary
- Bumps `electron` from `41.5.0` to `41.6.1` in `package.json` (`devDependencies`) and the matching `package-lock.json` entries.

## Upstream release-notes cross-reference vs. blocked issues

- **41.5.1** — `app.getLoginItemSettings()` macOS fix; DevTools race-condition crash fix; cross-origin isolation fix for non-file origins; **XDG App ID / WM_CLASS Linux fix ([electron/electron#51480](https://github.com/electron/electron/pull/51480), backport of [#51424](https://github.com/electron/electron/pull/51424))** which targets exactly the area maintainer-flagged on [#2383](https://github.com/IsmaelMartinez/teams-for-linux/issues/2383) (appTitle / appIcon / awayOnSystemIdle on Wayland).
- **41.5.2** — Windows-only frameless resize fix.
- **41.6.0** — macOS-only Touch ID WebAuthn prompt fix plus `touchID.promptReason`.
- **41.6.1** — Native event emission / IPC dispatch performance improvement; 20 Chrome 148 security backports.

None of the other open `blocked` issues (#2453 tenant switcher, #2228 short links, #2345 call crash, #2454 Agenda / Collaborative Notes, #2382 rename audio devices) have a release-note item that maps to their root cause, so the cross-reference null result is recorded explicitly.

## Test plan
- [ ] `npm run lint` clean (sanity check after install).
- [ ] `npm run test:e2e` clean.
- [ ] Cross-distro packaging build green (`npm run cross-distro` if Docker available, otherwise via CI).
- [ ] Manual Wayland retest for [#2383](https://github.com/IsmaelMartinez/teams-for-linux/issues/2383): launch under native Wayland (no `--ozone-platform=x11` flag) and confirm `--appTitle` / `--appIcon` / `awayOnSystemIdle` now take effect. Will ping @ssh-sato @SlyOrion @Srylax on #2383 with the PR Build Artifacts link once CI completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)