### PR TITLE
feat(config): default followSystemTheme to true

### DIFF
--- a/app/browser/tools/theme.js
+++ b/app/browser/tools/theme.js
@@ -13,7 +13,6 @@ class ThemeManager {
     }
 
     if (config.followSystemTheme) {
-      console.debug("followSystemTheme", config.followSystemTheme);
       this.ipcRenderer.on("system-theme-changed", this.applyTheme);
     }
   }

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -348,8 +348,9 @@ function extractYargConfig(configObject, appVersion) {
         type: "boolean",
       },
       followSystemTheme: {
-        default: false,
-        describe: "Follow system theme",
+        default: true,
+        describe:
+          "Follow the operating-system dark/light theme preference. Default is true; set false to keep Teams's own theme regardless of OS changes.",
         type: "boolean",
       },
       frame: {

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -96,7 +96,7 @@ Place your `config.json` file in the appropriate location based on your installa
 |--------|------|---------|-------------|
 | `customCSSName` | `string` | `""` | Custom CSS name. Options: "compactDark", "compactLight", "tweaks", "condensedDark", "condensedLight" |
 | `customCSSLocation` | `string` | `""` | Custom CSS styles file location |
-| `followSystemTheme` | `boolean` | `false` | Follow system theme |
+| `followSystemTheme` | `boolean` | `true` | Follow the operating-system dark/light theme preference. Set `false` to keep Teams's own theme regardless of OS changes. |
 
 ### Tray Icon
 


### PR DESCRIPTION
## Summary

Flip the default of `followSystemTheme` from `false` to `true` so the wrapper honours the OS dark/light preference out of the box. The listener is already wired in `app/mainAppWindow/index.js` (`nativeTheme.on` plus a startup snapshot), this just changes which value the schema hands the listener when the user has not set anything.

## Who is affected

- Users with `"followSystemTheme": true` in config: no change.
- Users with `"followSystemTheme": false` in config: no change, their explicit preference still wins.
- Users with no `followSystemTheme` key in config: behaviour flips from "ignore OS theme" to "follow OS theme". This is the change.

## Why

Every modern desktop app I install on Linux honours the OS theme by default. Users who want a fixed theme are the minority opt-out case, and they can still set `false` explicitly. The current default is a vestige from when system-theme integration was newer; the wrapper is now stable on this path.

## Test plan

- [ ] Pull the branch, `npm start` with no `followSystemTheme` in config.
- [ ] Toggle the OS to dark mode → Teams switches to dark.
- [ ] Toggle the OS to light mode → Teams switches to light.
- [ ] Set `"followSystemTheme": false` in config, restart. OS toggle no longer affects the wrapper.

## Versioning

This is a one-line default change, not an API change. Patch or minor bump per release-please; the existing `feat:` commit message produces a minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)