### PR TITLE
chore: update CLAUDE.md for ready → release ready label rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ When a PR has review comments, address them proactively:
 - Update status indicators (Ready → Implemented, etc.)
 - Add any new insights or follow-up work discovered during implementation
 
-**Label note:** The GitHub `ready` label means "release ready" (merged/approved for inclusion in the next release), not "ready for development". When triaging, apply `ready` only to issues or PRs that are done and waiting for the release cut.
+**Label note:** The GitHub label `release ready` (formerly `ready`) means the fix is merged to main and included in the next release. When triaging, apply `release ready` only to issues or PRs that are done and waiting for the release cut.
 
 **Roadmap sections:**
 - **Ready for Implementation** - Features with completed research, ready to build


### PR DESCRIPTION
## Summary

The GitHub label `ready` has been renamed to `release ready` to remove ambiguity (ready for testing? development? release?). This updates CLAUDE.md to reference the new label name.

The label itself was already renamed via `gh label edit` before this PR.

## Test plan

- [x] Label renamed on GitHub (verified via `gh label list`)
- [x] 3 open issues (#2560, #2534, #2465) automatically updated to new label name

🤖 Generated with [Claude Code](https://claude.com/claude-code)