### PR TITLE
refactor(config): remove six deprecated config keys

### DIFF
--- a/app/browser/tools/disableAutogain.js
+++ b/app/browser/tools/disableAutogain.js
@@ -90,8 +90,7 @@ const applyDisableAutogainPatch = function () {
  * @param {Object} config - Application configuration
  */
 function init(config) {
-  // Support both new nested config and deprecated flat config
-  const enabled = config.media?.microphone?.disableAutogain || config.disableAutogain;
+  const enabled = config.media?.microphone?.disableAutogain;
   if (!enabled) {
     return;
   }

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -111,16 +111,6 @@ function extractYargConfig(configObject, appVersion) {
           "Screen sharing configuration. thumbnail: controls the preview window shown during active sharing. lockInhibitionMethod: screen lock inhibition method (Electron/WakeLockSentinel).",
         type: "object",
       },
-      screenSharingThumbnail: {
-        default: {
-          enabled: true,
-          alwaysOnTop: true,
-        },
-        deprecated: "Use screenSharing.thumbnail instead. This option will be removed in a future version.",
-        describe:
-          "[DEPRECATED] Use screenSharing.thumbnail instead. Controls the thumbnail preview window during active screen sharing.",
-        type: "object",
-      },
       appIcon: {
         default: "",
         describe: "Teams app icon to show in the tray",
@@ -260,12 +250,6 @@ function extractYargConfig(configObject, appVersion) {
         default: "",
         describe: "Default application to be used to open the HTTP URLs",
         type: "string",
-      },
-      disableAutogain: {
-        default: false,
-        describe: "DEPRECATED: Use media.microphone.disableAutogain instead",
-        type: "boolean",
-        deprecated: "Use media.microphone.disableAutogain instead",
       },
       disableGpu: {
         default: false,
@@ -452,14 +436,6 @@ function extractYargConfig(configObject, appVersion) {
     	  "to re-enable QUIC if a future Chromium release fixes the underlying transport bug.",
 	type: "object",
       },
-      screenLockInhibitionMethod: {
-        default: "Electron",
-        deprecated: "Use screenSharing.lockInhibitionMethod instead. This option will be removed in a future version.",
-        describe:
-          "[DEPRECATED] Use screenSharing.lockInhibitionMethod instead. Screen lock inhibition method (Electron/WakeLockSentinel).",
-        type: "string",
-        choices: ["Electron", "WakeLockSentinel"],
-      },
       spellCheckerLanguages: {
         default: [],
         describe:
@@ -475,18 +451,6 @@ function extractYargConfig(configObject, appVersion) {
         default: "",
         describe: "Command to execute to retrieve password for SSO basic auth.",
         type: "string",
-      },
-      ssoInTuneEnabled: {
-        default: false,
-        describe: "Enable Single-Sign-On using Microsoft InTune.",
-        type: "boolean",
-        deprecated: "Use auth.intune.enabled instead",
-      },
-      ssoInTuneAuthUser: {
-        default: "",
-        describe: "User (e-mail) to use for InTune SSO.",
-        type: "string",
-        deprecated: "Use auth.intune.user instead",
       },
       trayIconEnabled: {
         default: true,
@@ -521,12 +485,6 @@ function extractYargConfig(configObject, appVersion) {
         default: false,
         describe: "Enable debug at start",
         type: "boolean",
-      },
-      videoMenu: {
-        default: false,
-        describe: "DEPRECATED: Use media.video.menuEnabled instead",
-        type: "boolean",
-        deprecated: "Use media.video.menuEnabled instead",
       },
       media: {
         default: {

--- a/app/index.js
+++ b/app/index.js
@@ -95,13 +95,11 @@ CommandLineManager.addSwitchesAfterConfigLoad(config);
 // ADR-020: multi-account is mutually exclusive with Intune MAM.
 // The Linux D-Bus Microsoft Identity Broker has undocumented behavior
 // around concurrent enrollments for different UPNs on one machine, so
-// force multi-account off when Intune is enabled via either the current
-// `auth.intune.enabled` or the legacy `ssoInTuneEnabled` flag.
-const intuneEnabled =
-  config.auth?.intune?.enabled || config.ssoInTuneEnabled;
+// force multi-account off when Intune is enabled.
+const intuneEnabled = config.auth?.intune?.enabled;
 if (config.multiAccount?.enabled && intuneEnabled) {
   const warning =
-    "[MultiAccount] Intune SSO is enabled (auth.intune.enabled or ssoInTuneEnabled); multi-account is not supported in this configuration and will be disabled for this session.";
+    "[MultiAccount] Intune SSO is enabled (auth.intune.enabled); multi-account is not supported in this configuration and will be disabled for this session.";
   console.warn(warning);
   config.warnings = [...(config.warnings || []), warning];
   config.multiAccount.enabled = false;

--- a/app/intune/README.md
+++ b/app/intune/README.md
@@ -55,7 +55,7 @@ The module integrates with the main configuration system to read:
 - `auth.intune.enabled`: Enable/disable Intune SSO integration
 - `auth.intune.user`: Specific user account to use for authentication
 
-Legacy flat options (`ssoInTuneEnabled`, `ssoInTuneAuthUser`) are automatically migrated to the new nested format.
+The legacy flat options `ssoInTuneEnabled` and `ssoInTuneAuthUser` were removed. Use `auth.intune.enabled` and `auth.intune.user` directly.
 
 ## Diagnostic Logging
 

--- a/app/intune/index.js
+++ b/app/intune/index.js
@@ -63,7 +63,7 @@ function extractCookieContent(response) {
   return null;
 }
 
-function processInTuneAccounts(resp, ssoInTuneAuthUser) {
+function processInTuneAccounts(resp, intuneUser) {
   // Enhanced account processing with detailed logging
   try {
     const response = JSON.parse(resp);
@@ -79,7 +79,7 @@ function processInTuneAccounts(resp, ssoInTuneAuthUser) {
 
     console.debug("[INTUNE_DIAG] Retrieved InTune accounts", {
       totalAccounts: response.accounts?.length || 0,
-      hasRequestedUser: !!ssoInTuneAuthUser,
+      hasRequestedUser: !!intuneUser,
     });
 
     if (!response.accounts || response.accounts.length === 0) {
@@ -89,9 +89,9 @@ function processInTuneAccounts(resp, ssoInTuneAuthUser) {
       return;
     }
 
-    if (ssoInTuneAuthUser) {
+    if (intuneUser) {
       // Case-insensitive comparison for email addresses
-      const requestedUserLower = ssoInTuneAuthUser.toLowerCase();
+      const requestedUserLower = intuneUser.toLowerCase();
       for (const account of response.accounts) {
         if (account.username?.toLowerCase() === requestedUserLower) {
           inTuneAccount = account;
@@ -178,18 +178,18 @@ async function getBrokerAccountsAsync() {
   });
 }
 
-exports.initSso = async function initIntuneSso(ssoInTuneAuthUser) {
+exports.initSso = async function initIntuneSso(intuneUser) {
   // Reset global state to prevent credential leakage between sessions
   inTuneAccount = null;
 
   console.debug("[INTUNE_DIAG] Initializing InTune SSO", {
-    hasConfiguredUser: !!ssoInTuneAuthUser,
+    hasConfiguredUser: !!intuneUser,
   });
 
   try {
     await waitForBrokerReady(10, 500);
     const resp = await getBrokerAccountsAsync();
-    processInTuneAccounts(resp, ssoInTuneAuthUser);
+    processInTuneAccounts(resp, intuneUser);
   } catch (err) {
     console.warn("[INTUNE_DIAG] Broker cannot initialize SSO", {
       error: err.message || err,

--- a/app/mainAppWindow/browserWindowManager.js
+++ b/app/mainAppWindow/browserWindowManager.js
@@ -26,13 +26,10 @@ class BrowserWindowManager {
 
   /**
    * Get screen lock inhibition method from config.
-   * Supports both new (screenSharing.lockInhibitionMethod) and legacy (screenLockInhibitionMethod) paths.
    * @returns {string} "Electron" or "WakeLockSentinel"
    */
   get screenLockInhibitionMethod() {
-    return this.config?.screenSharing?.lockInhibitionMethod ??
-           this.config?.screenLockInhibitionMethod ??
-           "Electron";
+    return this.config?.screenSharing?.lockInhibitionMethod ?? "Electron";
   }
 
   async createWindow() {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -124,11 +124,8 @@ function createScreenSharePreviewWindow() {
   const startTime = Date.now();
 
   // Get configuration - use the module-level config variable
-  // Support both new (screenSharing.thumbnail) and legacy (screenSharingThumbnail) config paths
   let thumbnailConfig =
-    config?.screenSharing?.thumbnail ??
-    config?.screenSharingThumbnail ??
-    DEFAULT_SCREEN_SHARING_THUMBNAIL_CONFIG;
+    config?.screenSharing?.thumbnail ?? DEFAULT_SCREEN_SHARING_THUMBNAIL_CONFIG;
 
   const previewWindow = screenSharingService.getPreviewWindow();
   const activeSource = screenSharingService.getSelectedSource();
@@ -387,9 +384,8 @@ exports.onAppReady = async function onAppReady(configGroup, customBackground, sh
   screenSharingService = sharingService;
   profilesManagerRef = profilesManager;
 
-  // Support both new (auth.intune.*) and deprecated (ssoInTune*) config options
-  const intuneEnabled = config.auth?.intune?.enabled || config.ssoInTuneEnabled;
-  const intuneUser = config.auth?.intune?.user ?? config.ssoInTuneAuthUser ?? "";
+  const intuneEnabled = config.auth?.intune?.enabled;
+  const intuneUser = config.auth?.intune?.user ?? "";
   if (intuneEnabled) {
     intune = require("../intune");
     await intune.initSso(intuneUser);

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -76,7 +76,7 @@ exports = module.exports = (Menus) => ({
       click: () => Menus.about(),
     },
     getHelpMenu(Menus),
-    ...((Menus.configGroup.startupConfig.media?.video?.menuEnabled || Menus.configGroup.startupConfig.videoMenu)
+    ...(Menus.configGroup.startupConfig.media?.video?.menuEnabled
       ? [
           {
             type: "separator",

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -219,7 +219,7 @@ InTune SSO uses a nested `auth.intune` configuration:
 | `auth.intune.enabled` | `boolean` | `false` | Enable Single-Sign-On using Microsoft InTune |
 | `auth.intune.user` | `string` | `""` | User (e-mail) to use for InTune SSO |
 
-**Legacy Options (Deprecated):**
+**Removed Options (migrate before upgrading):**
 
 | Old Option | New Option | Notes |
 |------------|------------|-------|
@@ -275,7 +275,7 @@ Opt-in configuration for the single-window multi-tenant account switcher:
 |--------|------|---------|-------------|
 | `multiAccount.enabled` | `boolean` | `false` | Opt-in flag for the multi-account profile switcher. See [ADR-020](development/adr/020-multi-account-profile-switcher) for the full design. |
 
-**Mutual exclusion with Intune SSO:** If `multiAccount.enabled` is `true` at startup and Intune SSO is enabled via either `auth.intune.enabled` or the legacy `ssoInTuneEnabled` flag, the app logs a warning, appends it to `config.warnings`, and disables multi-account for the session. The Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine, so Phase 1 treats Intune as single-profile-only. Users who need both can track follow-up discussion on the ADR.
+**Mutual exclusion with Intune SSO:** If `multiAccount.enabled` is `true` at startup and `auth.intune.enabled` is also `true`, the app logs a warning, appends it to `config.warnings`, and disables multi-account for the session. The Linux D-Bus Microsoft Identity Broker has undocumented behavior around concurrent enrollments for different UPNs on one machine, so Phase 1 treats Intune as single-profile-only. Users who need both can track follow-up discussion on the ADR.
 
 ### Network & Proxy
 
@@ -324,7 +324,7 @@ Screen sharing settings are organized under the `screenSharing` configuration ob
 | `screenSharing.thumbnail.alwaysOnTop` | `boolean` | `true` | Keep thumbnail window always on top |
 | `screenSharing.lockInhibitionMethod` | `string` | `"Electron"` | Screen lock inhibition method. Choices: `Electron`, `WakeLockSentinel` |
 
-**Legacy Options (Deprecated):**
+**Removed Options (migrate before upgrading):**
 
 | Old Option | New Option | Notes |
 |------------|------------|-------|
@@ -366,7 +366,7 @@ Media settings are organized under the `media` configuration object with subgrou
 }
 ```
 
-**Legacy Options (Deprecated):**
+**Removed Options (migrate before upgrading):**
 
 | Old Option | New Option | Notes |
 |------------|------------|-------|

--- a/docs-site/docs/intune-sso.md
+++ b/docs-site/docs/intune-sso.md
@@ -52,15 +52,7 @@ Enable Intune SSO in your configuration file. You can place the configuration in
 - `auth.intune.enabled`: Enable/disable Intune SSO integration (default: false)
 - `auth.intune.user`: Specific user account to use (default: "" - uses first available account)
 
-**Legacy Configuration (deprecated):**
-
-The old flat configuration keys are still supported but deprecated:
-```json
-{
-  "ssoInTuneEnabled": true,
-  "ssoInTuneAuthUser": "user@company.com"
-}
-```
+**Migration note:** The legacy flat keys `ssoInTuneEnabled` and `ssoInTuneAuthUser` were removed in this release. Move any existing values to `auth.intune.enabled` and `auth.intune.user` respectively before upgrading.
 
 ## Troubleshooting
 

--- a/docs-site/docs/screen-sharing.md
+++ b/docs-site/docs/screen-sharing.md
@@ -12,17 +12,19 @@ To find your config file [see the “Configuration” section](configuration.md#
 
 ```json
 {
-  "screenSharingThumbnail": {
-    "enabled": true,
-    "alwaysOnTop": true
+  "screenSharing": {
+    "thumbnail": {
+      "enabled": true,
+      "alwaysOnTop": true
+    }
   }
 }
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `enabled` | `boolean` | `true` | Enable/disable the preview thumbnail window |
-| `alwaysOnTop` | `boolean` | `true` | Keep preview window always on top of other windows |
+| `screenSharing.thumbnail.enabled` | `boolean` | `true` | Enable/disable the preview thumbnail window |
+| `screenSharing.thumbnail.alwaysOnTop` | `boolean` | `true` | Keep preview window always on top of other windows |
 
 ### Disabling Screen Sharing Preview
 
@@ -30,18 +32,22 @@ To disable the preview window entirely:
 
 ```json
 {
-  "screenSharingThumbnail": {
-    "enabled": false
+  "screenSharing": {
+    "thumbnail": {
+      "enabled": false
+    }
   }
 }
 ```
+
+> **Migration note:** the legacy flat `screenSharingThumbnail` key and `screenLockInhibitionMethod` key were removed in this release. Move any existing values into `screenSharing.thumbnail` and `screenSharing.lockInhibitionMethod` respectively before upgrading.
 
 ## Troubleshooting
 
 ### Common Issues
 
 #### Preview Window Not Appearing
-- **Check configuration**: Ensure `screenSharingThumbnail.enabled` is `true`
+- **Check configuration**: Ensure `screenSharing.thumbnail.enabled` is `true`
 - **Window manager**: Some Linux window managers may interfere with always-on-top windows
 - **Restart**: Try restarting Teams for Linux
 


### PR DESCRIPTION
## Summary

Removes the six deprecated flat config keys whose nested replacements have been in place for several releases. yargs has been printing the deprecation notice for each since they were deprecated, so users on the legacy paths have had visible warning.

| Removed | Replacement |
|---------|-------------|
| `screenSharingThumbnail` | `screenSharing.thumbnail` |
| `screenLockInhibitionMethod` | `screenSharing.lockInhibitionMethod` |
| `disableAutogain` | `media.microphone.disableAutogain` |
| `videoMenu` | `media.video.menuEnabled` |
| `ssoInTuneEnabled` | `auth.intune.enabled` |
| `ssoInTuneAuthUser` | `auth.intune.user` |

Each consumer's `??`/`||` fallback to the legacy key is dropped in the same change so the new path becomes the single source of truth. The Intune flow's internal parameter `ssoInTuneAuthUser` is renamed to `intuneUser` for symmetry — that parameter is local to `app/intune/index.js` and has no public surface.

## User impact

This is **user-visible breaking** for anyone who still has the legacy keys in their config file. The migration is one-line per key. The docs (`configuration.md`, `intune-sso.md`, `screen-sharing.md`) are updated to flag the keys as removed and to point upgraders at the new paths.

## Versioning

The commit type is `refactor:` so release-please will propose a minor bump. If a major bump is preferred (defensible — it's breaking for unmigrated configs), change to `refactor!:` before merging and the next Release PR will jump to 3.0.0.

## Files touched

- `app/config/index.js` — schema entries removed
- `app/mainAppWindow/index.js` — fallbacks dropped (screenSharingThumbnail, ssoInTune*)
- `app/mainAppWindow/browserWindowManager.js` — getter simplified
- `app/browser/tools/disableAutogain.js` — fallback dropped
- `app/index.js` — Intune-vs-multiAccount fallback dropped
- `app/intune/index.js` — internal `ssoInTuneAuthUser` parameter renamed to `intuneUser`
- `app/menus/appMenu.js` — `videoMenu` fallback dropped
- `docs-site/docs/configuration.md` — migration tables marked as Removed
- `docs-site/docs/intune-sso.md` — legacy snippet replaced with migration note
- `docs-site/docs/screen-sharing.md` — example uses the new nested shape, migration note added

## Test plan

- [ ] `npm run lint` clean.
- [ ] `npm run test:unit` clean (221 tests).
- [ ] Pull the branch with a config that uses only the new keys. Behaviour identical to main.
- [ ] Pull the branch with a config that still uses one of the removed keys (e.g. `screenSharingThumbnail`). Behaviour is the documented default for that subsystem (no fallback). yargs no longer recognises the legacy key so it is ignored as an unknown property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)