### PR TITLE
fix(#2383): also setDesktopName so --class reaches X11 + Wayland

### DIFF
--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -51,10 +51,17 @@ class CommandLineManager {
       app.commandLine.appendSwitch("proxy-server", config.proxyServer);
     }
 
-    // Custom WM_CLASS for Linux window managers
+    // Custom WM_CLASS for Linux window managers.
+    // Electron 41.6.1 (backport of electron/electron#51424) changed the X11
+    // WM_CLASS path to read from the XDG App ID rather than app.getName(),
+    // and the Wayland app_id path has always read from the XDG App ID. The
+    // XDG App ID is set via app.setDesktopName(), so calling setName() alone
+    // no longer reaches either compositor. Set both so --class propagates to
+    // X11 WM_CLASS and Wayland wayland_app_id consistently (#2383).
     if (config.class) {
       console.info("Setting WM_CLASS property to custom value " + config.class);
       app.setName(config.class);
+      app.setDesktopName(`${config.class}.desktop`);
     }
 
     // Authentication server whitelist for SSO


### PR DESCRIPTION
## Summary

Calls `app.setDesktopName(config.class + '.desktop')` alongside the existing `app.setName(config.class)` in `app/startup/commandLine.js`, so the `--class` / `class` config setting propagates to both the X11 `WM_CLASS` and the Wayland `wayland_app_id`.

## Background

Electron 41.6.1 (backport of [electron/electron#51424](https://github.com/electron/electron/pull/51424) via [#51480](https://github.com/electron/electron/pull/51480)) changed `shell/browser/native_window_views.cc`:

```diff
-  std::string name = Browser::Get()->GetName();
+  const auto app_id = platform_util::GetXdgAppId();
+  const std::string name = app_id.value_or(Browser::Get()->GetName());
   params.wm_class_name = base::ToLowerASCII(name);
   params.wm_class_class = name;
-  if (auto const app_id = platform_util::GetXdgAppId()) {
+  if (app_id) {
     params.wayland_app_id = *app_id;
   }
```

The X11 `WM_CLASS` now derives from `platform_util::GetXdgAppId()` (which is set via `app.setDesktopName()`) instead of `Browser::Get()->GetName()` (which `app.setName()` was feeding). The Wayland `app_id` path was already reading from the same source, which is why `--class` on Wayland has never worked regardless of Electron version.

ssh-sato reported on #2383 that the X11 `--appTitle` / `--appIcon` flow that worked on 2.7.x–2.9.x is broken on the PR #2549 build (Electron 41.6.1).

## Fix

```js
if (config.class) {
  app.setName(config.class);
  app.setDesktopName(`${config.class}.desktop`);  // new
}
```

Single line, encoded with a comment block referencing the upstream change so future readers do not "simplify" the duplicate-looking call away.

## Test plan

- [ ] `npm run lint`
- [ ] Diagnostic on X11: launch with `--class=osapiens-work --appIcon=...`, run `xprop WM_CLASS` and confirm the value is `osapiens-work`.
- [ ] Diagnostic on Wayland (sway): launch with `--class=osapiens-work`, run `swaymsg -t get_tree | jq '.. | .app_id? // empty'` and confirm `osapiens-work` appears.
- [ ] Cross-check: with no `--class`, both should still return `teams-for-linux` (the default).
- [ ] Tester ping on #2383 once the build artifacts comment is up.

Refs #2383