### PR TITLE
fix(logging): down-level pre-login auth-noise from renderer

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -318,10 +318,11 @@ if (gotTheLock) {
     // messages were silently dropped. Fields are run through
     // sanitizeRendererLogField to scrub URL query strings before logging.
     try {
-      const message = sanitizeRendererLogField(errorData?.message, "unknown");
-      const log = isPreLoginAuthNoise(message) ? console.debug : console.error;
+      // Run the noise check on the raw message — the sanitizer may strip
+      // query strings / fragments that contain the auth error code.
+      const log = isPreLoginAuthNoise(errorData?.message) ? console.debug : console.error;
       log("[Renderer] Unhandled rejection:", {
-        message,
+        message: sanitizeRendererLogField(errorData?.message, "unknown"),
         stack: sanitizeRendererLogField(errorData?.stack),
         timestamp: toFiniteNumber(errorData?.timestamp, Date.now()),
       });
@@ -333,10 +334,9 @@ if (gotTheLock) {
   // Log renderer-side uncaught window errors
   ipcMain.on("window-error", (_event, errorData) => {
     try {
-      const message = sanitizeRendererLogField(errorData?.message, "unknown");
-      const log = isPreLoginAuthNoise(message) ? console.debug : console.error;
+      const log = isPreLoginAuthNoise(errorData?.message) ? console.debug : console.error;
       log("[Renderer] Window error:", {
-        message,
+        message: sanitizeRendererLogField(errorData?.message, "unknown"),
         filename: sanitizeRendererLogField(errorData?.filename, "") || "",
         lineno: toFiniteNumber(errorData?.lineno, 0),
         colno: toFiniteNumber(errorData?.colno, 0),
@@ -405,14 +405,15 @@ function toFiniteNumber(value, fallback = 0) {
 // the noise.
 const PRE_LOGIN_AUTH_NOISE_PATTERNS = [
   "login_required",
-  "AADSTS50058",
-  "InteractionRequired",
-  "AuthFailed",
+  "aadsts50058",
+  "interactionrequired",
+  "authfailed",
 ];
 
 function isPreLoginAuthNoise(message) {
   if (typeof message !== "string") return false;
-  return PRE_LOGIN_AUTH_NOISE_PATTERNS.some((p) => message.includes(p));
+  const lower = message.toLowerCase();
+  return PRE_LOGIN_AUTH_NOISE_PATTERNS.some((p) => lower.includes(p));
 }
 
 /**

--- a/app/index.js
+++ b/app/index.js
@@ -318,8 +318,10 @@ if (gotTheLock) {
     // messages were silently dropped. Fields are run through
     // sanitizeRendererLogField to scrub URL query strings before logging.
     try {
-      console.error("[Renderer] Unhandled rejection:", {
-        message: sanitizeRendererLogField(errorData?.message, "unknown"),
+      const message = sanitizeRendererLogField(errorData?.message, "unknown");
+      const log = isPreLoginAuthNoise(message) ? console.debug : console.error;
+      log("[Renderer] Unhandled rejection:", {
+        message,
         stack: sanitizeRendererLogField(errorData?.stack),
         timestamp: toFiniteNumber(errorData?.timestamp, Date.now()),
       });
@@ -331,8 +333,10 @@ if (gotTheLock) {
   // Log renderer-side uncaught window errors
   ipcMain.on("window-error", (_event, errorData) => {
     try {
-      console.error("[Renderer] Window error:", {
-        message: sanitizeRendererLogField(errorData?.message, "unknown"),
+      const message = sanitizeRendererLogField(errorData?.message, "unknown");
+      const log = isPreLoginAuthNoise(message) ? console.debug : console.error;
+      log("[Renderer] Window error:", {
+        message,
         filename: sanitizeRendererLogField(errorData?.filename, "") || "",
         lineno: toFiniteNumber(errorData?.lineno, 0),
         colno: toFiniteNumber(errorData?.colno, 0),
@@ -391,6 +395,24 @@ function sanitizeRendererLogField(value, fallback = null) {
  */
 function toFiniteNumber(value, fallback = 0) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+// Teams floods the renderer with these error signatures whenever no user is
+// signed in, until the auth-recovery layer (see app/mainAppWindow/index.js)
+// clears stale state and reloads. The recovery layer is the actionable
+// channel for these; mirroring them as console.error in our logs just buries
+// real issues. Down-leveling to console.debug keeps them available without
+// the noise.
+const PRE_LOGIN_AUTH_NOISE_PATTERNS = [
+  "login_required",
+  "AADSTS50058",
+  "InteractionRequired",
+  "AuthFailed",
+];
+
+function isPreLoginAuthNoise(message) {
+  if (typeof message !== "string") return false;
+  return PRE_LOGIN_AUTH_NOISE_PATTERNS.some((p) => message.includes(p));
 }
 
 /**


### PR DESCRIPTION
## Summary

Teams floods the renderer with `login_required` / `AADSTS50058` / `InteractionRequired` / `AuthFailed` errors whenever no user is signed in, until the auth-recovery layer (in `app/mainAppWindow/index.js`) clears stale state and reloads. The recovery layer is the actionable channel for these — mirroring them as `console.error` in our logs just buries real issues. The renderer error forwarder now down-levels matching messages to `console.debug` so they stay accessible at debug level without spamming the default output.

Fourth of four fixes from #2560.

## Test plan

- [x] `npm run lint` — clean
- [x] Manual: fresh launch with no signed-in user.
  - Baseline: ~120 matching `console.error` lines during the ~6s before `[AUTH_RECOVERY] Cleaned`.
  - With this patch: 0 matching lines at the default `info` console level. `[AUTH_RECOVERY]` info lines still fire as before.
- [x] Manual: full session including screen sharing — no new errors introduced.

Refs #2560