### PR TITLE
fix(preload): serialize object-shaped unhandled rejections

### DIFF
--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -429,18 +429,38 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 // Forward unhandled promise rejections and window errors to main for diagnostics with secure IPC
+// Plain objects without a `.message` (and `undefined` rejections) previously stringified to
+// the literals "[object Object]" / "undefined", which discarded all diagnostic content.
+function serializeRejectionReason(reason) {
+  if (reason === undefined) return "<undefined>";
+  if (reason === null) return "<null>";
+  if (typeof reason === "string") return reason;
+  if (typeof reason !== "object") return String(reason);
+  if (typeof reason.message === "string" && reason.message.length > 0) return reason.message;
+  try {
+    const seen = new WeakSet();
+    return JSON.stringify(reason, (_key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) return "[Circular]";
+        seen.add(value);
+      }
+      return value;
+    }) ?? "[unserializable rejection]";
+  } catch {
+    return "[unserializable rejection]";
+  }
+}
+
 try {
   globalThis.addEventListener("unhandledrejection", (event) => {
     try {
       const reason = event?.reason;
       const errorData = {
-        message: reason?.message ? String(reason.message).substring(0, 1000) : String(reason).substring(0, 1000),
+        message: serializeRejectionReason(reason).substring(0, 1000),
         stack: reason?.stack ? String(reason.stack).substring(0, 5000) : null,
         timestamp: Date.now(),
-        // Keep the raw reason only when it's a plain object to avoid huge payloads
-        reason: typeof reason === "object" && reason !== null ? reason : null,
       };
-      
+
       ipcRenderer.send("unhandled-rejection", errorData);
     } catch (err) {
       console.debug("Unhandled rejection forwarding failed:", err);

--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -432,12 +432,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Plain objects without a `.message` (and `undefined` rejections) previously stringified to
 // the literals "[object Object]" / "undefined", which discarded all diagnostic content.
 function serializeRejectionReason(reason) {
-  if (reason === undefined) return "<undefined>";
-  if (reason === null) return "<null>";
-  if (typeof reason === "string") return reason;
-  if (typeof reason !== "object") return String(reason);
-  if (typeof reason.message === "string" && reason.message.length > 0) return reason.message;
+  // The whole body is wrapped in try/catch so a throwing `reason.message`
+  // getter (or any other unexpected exception) degrades to a sentinel
+  // string instead of propagating to the outer handler and dropping the
+  // whole rejection payload.
   try {
+    if (reason === undefined) return "<undefined>";
+    if (reason === null) return "<null>";
+    if (typeof reason === "string") return reason;
+    if (typeof reason !== "object") return String(reason);
+    if (typeof reason.message === "string" && reason.message.length > 0) return reason.message;
     const seen = new WeakSet();
     return JSON.stringify(reason, (_key, value) => {
       if (typeof value === "object" && value !== null) {


### PR DESCRIPTION
## Summary

Plain-object and `undefined` rejections from the renderer were stringified via `String(reason)`, producing the literal `"[object Object]"` / `"undefined"` in main-process logs and discarding all diagnostic content. Teams emits a lot of object-shaped rejections, so a large fraction of `[Renderer] Unhandled rejection` log lines carried no useful information.

A small `serializeRejectionReason` helper now handles each case (Error-like with `.message`, string/number/boolean, plain object via safe `JSON.stringify` with circular-ref guard, `null`/`undefined` sentinels) so the forwarded message carries the actual payload. The unused `reason` field is also dropped from the IPC payload — the main side never read it and an unclonable object would have broken the whole `ipcRenderer.send` call.

First of four fixes from #2560.

## Test plan

- [x] `npm run lint` — clean
- [x] Manual: ran `ELECTRON_DEBUG_LOG=true npm start` before and after. Before: 40 lines containing `"[object Object]"`. After: 0, and rejection messages now show their JSON content (e.g. `'{"statusMsg":"the request type for aadGetToken failed due to {...}"}'` instead of `'[object Object]'`).

Refs #2560