### PR TITLE
fix(ci): extract Electron binary with system unzip (e2e)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,19 +60,38 @@ jobs:
 
       - name: Install Electron binary
         # In CI the extracted Electron dist ends up with only locales/ (no
-        # binary, no path.txt), which points at a stale/partial cached artifact.
-        # Clear the @electron/get cache and force a fresh, uncached download.
+        # binary, no path.txt). The zip downloads and passes @electron/get's
+        # checksum, yet extract-zip only unpacks part of it. Retry the
+        # force-download + extract a few times and verify the real binary
+        # (not just path.txt) lands before continuing. The diagnostics below
+        # tell us whether the cached zip is complete and how install.js exits.
         env:
           DEBUG: "@electron/get:*"
         run: |
-          rm -rf node_modules/electron/dist node_modules/electron/path.txt "$HOME/.cache/electron"
-          force_no_cache=true node node_modules/electron/install.js
-          if [ ! -f node_modules/electron/path.txt ]; then
-            echo "::error::Electron binary still not installed (no path.txt)"
-            ls -laR node_modules/electron/dist || true
-            exit 1
-          fi
-          echo "OK path.txt = $(cat node_modules/electron/path.txt)"
+          bin=node_modules/electron/dist/electron
+          for attempt in 1 2 3; do
+            echo "::group::Electron install attempt $attempt"
+            rm -rf node_modules/electron/dist node_modules/electron/path.txt "$HOME/.cache/electron"
+            ec=0
+            force_no_cache=true node node_modules/electron/install.js || ec=$?
+            echo "install.js exit=$ec"
+            zip=$(find "$HOME/.cache/electron" -name '*.zip' 2>/dev/null | head -1)
+            if [ -n "$zip" ]; then
+              echo "cached zip: $(ls -l "$zip" | awk '{print $5}') bytes -> $zip"
+              echo "zip entry count: $(unzip -l "$zip" 2>/dev/null | tail -1)"
+            else
+              echo "no cached zip found"
+            fi
+            echo "dist tree:"; ls -laR node_modules/electron/dist 2>/dev/null | head -40
+            echo "::endgroup::"
+            if [ -f node_modules/electron/path.txt ] && [ -x "$bin" ]; then
+              echo "OK path.txt = $(cat node_modules/electron/path.txt); binary present"
+              exit 0
+            fi
+            echo "::warning::Electron binary not fully installed on attempt $attempt"
+          done
+          echo "::error::Electron binary still not installed after 3 attempts"
+          exit 1
 
       - name: Run unit tests
         run: npm run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,39 +59,37 @@ jobs:
         run: npm ci
 
       - name: Install Electron binary
-        # In CI the extracted Electron dist ends up with only locales/ (no
-        # binary, no path.txt). The zip downloads and passes @electron/get's
-        # checksum, yet extract-zip only unpacks part of it. Retry the
-        # force-download + extract a few times and verify the real binary
-        # (not just path.txt) lands before continuing. The diagnostics below
-        # tell us whether the cached zip is complete and how install.js exits.
+        # Electron's bundled extract-zip deterministically unpacks only one
+        # file from the (complete, checksum-verified) zip in the current CI
+        # image, leaving dist with no binary and no path.txt, which breaks
+        # electron.launch() in the e2e tests. Download via @electron/get as
+        # usual, then extract the cached zip with the system unzip — an
+        # independent extractor — and write path.txt ourselves.
         env:
           DEBUG: "@electron/get:*"
         run: |
-          bin=node_modules/electron/dist/electron
-          for attempt in 1 2 3; do
-            echo "::group::Electron install attempt $attempt"
-            rm -rf node_modules/electron/dist node_modules/electron/path.txt "$HOME/.cache/electron"
-            ec=0
-            force_no_cache=true node node_modules/electron/install.js || ec=$?
-            echo "install.js exit=$ec"
-            zip=$(find "$HOME/.cache/electron" -name '*.zip' 2>/dev/null | head -1)
-            if [ -n "$zip" ]; then
-              echo "cached zip: $(ls -l "$zip" | awk '{print $5}') bytes -> $zip"
-              echo "zip entry count: $(unzip -l "$zip" 2>/dev/null | tail -1)"
-            else
-              echo "no cached zip found"
-            fi
-            echo "dist tree:"; ls -laR node_modules/electron/dist 2>/dev/null | head -40
-            echo "::endgroup::"
-            if [ -f node_modules/electron/path.txt ] && [ -x "$bin" ]; then
-              echo "OK path.txt = $(cat node_modules/electron/path.txt); binary present"
-              exit 0
-            fi
-            echo "::warning::Electron binary not fully installed on attempt $attempt"
-          done
-          echo "::error::Electron binary still not installed after 3 attempts"
-          exit 1
+          set -euo pipefail
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt "$HOME/.cache/electron"
+          # Populate the (checksum-verified) zip in the cache. The bundled
+          # extraction fails here, so ignore its exit status.
+          force_no_cache=true node node_modules/electron/install.js || true
+          zip=$(find "$HOME/.cache/electron" -name 'electron-*.zip' | head -1)
+          if [ -z "$zip" ]; then
+            echo "::error::Electron zip was not downloaded"
+            exit 1
+          fi
+          echo "Extracting $(stat -c%s "$zip") bytes from $zip"
+          rm -rf node_modules/electron/dist
+          mkdir -p node_modules/electron/dist
+          unzip -q -o "$zip" -d node_modules/electron/dist
+          chmod +x node_modules/electron/dist/electron
+          printf electron > node_modules/electron/path.txt
+          if [ ! -x node_modules/electron/dist/electron ]; then
+            echo "::error::Electron binary missing after unzip"
+            ls -laR node_modules/electron/dist | head -40
+            exit 1
+          fi
+          echo "OK: electron binary installed ($(stat -c%s node_modules/electron/dist/electron) bytes)"
 
       - name: Run unit tests
         run: npm run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Electron binary
+        # Electron 42+ no longer downloads its binary during postinstall (lazy
+        # on first run), so Playwright's electron.launch cannot find path.txt.
+        # Force the download for whatever Electron version is installed.
+        run: node node_modules/electron/install.js
+
       - name: Run unit tests
         run: npm run test:unit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,18 +59,22 @@ jobs:
         run: npm ci
 
       - name: Install Electron binary
-        # Electron's postinstall does not reliably leave a usable binary in CI
-        # (Playwright resolves it via node_modules/electron/path.txt). Force a
-        # clean install and fail loudly if path.txt is still missing.
+        # Electron's postinstall is being skipped in CI (electron/install.js
+        # exits before writing path.txt, which Playwright needs). Dump the
+        # electron-related env to find the cause, neutralise any skip flag,
+        # force a clean install, and assert path.txt exists.
         run: |
+          echo "=== electron-related env ==="
+          env | grep -iE 'electron' || echo "(none)"
+          unset ELECTRON_SKIP_BINARY_DOWNLOAD
           rm -rf node_modules/electron/dist node_modules/electron/path.txt
           node node_modules/electron/install.js
           if [ ! -f node_modules/electron/path.txt ]; then
-            echo "::error::Electron binary did not install (no path.txt)"
-            ls -la node_modules/electron/ || true
+            echo "::error::Electron binary still not installed (no path.txt)"
+            ls -la node_modules/electron/ node_modules/electron/dist/ || true
             exit 1
           fi
-          echo "Electron path.txt: $(cat node_modules/electron/path.txt)"
+          echo "OK path.txt = $(cat node_modules/electron/path.txt)"
 
       - name: Run unit tests
         run: npm run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,18 @@ jobs:
         run: npm ci
 
       - name: Install Electron binary
-        # Electron 42+ no longer downloads its binary during postinstall (lazy
-        # on first run), so Playwright's electron.launch cannot find path.txt.
-        # Force the download for whatever Electron version is installed.
-        run: node node_modules/electron/install.js
+        # Electron's postinstall does not reliably leave a usable binary in CI
+        # (Playwright resolves it via node_modules/electron/path.txt). Force a
+        # clean install and fail loudly if path.txt is still missing.
+        run: |
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt
+          node node_modules/electron/install.js
+          if [ ! -f node_modules/electron/path.txt ]; then
+            echo "::error::Electron binary did not install (no path.txt)"
+            ls -la node_modules/electron/ || true
+            exit 1
+          fi
+          echo "Electron path.txt: $(cat node_modules/electron/path.txt)"
 
       - name: Run unit tests
         run: npm run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,19 +59,17 @@ jobs:
         run: npm ci
 
       - name: Install Electron binary
-        # Electron's postinstall is being skipped in CI (electron/install.js
-        # exits before writing path.txt, which Playwright needs). Dump the
-        # electron-related env to find the cause, neutralise any skip flag,
-        # force a clean install, and assert path.txt exists.
+        # In CI the extracted Electron dist ends up with only locales/ (no
+        # binary, no path.txt), which points at a stale/partial cached artifact.
+        # Clear the @electron/get cache and force a fresh, uncached download.
+        env:
+          DEBUG: "@electron/get:*"
         run: |
-          echo "=== electron-related env ==="
-          env | grep -iE 'electron' || echo "(none)"
-          unset ELECTRON_SKIP_BINARY_DOWNLOAD
-          rm -rf node_modules/electron/dist node_modules/electron/path.txt
-          node node_modules/electron/install.js
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt "$HOME/.cache/electron"
+          force_no_cache=true node node_modules/electron/install.js
           if [ ! -f node_modules/electron/path.txt ]; then
             echo "::error::Electron binary still not installed (no path.txt)"
-            ls -la node_modules/electron/ node_modules/electron/dist/ || true
+            ls -laR node_modules/electron/dist || true
             exit 1
           fi
           echo "OK path.txt = $(cat node_modules/electron/path.txt)"


### PR DESCRIPTION
## Problem

`e2e_tests` has been failing in CI since the evening of 2026-05-27, which (because packaging was gated on it) is why **v2.11.0 published with no assets**. Every e2e test dies in ~10ms at `electron.launch()` with:

```
Error: electron.launch: Electron failed to install correctly, please delete node_modules/electron
```

## Root cause (verified in CI)

It is **not** the Electron version. e2e passed repeatedly on 41.7.1 (commits `79e9540`, `182d559`, `b564e87` on 05-27) and only started failing later that evening at a commit that doesn't touch the build — i.e. an environment change in the `ubuntu-latest` image, not our code. Both 41.7.1 and the Electron 42 branch (#2589) fail identically.

It is **not** the download either. Instrumenting the install step showed the cached zip is the complete, correct artifact: **117,260,958 bytes, 74 files, passing `@electron/get`'s checksum**. Yet Electron's bundled `extract-zip` deterministically unpacks **only one file** (`locales/de.pak`) and resolves with exit 0, leaving `dist/` with no `electron` binary and no `path.txt` (which Playwright resolves the binary through). Reproduced identically on 3 consecutive force-downloads.

So the failing component is `extract-zip`/`yauzl` in the current CI image — not the version, not the network.

## Fix

Download via `@electron/get` as before (keeps the checksum verification), then extract the cached zip with the **system `unzip`** — an independent extractor — and write `path.txt` ourselves. The diagnostics step already confirmed `unzip -l` lists all 74 files correctly.

This keeps `e2e_tests` a real blocking gate. It also clears the same failure on the Electron 42 PR (#2589) after a rebase.

## Verification

`e2e_tests` is green on this branch: the `Install Electron binary` step installs the full binary and all e2e specs pass (run 26650819215).
