### PR TITLE
ci: bump checkout to Node 24 and make e2e non-blocking for packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -76,14 +76,14 @@ jobs:
           retention-days: 7
 
   linux_x64:
-    needs: [lint_and_audit, e2e_tests]
+    needs: [lint_and_audit]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -118,14 +118,14 @@ jobs:
           compression-level: 6
 
   linux_arm64:
-    needs: [lint_and_audit, e2e_tests]
+    needs: [lint_and_audit]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -160,14 +160,14 @@ jobs:
           compression-level: 6
 
   linux_arm:
-    needs: [lint_and_audit, e2e_tests]
+    needs: [lint_and_audit]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -202,14 +202,14 @@ jobs:
           compression-level: 6
 
   dmg:
-    needs: [lint_and_audit, e2e_tests]
+    needs: [lint_and_audit]
     runs-on: macos-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -240,14 +240,14 @@ jobs:
           compression-level: 6
 
   exe:
-    needs: [lint_and_audit, e2e_tests]
+    needs: [lint_and_audit]
     runs-on: windows-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Node.js and NPM
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
Two build-pipeline fixes, both in `.github/workflows/build.yml`.

## 1. Bump actions/checkout to Node 24

`actions/checkout` was pinned to v4.3.0, which runs on the deprecated Node 20 action runtime ("Node.js 20 actions are deprecated" warning on every run). Bumped to v6.0.2 (Node 24), pinned by SHA, across all jobs. `setup-node` (v6.3.0) and `upload-artifact` (v7.0.0) already run on Node 24, so they're unchanged.

## 2. Make e2e_tests non-blocking for packaging

The packaging jobs (`linux_x64`, `linux_arm64`, `linux_arm`, `dmg`, `exe`) were gated on `e2e_tests` via #2545. `e2e_tests` currently fails on an unresolved Electron-binary install problem in CI (the binary downloads but extracts only a partial fragment, so Playwright can't launch). Because of the gate, every packaging job was **skipped** — which is why v2.11.0 shipped with no assets, and why we can't currently tell whether the deb/rpm/AppImage/exe/dmg builds even work.

This drops `e2e_tests` from those jobs' `needs` so they build regardless. `e2e_tests` still runs on every push/PR as an informational job, and `lint_and_audit` stays a hard gate.

Packaging uses electron-builder (which manages its own Electron binary), a different path from the e2e Playwright launch, so packaging should succeed once unblocked. Once merged, the next main build will confirm the builds produce assets.

The underlying e2e Electron-install failure is being investigated separately (partial archive extraction in CI); this PR just stops it from blocking releases. Supersedes the earlier #2593.