### PR TITLE
refactor: drop explicit ozone-platform default (retry on Electron 42)

### DIFF
--- a/.github/workflows/cross-distro-smoke.yml
+++ b/.github/workflows/cross-distro-smoke.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to test (downloads the AppImage from that PR's most recent Build & Release run)"
+        required: false
+        default: ''
+      app_url:
+        description: 'Override AppImage URL (takes precedence over pr_number)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   smoke:
@@ -22,21 +32,67 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - name: Resolve latest AppImage URL
+      - name: Resolve AppImage source
         id: appimage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          APP_URL_OVERRIDE: ${{ inputs.app_url }}
         run: |
-          # gh CLI's release view returns .url as the browser download URL
-          # (unlike the raw REST API, where .url is the API endpoint).
-          URL=$(gh release view --repo IsmaelMartinez/teams-for-linux --json assets \
-            --jq '.assets[] | select(.name | test("\\.AppImage$") and (test("-(arm64|armv7l)\\.AppImage$") | not)) | .url' | head -1)
-          if [ -z "$URL" ]; then
-            echo "::error::Could not resolve AppImage URL from latest release"
-            exit 1
+          set -euo pipefail
+          # PR_NUMBER and APP_URL_OVERRIDE come from workflow_dispatch inputs and
+          # are consumed only via env vars (never interpolated into commands) to
+          # avoid workflow injection. PR_NUMBER is additionally validated as a
+          # positive integer before any gh call.
+          if [ -n "${APP_URL_OVERRIDE:-}" ]; then
+            echo "Using app_url override"
+            echo "url=${APP_URL_OVERRIDE}" >> "$GITHUB_OUTPUT"
+            echo "local=" >> "$GITHUB_OUTPUT"
+          elif [ -n "${PR_NUMBER:-}" ]; then
+            if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+              echo "::error::pr_number must be a positive integer, got: ${PR_NUMBER}"
+              exit 1
+            fi
+            echo "Resolving build artifact for PR #${PR_NUMBER}"
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo IsmaelMartinez/teams-for-linux --json headRefOid --jq .headRefOid)
+            if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+              echo "::error::Could not resolve head SHA for PR #${PR_NUMBER}"
+              exit 1
+            fi
+            RUN_ID=$(gh run list --repo IsmaelMartinez/teams-for-linux \
+              --workflow "Build & Release" --commit "$HEAD_SHA" \
+              --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+              echo "::error::No successful 'Build & Release' run found for PR #${PR_NUMBER} (sha ${HEAD_SHA})"
+              exit 1
+            fi
+            DOWNLOAD_DIR="${RUNNER_TEMP}/pr-build"
+            mkdir -p "$DOWNLOAD_DIR"
+            gh run download "$RUN_ID" --repo IsmaelMartinez/teams-for-linux \
+              --name teams-for-linux-linux-x64 --dir "$DOWNLOAD_DIR"
+            APPIMAGE=$(find "$DOWNLOAD_DIR" -name '*.AppImage' \
+              -not -name '*-arm64*' -not -name '*-armv7l*' | head -1)
+            if [ -z "$APPIMAGE" ]; then
+              echo "::error::No x86_64 AppImage found in artifact teams-for-linux-linux-x64"
+              exit 1
+            fi
+            chmod +x "$APPIMAGE"
+            echo "Resolved PR build AppImage: ${APPIMAGE}"
+            echo "url=" >> "$GITHUB_OUTPUT"
+            echo "local=${APPIMAGE}" >> "$GITHUB_OUTPUT"
+          else
+            # gh CLI's release view returns .url as the browser download URL
+            # (unlike the raw REST API, where .url is the API endpoint).
+            URL=$(gh release view --repo IsmaelMartinez/teams-for-linux --json assets \
+              --jq '.assets[] | select(.name | test("\\.AppImage$") and (test("-(arm64|armv7l)\\.AppImage$") | not)) | .url' | head -1)
+            if [ -z "$URL" ]; then
+              echo "::error::Could not resolve AppImage URL from latest release"
+              exit 1
+            fi
+            echo "url=${URL}" >> "$GITHUB_OUTPUT"
+            echo "local=" >> "$GITHUB_OUTPUT"
+            echo "Resolved AppImage URL: ${URL}"
           fi
-          echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          echo "Resolved AppImage URL: ${URL}"
 
       - name: Build Docker image
         env:
@@ -52,7 +108,17 @@ jobs:
           DISTRO: ${{ matrix.distro }}
           DISPLAY_SERVER: ${{ matrix.display }}
           APP_URL: ${{ steps.appimage.outputs.url }}
+          APP_LOCAL: ${{ steps.appimage.outputs.local }}
         run: |
+          set -euo pipefail
+          MOUNT_ARGS=()
+          ENV_URL=""
+          if [ -n "${APP_LOCAL:-}" ]; then
+            MOUNT_ARGS=(-v "${APP_LOCAL}:/app/teams-for-linux.AppImage:ro")
+            echo "Mounting local AppImage: ${APP_LOCAL}"
+          else
+            ENV_URL="${APP_URL}"
+          fi
           docker run -d \
             --name "smoke-${DISTRO}-${DISPLAY_SERVER}" \
             --security-opt seccomp=unconfined \
@@ -61,8 +127,9 @@ jobs:
             --cap-add SYS_NICE \
             --shm-size 4g \
             --platform linux/amd64 \
+            "${MOUNT_ARGS[@]}" \
             -e "DISPLAY_SERVER=${DISPLAY_SERVER}" \
-            -e "APP_URL=${APP_URL}" \
+            -e "APP_URL=${ENV_URL}" \
             -e AUTO_LAUNCH=true \
             -e SCREEN_RESOLUTION=1920x1080x24 \
             "cross-distro-${DISTRO}"

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -741,7 +741,7 @@ The configuration file can include Electron CLI flags that will be added when th
 > For options that require a value, provide them as an array where the first element is the flag and the second is its value. If no value is needed, you can use a simple string.
 
 > [!WARNING]
-> The `ozone-platform` flag **cannot** be set via `electronCLIFlags` because it must be applied before the Electron process starts (before any JavaScript executes). The current default is `--ozone-platform=x11` on all Linux packaging formats. To force a different backend, pass `--ozone-platform=wayland` as a command-line argument when launching the app, or edit the `Exec=` line in your `.desktop` file. See [Troubleshooting: Wayland / Display Issues](troubleshooting.md#wayland--display-issues) for details.
+> The `ozone-platform` flag **cannot** be set via `electronCLIFlags` because it must be applied before the Electron process starts (before any JavaScript executes). Teams for Linux no longer ships a default value, so Chromium decides per session: Chromium 140+ (Electron 42+) defaults `--ozone-platform-hint` to `auto` and picks Wayland on a Wayland session, while older Chromium baselines fall back to X11. To force a specific backend, pass `--ozone-platform=x11` or `--ozone-platform=wayland` as a command-line argument when launching the app, or edit the `Exec=` line in your `.desktop` file. See [Troubleshooting: Wayland / Display Issues](troubleshooting.md#wayland--display-issues) for details.
 
 #### Custom Feature Flags (enable-features / disable-features)
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -353,7 +353,7 @@ Since v2.7.13, report-only CSP headers are automatically stripped for all non-Te
 ### Wayland / Display Issues
 
 :::info Default Behavior
-Teams for Linux currently launches with --ozone-platform=x11 by default on all Linux packaging formats. If you are on a Wayland session and want native Wayland, override on the command line or in your .desktop file with --ozone-platform=wayland.
+Teams for Linux no longer bakes a default `--ozone-platform` value into its `.desktop` entries. Chromium picks the backend itself: on Chromium 140+ (Electron 42+) the `--ozone-platform-hint` switch defaults to `auto` and Wayland sessions get a native Wayland backend, while older Chromium baselines fall back to X11. If you hit a Wayland-specific regression you can pin the backend by launching with `--ozone-platform=x11`, and conversely you can force native Wayland with `--ozone-platform=wayland` (or `--ozone-platform-hint=auto` on older builds).
 :::
 
 #### Issue: Blank or black window on Wayland
@@ -366,7 +366,7 @@ Teams for Linux currently launches with --ozone-platform=x11 by default on all L
     ```bash
     teams-for-linux --ozone-platform=x11
     ```
-2. **Confirm the default sticks:** `--ozone-platform=x11` is the shipped default. If you have previously edited your `.desktop` file, ensure the `Exec=` line still includes `--ozone-platform=x11`.
+2. **Edit your `.desktop` file** to make the override permanent by adding `--ozone-platform=x11` to the `Exec=` line.
 
 **Related GitHub Issues:** [#1604](https://github.com/IsmaelMartinez/teams-for-linux/issues/1604), [#1494](https://github.com/IsmaelMartinez/teams-for-linux/issues/1494), [#519](https://github.com/IsmaelMartinez/teams-for-linux/issues/519), [#504](https://github.com/IsmaelMartinez/teams-for-linux/issues/504)
 
@@ -393,7 +393,7 @@ Teams for Linux currently launches with --ozone-platform=x11 by default on all L
     ```bash
     teams-for-linux --ozone-platform=wayland
     ```
-2. **Edit your `.desktop` file** to make the override permanent. Replace `--ozone-platform=x11` with `--ozone-platform=wayland` in the `Exec=` line.
+2. **Edit your `.desktop` file** to make the override permanent by adding `--ozone-platform=wayland` to the `Exec=` line.
 
 **Related GitHub Issues:** [#1787](https://github.com/IsmaelMartinez/teams-for-linux/issues/1787)
 

--- a/package.json
+++ b/package.json
@@ -98,9 +98,6 @@
       "executableName": "teams-for-linux",
       "synopsis": "Teams for Linux",
       "description": "Unofficial Microsoft Teams client for Linux using Electron. It uses the Web App and wraps it as a standalone application using Electron.",
-      "executableArgs": [
-        "--ozone-platform=x11"
-      ],
       "desktop": {
         "entry": {
           "Name": "Teams for Linux",
@@ -142,9 +139,6 @@
       "confinement": "strict",
       "grade": "stable",
       "base": "core22",
-      "executableArgs": [
-        "--ozone-platform=x11"
-      ],
       "plugs": [
         "default",
         "audio-record",

--- a/tests/cross-distro/README.md
+++ b/tests/cross-distro/README.md
@@ -151,7 +151,7 @@ The entrypoint handles these automatically:
 | Shared memory | `--disable-dev-shm-usage`, `shm_size: 2gb` |
 | No namespaces | `--no-sandbox` |
 | Wayland detection | `XDG_SESSION_TYPE` set per display server |
-| Ozone override | AppImage ships `--ozone-platform=x11`; Wayland script overrides to `=wayland` |
+| Ozone override | AppImage ships no `--ozone-platform` default; Wayland script forces `=wayland`, X11/XWayland scripts launch with no flag and let Chromium pick |
 
 **X11** -- high confidence, mirrors CI exactly (`xvfb-run` + Electron).
 **XWayland** -- high confidence, app sees X11 through Sway's XWayland bridge.

--- a/tests/cross-distro/README.md
+++ b/tests/cross-distro/README.md
@@ -151,7 +151,7 @@ The entrypoint handles these automatically:
 | Shared memory | `--disable-dev-shm-usage`, `shm_size: 2gb` |
 | No namespaces | `--no-sandbox` |
 | Wayland detection | `XDG_SESSION_TYPE` set per display server |
-| Ozone override | AppImage ships no `--ozone-platform` default; Wayland script forces `=wayland`, X11/XWayland scripts launch with no flag and let Chromium pick |
+| Ozone override | AppImage ships no `--ozone-platform` default; the Wayland scenario forces `=wayland` and the XWayland scenario forces `=x11` (otherwise Electron 42's `--ozone-platform-hint=auto` picks native Wayland), while the X11 scenario launches with no flag and lets Chromium pick |
 
 **X11** -- high confidence, mirrors CI exactly (`xvfb-run` + Electron).
 **XWayland** -- high confidence, app sees X11 through Sway's XWayland bridge.

--- a/tests/cross-distro/README.md
+++ b/tests/cross-distro/README.md
@@ -92,14 +92,14 @@ APP_FLAGS="--logConfig.transports.console.level=debug" docker compose up --build
 With `--no-launch`, start the app from the terminal inside VNC:
 
 ```bash
-# X11 / XWayland
+# All scenarios: launch with no ozone flag (matches the shipped default).
+# Chromium auto-selects the backend per session.
 /home/tester/app-local/teams-for-linux.AppImage --appimage-extract-and-run \
     --no-sandbox --disable-gpu --disable-dev-shm-usage
 
-# Wayland (native)
-/home/tester/app-local/teams-for-linux.AppImage --appimage-extract-and-run \
-    --no-sandbox --disable-gpu --disable-dev-shm-usage \
-    --enable-features=UseOzonePlatform --ozone-platform=wayland
+# To force a specific backend manually, append one of:
+#   --ozone-platform=x11        (force X11 / XWayland)
+#   --ozone-platform=wayland    (force native Wayland)
 ```
 
 ### Apple Silicon (ARM64 Macs)
@@ -151,7 +151,7 @@ The entrypoint handles these automatically:
 | Shared memory | `--disable-dev-shm-usage`, `shm_size: 2gb` |
 | No namespaces | `--no-sandbox` |
 | Wayland detection | `XDG_SESSION_TYPE` set per display server |
-| Ozone override | AppImage ships no `--ozone-platform` default; the Wayland scenario forces `=wayland` and the XWayland scenario forces `=x11` (otherwise Electron 42's `--ozone-platform-hint=auto` picks native Wayland), while the X11 scenario launches with no flag and lets Chromium pick |
+| Ozone override | No scenario passes an `--ozone-platform` flag; each launches the app exactly as shipped and lets Chromium auto-select per session (X11 on X11, native Wayland on Wayland, and native Wayland on a Wayland session even when XWayland is available) |
 
 **X11** -- high confidence, mirrors CI exactly (`xvfb-run` + Electron).
 **XWayland** -- high confidence, app sees X11 through Sway's XWayland bridge.

--- a/tests/cross-distro/scripts/entrypoint.sh
+++ b/tests/cross-distro/scripts/entrypoint.sh
@@ -76,9 +76,10 @@ export LIBGL_ALWAYS_SOFTWARE=1
 export MESA_GL_VERSION_OVERRIDE=3.3
 
 # Set XDG_SESSION_TYPE so the app's Wayland detection (commandLine.js) triggers.
-# The built AppImage ships --ozone-platform=x11 via executableArgs. For Wayland
-# testing, start-wayland.sh overrides that with --ozone-platform=wayland. For
-# XWayland testing, the baked-in x11 value is correct (app runs as X11 client).
+# The AppImage no longer bakes in an --ozone-platform default; Chromium picks the
+# backend itself per session. For Wayland testing, start-wayland.sh forces native
+# Wayland with --ozone-platform=wayland. For XWayland testing, the app launches
+# without an explicit ozone flag and Chromium chooses X11/XWayland on its own.
 if [[ "$DISPLAY_SERVER" == "wayland" ]] || [[ "$DISPLAY_SERVER" == "xwayland" ]]; then
     export XDG_SESSION_TYPE=wayland
 else

--- a/tests/cross-distro/scripts/entrypoint.sh
+++ b/tests/cross-distro/scripts/entrypoint.sh
@@ -77,9 +77,11 @@ export MESA_GL_VERSION_OVERRIDE=3.3
 
 # Set XDG_SESSION_TYPE so the app's Wayland detection (commandLine.js) triggers.
 # The AppImage no longer bakes in an --ozone-platform default; Chromium picks the
-# backend itself per session. For Wayland testing, start-wayland.sh forces native
-# Wayland with --ozone-platform=wayland. For XWayland testing, the app launches
-# without an explicit ozone flag and Chromium chooses X11/XWayland on its own.
+# backend itself per session. For Wayland testing, the app is forced to native
+# Wayland with --ozone-platform=wayland. For XWayland testing, the app is forced
+# to X11 with --ozone-platform=x11 -- under Electron 42 (Chromium 140+) the
+# --ozone-platform-hint=auto default would otherwise pick native Wayland whenever
+# a Wayland socket is present, bypassing the XWayland path entirely.
 if [[ "$DISPLAY_SERVER" == "wayland" ]] || [[ "$DISPLAY_SERVER" == "xwayland" ]]; then
     export XDG_SESSION_TYPE=wayland
 else

--- a/tests/cross-distro/scripts/entrypoint.sh
+++ b/tests/cross-distro/scripts/entrypoint.sh
@@ -76,12 +76,10 @@ export LIBGL_ALWAYS_SOFTWARE=1
 export MESA_GL_VERSION_OVERRIDE=3.3
 
 # Set XDG_SESSION_TYPE so the app's Wayland detection (commandLine.js) triggers.
-# The AppImage no longer bakes in an --ozone-platform default; Chromium picks the
-# backend itself per session. For Wayland testing, the app is forced to native
-# Wayland with --ozone-platform=wayland. For XWayland testing, the app is forced
-# to X11 with --ozone-platform=x11 -- under Electron 42 (Chromium 140+) the
-# --ozone-platform-hint=auto default would otherwise pick native Wayland whenever
-# a Wayland socket is present, bypassing the XWayland path entirely.
+# The AppImage no longer bakes in an --ozone-platform default, and the test scripts
+# do not add one either -- they launch the app exactly as shipped and let Chromium
+# auto-select the backend per session (X11 on X11, native Wayland on Wayland, and
+# native Wayland on a Wayland session even when XWayland is available).
 if [[ "$DISPLAY_SERVER" == "wayland" ]] || [[ "$DISPLAY_SERVER" == "xwayland" ]]; then
     export XDG_SESSION_TYPE=wayland
 else

--- a/tests/cross-distro/scripts/run-tests.sh
+++ b/tests/cross-distro/scripts/run-tests.sh
@@ -207,15 +207,8 @@ if [[ "$MODE" == "login" ]]; then
     ELECTRON_FLAGS="${ELECTRON_FLAGS} --renderer-process-limit=1 --js-flags=--max-old-space-size=4096"
     ELECTRON_FLAGS="${ELECTRON_FLAGS} --password-store=basic"
 
-    if [[ "${DISPLAY_SERVER}" == "wayland" ]]; then
-        ELECTRON_FLAGS="${ELECTRON_FLAGS} --ozone-platform=wayland"
-    elif [[ "${DISPLAY_SERVER}" == "xwayland" ]]; then
-        # Electron 42 (Chromium 140+) defaults --ozone-platform-hint to auto, which
-        # selects native Wayland whenever a Wayland socket is present. Force X11 so
-        # the XWayland compatibility path is actually exercised instead of silently
-        # running as a native Wayland client.
-        ELECTRON_FLAGS="${ELECTRON_FLAGS} --ozone-platform=x11"
-    fi
+    # No --ozone-platform flag is passed, matching the shipped default: Chromium
+    # auto-selects the backend per session (X11 on X11, native Wayland on Wayland).
 
     echo ""
     echo "$SEPARATOR"

--- a/tests/cross-distro/scripts/run-tests.sh
+++ b/tests/cross-distro/scripts/run-tests.sh
@@ -209,6 +209,12 @@ if [[ "$MODE" == "login" ]]; then
 
     if [[ "${DISPLAY_SERVER}" == "wayland" ]]; then
         ELECTRON_FLAGS="${ELECTRON_FLAGS} --ozone-platform=wayland"
+    elif [[ "${DISPLAY_SERVER}" == "xwayland" ]]; then
+        # Electron 42 (Chromium 140+) defaults --ozone-platform-hint to auto, which
+        # selects native Wayland whenever a Wayland socket is present. Force X11 so
+        # the XWayland compatibility path is actually exercised instead of silently
+        # running as a native Wayland client.
+        ELECTRON_FLAGS="${ELECTRON_FLAGS} --ozone-platform=x11"
     fi
 
     echo ""

--- a/tests/cross-distro/scripts/start-wayland.sh
+++ b/tests/cross-distro/scripts/start-wayland.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Start Wayland environment: Sway (headless) + wayvnc + noVNC
-# The app runs with native Wayland (--ozone-platform=wayland)
+# The app launches with no --ozone-platform flag (matching the shipped default);
+# on this pure-Wayland session Chromium auto-selects the native Wayland backend.
 set -e
 
 WIDTH=$(echo "$SCREEN_RESOLUTION" | cut -dx -f1)
@@ -47,14 +48,13 @@ echo "  VNC:   localhost:${VNC_PORT}"
 echo "============================================="
 
 if [[ -n "$APP_CMD" ]]; then
-    WAYLAND_APP_CMD="${APP_CMD} --enable-features=UseOzonePlatform --ozone-platform=wayland"
     APP_LOG="/tmp/app.log"
     if [[ "${AUTO_LAUNCH}" == "true" ]]; then
-        echo "[Wayland] Auto-launching app with native Wayland (logs: tail -f ${APP_LOG})..."
-        bash -c "$WAYLAND_APP_CMD > $APP_LOG 2>&1" &
+        echo "[Wayland] Auto-launching app (no ozone flag; Chromium auto-selects Wayland, logs: tail -f ${APP_LOG})..."
+        bash -c "$APP_CMD > $APP_LOG 2>&1" &
     else
-        echo "[Wayland] Launch app with native Wayland:"
-        echo "      $WAYLAND_APP_CMD"
+        echo "[Wayland] Launch app (no ozone flag; Chromium auto-selects native Wayland):"
+        echo "      $APP_CMD"
         echo ""
         echo "  Or launch from the foot terminal inside the VNC session."
     fi

--- a/tests/cross-distro/scripts/start-xwayland.sh
+++ b/tests/cross-distro/scripts/start-xwayland.sh
@@ -51,14 +51,18 @@ echo "============================================="
 
 if [[ -n "$APP_CMD" ]]; then
     APP_LOG="/tmp/app.log"
+    # Force X11 so the app runs through XWayland. Under Electron 42 (Chromium 140+)
+    # the --ozone-platform-hint=auto default picks native Wayland when a Wayland
+    # socket is present, so an explicit --ozone-platform=x11 is required here.
+    XWAYLAND_APP_CMD="${APP_CMD} --ozone-platform=x11"
     if [[ "${AUTO_LAUNCH}" == "true" ]]; then
         echo "[XWayland] Auto-launching app (X11 client via XWayland, logs: tail -f ${APP_LOG})..."
-        bash -c "$APP_CMD > $APP_LOG 2>&1" &
+        bash -c "$XWAYLAND_APP_CMD > $APP_LOG 2>&1" &
     else
         echo "[XWayland] Launch app (runs as X11 client via XWayland):"
-        echo "      $APP_CMD"
+        echo "      $XWAYLAND_APP_CMD"
         echo ""
-        echo "  Do NOT add --ozone-platform=wayland (app should use XWayland)."
+        echo "  Keep --ozone-platform=x11 so the app uses XWayland rather than native Wayland."
         echo "  Or launch from the terminal inside the VNC session."
     fi
 fi

--- a/tests/cross-distro/scripts/start-xwayland.sh
+++ b/tests/cross-distro/scripts/start-xwayland.sh
@@ -51,18 +51,17 @@ echo "============================================="
 
 if [[ -n "$APP_CMD" ]]; then
     APP_LOG="/tmp/app.log"
-    # Force X11 so the app runs through XWayland. Under Electron 42 (Chromium 140+)
-    # the --ozone-platform-hint=auto default picks native Wayland when a Wayland
-    # socket is present, so an explicit --ozone-platform=x11 is required here.
-    XWAYLAND_APP_CMD="${APP_CMD} --ozone-platform=x11"
+    # Launch with no ozone flag, matching the shipped default. XWayland is available
+    # in this session, so this validates that Chromium's auto selection still lands on
+    # native Wayland (it does not get pulled onto X11/XWayland just because X11 exists).
     if [[ "${AUTO_LAUNCH}" == "true" ]]; then
-        echo "[XWayland] Auto-launching app (X11 client via XWayland, logs: tail -f ${APP_LOG})..."
-        bash -c "$XWAYLAND_APP_CMD > $APP_LOG 2>&1" &
+        echo "[XWayland] Auto-launching app (no ozone flag; Chromium auto-selects per session, logs: tail -f ${APP_LOG})..."
+        bash -c "$APP_CMD > $APP_LOG 2>&1" &
     else
-        echo "[XWayland] Launch app (runs as X11 client via XWayland):"
-        echo "      $XWAYLAND_APP_CMD"
+        echo "[XWayland] Launch app (no ozone flag; Chromium auto-selects per session):"
+        echo "      $APP_CMD"
         echo ""
-        echo "  Keep --ozone-platform=x11 so the app uses XWayland rather than native Wayland."
+        echo "  To force XWayland manually, append --ozone-platform=x11."
         echo "  Or launch from the terminal inside the VNC session."
     fi
 fi


### PR DESCRIPTION
## Summary

Re-applies #2506 (which was reverted in #2600) now that `main` ships **Electron 42.3.0** (#2589).

The X11 force was added in 2.7.4 to mask Electron 38-era native-Wayland regressions. PR #2506 removed it too early: on the Electron 41 baseline, dropping the flag just fell back to Chromium's compiled-in default rather than doing anything smarter, so the change was reverted. On **Chromium 140+ (Electron 42+)** the `--ozone-platform-hint` switch defaults to `auto` upstream, so removing our explicit `--ozone-platform=x11` lets Chromium pick a native Wayland backend on Wayland sessions and X11 elsewhere. This is the retest the earlier change was waiting for.

This drops both `executableArgs` entries from `package.json` (the deb/rpm/AppImage block and the snap block). Users who hit a Wayland-specific regression can still pin `--ozone-platform=x11`, or force native Wayland with `--ozone-platform=wayland`, from the CLI or their `.desktop` file.

## What changed vs the original #2506

#2506 was branched from a stale `main` and its squash merge collaterally deleted several unrelated doc sections (FIDO2/WebAuthn, GNOME notifications, the Downloads block, `network.disableQuic`, `notifications.timeoutType`). This PR re-applies **only** the intentional ozone changes and leaves all of those sections intact.

Files touched: `package.json` (drop both x11 blocks), the ozone/Wayland wording in `configuration.md` and `troubleshooting.md`, and the cross-distro smoke harness (`cross-distro-smoke.yml` gains a `pr_number`/`app_url` `workflow_dispatch` input; `entrypoint.sh` and the README no longer claim x11 is baked into the AppImage).

## Cross-distro testing

The smoke workflow accepts this PR's build directly:

```
gh workflow run cross-distro-smoke.yml --repo IsmaelMartinez/teams-for-linux \
  --field pr_number=<this PR>
```

## Test plan

- [ ] Trigger `cross-distro-smoke.yml` with this PR number; confirm all 9 matrix entries pass
- [ ] Native Wayland session (Fedora/Ubuntu GNOME, KDE Plasma): window renders correctly, screen share works
- [ ] X11 session: Chromium selects X11 cleanly
- [ ] Override with `--ozone-platform=x11` on Wayland and confirm `wayland.xwaylandOptimizations` still behaves
- [ ] Confirm deb/rpm/AppImage/snap `.desktop` `Exec=` lines carry no `--ozone-platform` value

## Tracking

Community testing continues in #2508. Calling the testers from the original round — @akettmann-apic @dannytrunk @farajaahdaf @isorropisths @mbartosi — this build is the Electron 42 retry; both "still works" and "regressed" reports are equally useful, especially launched from the application menu (not a terminal) so the `.desktop` default applies.

Refs #2508
