### PR TITLE
feat(#2577): add Telegram sticker pack import

### DIFF
--- a/app/browser/tools/customStickers.js
+++ b/app/browser/tools/customStickers.js
@@ -325,7 +325,7 @@ class CustomStickers {
     urlInput.id = URL_INPUT_ID;
     urlInput.className = "tfl-sticker-url-input";
     urlInput.type = "url";
-    urlInput.placeholder = "Paste image URL";
+    urlInput.placeholder = "Image URL or t.me/addstickers/...";
     urlInput.spellcheck = false;
     const urlButton = document.createElement("button");
     urlButton.className = "tfl-sticker-url-button";
@@ -429,6 +429,9 @@ class CustomStickers {
       return;
     }
     if (input) input.value = "";
+    if (result.count != null) {
+      this.#showToast(`Imported ${result.count} stickers from "${result.packName}"`);
+    }
     await this.#refreshStickers();
   }
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -211,6 +211,9 @@ function extractYargConfig(configObject, appVersion) {
             ],
             maxBytes: 5242880,
           },
+          telegram: {
+            botToken: "",
+          },
         },
         describe:
           "Custom stickers feature. enabled: master flag (off by default). folder: absolute path to the sticker folder; empty string uses <userData>/stickers/ (auto-created). formats: file extensions to scan (lowercase, no leading dot). The scanner reads the configured folder plus one level of subdirectories so packs imported under <folder>/<pack>/ are visible. urlImport: HTTPS URL import (drop or paste a URL onto the sticker panel); allowedContentTypes restricts what the wrapper will save; maxBytes caps individual file size.",

--- a/app/customStickers/README.md
+++ b/app/customStickers/README.md
@@ -50,6 +50,25 @@ When the feature is enabled and the default folder did not previously exist, a s
 
 Stickers are sent into Teams by dispatching a synthetic `ClipboardEvent('paste')` at the focused compose box. Teams's editor (CKEditor 5) handles the event the same way it handles a real paste. This was validated end-to-end during the feasibility spike — see [`spike/2476-stickers/`](../../spike/2476-stickers/) at the repo root for the research and design notes.
 
+## Importing Telegram Sticker Packs
+
+When a Telegram bot token is configured, you can import entire sticker packs by pasting a `https://t.me/addstickers/<PackName>` URL into the same import field. The wrapper calls the Telegram Bot API to fetch the pack's static `.webp` stickers and saves them into a subfolder named after the pack.
+
+To set up: create a Telegram bot via [@BotFather](https://t.me/BotFather) (it takes 30 seconds, and the bot does not need any special permissions), then add the token to your config:
+
+```jsonc
+{
+  "customStickers": {
+    "enabled": true,
+    "telegram": {
+      "botToken": "123456:ABC-DEF..."
+    }
+  }
+}
+```
+
+Animated (TGS) and video (WebM) stickers are skipped; only static stickers are imported. Re-importing the same pack overwrites existing files (file names are based on Telegram's unique sticker ID, so the set is idempotent).
+
 ## What's out of scope
 
 The MVP keeps the surface small. The following were considered and intentionally deferred:

--- a/app/customStickers/index.js
+++ b/app/customStickers/index.js
@@ -387,6 +387,10 @@ class CustomStickers {
       return { success: false, error: `Telegram API error: ${err.message}` };
     }
 
+    if (!Array.isArray(stickerSet?.stickers)) {
+      return { success: false, error: "Unexpected Telegram API response" };
+    }
+
     const staticStickers = stickerSet.stickers.filter(
       (s) => !s.is_animated && !s.is_video,
     );
@@ -408,13 +412,20 @@ class CustomStickers {
         const buf = await this.#telegramDownloadFile(token, filePath);
         const ext = path.extname(filePath).slice(1) || "webp";
         const dest = path.join(packFolder, `${sticker.file_unique_id}.${ext}`);
-        fs.writeFileSync(dest, buf);
+        await fs.promises.writeFile(dest, buf);
         imported++;
       } catch (err) {
         console.warn(
           `${LOG_PREFIX} Skipped Telegram sticker ${sticker.file_unique_id}: ${err.message}`,
         );
       }
+    }
+
+    if (imported === 0) {
+      return {
+        success: false,
+        error: `All ${staticStickers.length} stickers failed to download`,
+      };
     }
 
     console.info(
@@ -441,12 +452,16 @@ class CustomStickers {
     let response;
     try {
       response = await fetch(url.toString(), { signal: controller.signal });
+    } catch (err) {
+      clearTimeout(timeout);
+      const msg = err.name === "AbortError" ? "Request timed out" : "Network error";
+      throw new Error(`${method}: ${msg}`);
     } finally {
       clearTimeout(timeout);
     }
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      throw new Error(`HTTP ${response.status}: ${text.slice(0, 200)}`);
+      throw new Error(`${method}: HTTP ${response.status}: ${text.slice(0, 200)}`);
     }
     const json = await response.json();
     if (!json.ok) {
@@ -472,11 +487,15 @@ class CustomStickers {
     let response;
     try {
       response = await fetch(url, { signal: controller.signal });
+    } catch (err) {
+      clearTimeout(timeout);
+      const msg = err.name === "AbortError" ? "Download timed out" : "Network error";
+      throw new Error(`File download: ${msg}`);
     } finally {
       clearTimeout(timeout);
     }
     if (!response.ok) {
-      throw new Error(`Download failed: HTTP ${response.status}`);
+      throw new Error(`File download: HTTP ${response.status}`);
     }
     return Buffer.from(await response.arrayBuffer());
   }

--- a/app/customStickers/index.js
+++ b/app/customStickers/index.js
@@ -4,6 +4,8 @@ const fs = require("node:fs");
 const crypto = require("node:crypto");
 
 const LOG_PREFIX = "[CUSTOM_STICKERS]";
+const TELEGRAM_PACK_RE = /^https?:\/\/t\.me\/addstickers\/([a-zA-Z0-9_]+)$/;
+const TELEGRAM_API_TIMEOUT_MS = 30000;
 
 const EXTENSION_MIME = {
   png: "image/png",
@@ -281,6 +283,11 @@ class CustomStickers {
       return { success: false, error: "Only HTTPS URLs are accepted" };
     }
 
+    const telegramMatch = String(rawUrl).match(TELEGRAM_PACK_RE);
+    if (telegramMatch) {
+      return this.#importTelegramPack(telegramMatch[1]);
+    }
+
     const allowedTypes = this.getUrlImportContentTypes();
     const maxBytes = this.getUrlImportMaxBytes();
 
@@ -355,6 +362,123 @@ class CustomStickers {
     } catch (err) {
       return { success: false, error: `Write failed: ${err.message}` };
     }
+  }
+
+  #getTelegramBotToken() {
+    return this.config.customStickers?.telegram?.botToken || "";
+  }
+
+  async #importTelegramPack(packName) {
+    const token = this.#getTelegramBotToken();
+    if (!token) {
+      return {
+        success: false,
+        error:
+          "Telegram bot token not configured. Set customStickers.telegram.botToken in config.json (create a bot via @BotFather on Telegram to get one).",
+      };
+    }
+
+    let stickerSet;
+    try {
+      stickerSet = await this.#telegramApiCall(token, "getStickerSet", {
+        name: packName,
+      });
+    } catch (err) {
+      return { success: false, error: `Telegram API error: ${err.message}` };
+    }
+
+    const staticStickers = stickerSet.stickers.filter(
+      (s) => !s.is_animated && !s.is_video,
+    );
+    if (staticStickers.length === 0) {
+      return {
+        success: false,
+        error: "Pack contains no static stickers (animated and video stickers are not supported yet).",
+      };
+    }
+
+    const folder = this.stickerFolder ?? this.resolveStickerFolder();
+    const packFolder = path.join(folder, packName);
+    fs.mkdirSync(packFolder, { recursive: true });
+
+    let imported = 0;
+    for (const sticker of staticStickers) {
+      try {
+        const filePath = await this.#telegramGetFilePath(token, sticker.file_id);
+        const buf = await this.#telegramDownloadFile(token, filePath);
+        const ext = path.extname(filePath).slice(1) || "webp";
+        const dest = path.join(packFolder, `${sticker.file_unique_id}.${ext}`);
+        fs.writeFileSync(dest, buf);
+        imported++;
+      } catch (err) {
+        console.warn(
+          `${LOG_PREFIX} Skipped Telegram sticker ${sticker.file_unique_id}: ${err.message}`,
+        );
+      }
+    }
+
+    console.info(
+      `${LOG_PREFIX} Telegram pack "${packName}" imported: ${imported}/${staticStickers.length} stickers`,
+    );
+    return {
+      success: true,
+      count: imported,
+      total: staticStickers.length,
+      packName,
+    };
+  }
+
+  async #telegramApiCall(token, method, params) {
+    const url = new URL(`https://api.telegram.org/bot${token}/${method}`);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      TELEGRAM_API_TIMEOUT_MS,
+    );
+    let response;
+    try {
+      response = await fetch(url.toString(), { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${text.slice(0, 200)}`);
+    }
+    const json = await response.json();
+    if (!json.ok) {
+      throw new Error(json.description || "Telegram API returned not ok");
+    }
+    return json.result;
+  }
+
+  async #telegramGetFilePath(token, fileId) {
+    const result = await this.#telegramApiCall(token, "getFile", {
+      file_id: fileId,
+    });
+    return result.file_path;
+  }
+
+  async #telegramDownloadFile(token, filePath) {
+    const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      TELEGRAM_API_TIMEOUT_MS,
+    );
+    let response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!response.ok) {
+      throw new Error(`Download failed: HTTP ${response.status}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
   }
 
   static async #cancelBody(response) {


### PR DESCRIPTION
## Summary

Adds Telegram sticker pack import to the custom stickers feature. When a user pastes a `https://t.me/addstickers/<PackName>` URL into the sticker panel's import field, the wrapper detects it and routes to the Telegram Bot API instead of the generic single-image download.

The Bot API calls `getStickerSet` to list stickers, then downloads each static `.webp` file into `<stickerFolder>/<packName>/`. The existing one-level subfolder scanning picks them up on the next panel open. Animated (TGS) and video (WebM) stickers are skipped.

Requires a bot token in `customStickers.telegram.botToken` (create one via @BotFather in 30 seconds, no special permissions needed). Without a token, Telegram URLs return a descriptive error message.

Changes:
- `app/customStickers/index.js`: detect Telegram URLs in `handleImportStickerUrl`, add `#importTelegramPack`, `#telegramApiCall`, `#telegramGetFilePath`, `#telegramDownloadFile`
- `app/browser/tools/customStickers.js`: update placeholder text, show pack import count on success
- `app/config/index.js`: add `customStickers.telegram.botToken` default
- `app/customStickers/README.md`: document the Telegram import flow and setup

## Test plan

- [ ] Configure a bot token and import a known pack (e.g., `https://t.me/addstickers/HotCherry`)
- [ ] Verify stickers appear in a subfolder and show in the panel
- [ ] Verify re-importing the same pack is idempotent (same filenames)
- [ ] Verify animated-only packs return a clear error message
- [ ] Verify missing bot token returns a descriptive error
- [ ] Verify invalid pack names return a Telegram API error

closes #2577

🤖 Generated with [Claude Code](https://claude.com/claude-code)