### PR TITLE
chore(deps-dev): bump electron from 41.6.1 to 41.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@electron/fuses": "^2.1.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.60.0",
-        "electron": "41.6.1",
+        "electron": "41.7.1",
         "electron-builder": "^26.8.1",
         "eslint": "^10.4.0",
         "globals": "^17.6.0",
@@ -2859,9 +2859,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.6.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.6.1.tgz",
-      "integrity": "sha512-3y1Q0AkPnqwaJJZV146KlZ63VIVlQVlWdLiArkwnGUOxZAZD5cvag4TMUsu/gN+FZhkkpelgvdTXPZvTb34I8A==",
+      "version": "41.7.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.7.1.tgz",
+      "integrity": "sha512-pdRvNNP99Qfvs1lyIxo/sfIGAwJP0CrJFNCE3goFKc7/fV+kjK3EPxx5Nt6sLTkzqTyeRYylpwPUfpeGojiyyw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@electron/fuses": "^2.1.1",
     "@eslint/js": "^10.0.1",
-    "electron": "41.6.1",
+    "electron": "41.7.1",
     "@playwright/test": "1.60.0",
     "electron-builder": "^26.8.1",
     "eslint": "^10.4.0",


### PR DESCRIPTION
## Summary

Bumps Electron from 41.6.1 to 41.7.1 (staying on the 41.x branch).

### 41.7.0

- Added support for the `--experimental-inspector-network-resource` Node.js flag
- Fixed a crash on `Notification.close()`
- Backported upstream Chromium fixes for memory-safety and validation issues across media, GPU, networking, accessibility, compositing, ANGLE GL backend, input, UI, Aura, HID, file-system teardown, Skia runtime-effect validation, and GLSL translator integer overflow

### 41.7.1

- Fixed a potential crash when using `webContents.print()`
- Fixed an issue where custom print options did not prefill the print dialog on macOS

### Cross-reference with blocked issues

None of the fixes in 41.7.0 or 41.7.1 directly address any currently blocked issues (#2454, #2453, #2383, #2382, #2345, #2228). The notification crash fix in 41.7.0 is unrelated to the calling crash in #2345 (which involves incoming call handling, not notification teardown).

The Chromium security backports are valuable regardless, improving stability and addressing several use-after-free and memory-safety issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)