### PR TITLE
docs(config): phase 0 of config/docs UX initiative (#2597)

### DIFF
--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -294,8 +294,9 @@ Opt-in configuration for the single-window multi-tenant account switcher:
 
 *   `disable_non_proxied_udp` - Does not expose public or local IPs. When this policy is used, WebRTC should only use TCP to contact peers or servers unless the proxy server supports UDP.
 
-[!NOTE]
+:::note
 **`network.webRTCIPHandlingPolicy`** is useful on systems with multiple network interfaces (e.g. WiFi for internet and a secondary Ethernet adapter with no internet gateway). Without this option, WebRTC advertises all interfaces as ICE candidates, which can cause asymmetric STUN routing and drop calls to **OnHold**. Setting it to `default_public_interface_only` restricts ICE gathering to the interface holding the default route only.
+:::
 
 ```json
 "network": {
@@ -405,7 +406,7 @@ A floating sticker panel that lists image files from a local folder and pastes t
 |--------|------|---------|-------------|
 | `defaultURLHandler` | `string` | `""` | Default application to open HTTP URLs |
 | `meetupJoinRegEx` | `string` | `^https://teams\\.(?:microsoft\\.com|live\\.com|cloud\\.microsoft)/(v2/\\?meetingjoin=|meet/|l/(?:app|call|channel|chat|entity|file|meet(?:ing|up-join)|message|task|team)/)` | Regex for Teams meetup-join and related links |
-| `msTeamsProtocols` | `object` | `{ v1: "^msteams:\/l\/(?:meetup-join\|channel\|chat\|message)", v2: "^msteams:\/\/teams\.microsoft\.com\/l\/(?:meetup-join\|channel\|chat\|message)" }` | Regular expressions for Microsoft Teams protocol links |
+| `msTeamsProtocols` | `object` | `{ v1: "^msteams:/(?:meet/\|l/(?:app\|call\|channel\|chat\|entity\|file\|meet(?:ing\|up-join)\|message\|task\|team)/)", v2: "^msteams://teams\\.(?:microsoft\\.com\|live\\.com\|cloud\\.microsoft)/(?:meet/\|l/(?:app\|call\|channel\|chat\|entity\|file\|meet(?:ing\|up-join)\|message\|task\|team)/)" }` | Regular expressions for Microsoft Teams protocol links (v1 = legacy `msteams:` scheme, v2 = host-based `msteams://` scheme) |
 | `onNewWindowOpenMeetupJoinUrlInApp` | `boolean` | `true` | Open meetupJoinRegEx URLs in the app instead of default browser |
 
 ### Keyboard Shortcuts

--- a/docs-site/docs/development/contributing.md
+++ b/docs-site/docs/development/contributing.md
@@ -161,6 +161,43 @@ class ExampleModule {
 - Provide graceful degradation
 - Use `electron-log` for structured logging
 
+## Adding a Configuration Option
+
+Configuration options are declared in one place, the yargs `.options({})` block in `app/config/index.js`, where each option is an object carrying a `default`, a `describe` string, and a `type`. Adding one is a small, self-contained change that follows the shape of the options already there.
+
+### 1. Declare the option
+
+Add an entry to the `.options({})` block in `app/config/index.js`, following the existing convention:
+
+```javascript
+myFeatureEnabled: {
+  default: false,
+  describe: "Enable the my-feature behaviour.",
+  type: "boolean",
+},
+```
+
+Use the `type` that matches the value (`boolean`, `string`, `number`, or `object` for a nested group of settings). The `describe` text is user-facing, so write it as a one-line explanation of what the option does.
+
+### 2. (Optional) Share the default with other modules
+
+If the default needs to be read outside the config system — for example by a module or a unit test that should not initialise the full config — add it to `app/config/defaults.js` and reference it from `index.js`, the way `meetupJoinRegEx` already does.
+
+### 3. Read the option
+
+The parsed configuration object returned by `app/config/index.js` is passed through `AppConfiguration`. Read your option from that object where you need it, and treat the value as immutable after startup.
+
+### 4. Document the option
+
+The reference table in `docs-site/docs/configuration.md` is maintained by hand today, so a new option must be added to that table in the same change or the docs drift from the code. This manual documentation step is exactly what the planned config-schema generator (issue [#2597](https://github.com/IsmaelMartinez/teams-for-linux/issues/2597), Phase 1) is meant to automate later.
+
+### 5. Lint and test
+
+```bash
+npm run lint
+npm run test:e2e
+```
+
 ## Documentation
 
 ### Contributing to Documentation

--- a/docs-site/docs/quick-reference.md
+++ b/docs-site/docs/quick-reference.md
@@ -37,7 +37,7 @@ Common options and what they control. Names link to the full reference for curre
 
 | Option | Purpose |
 |--------|---------|
-| `disableGpu` | Disable GPU acceleration (auto-enabled on Wayland; the main escape hatch for blank-window and rendering issues) |
+| `disableGpu` | Turn GPU/hardware acceleration off. On Wayland the app already disables the GPU by default, so set this to `false` to force it back on; the main lever for blank-window and rendering issues |
 | `notificationMethod` | Choose how notifications are delivered: `web`, `electron`, or `custom` |
 | `closeAppOnCross` | Quit the app on window close instead of minimising to tray |
 | `trayIconEnabled` | Show or hide the system tray icon |

--- a/docs-site/docs/quick-reference.md
+++ b/docs-site/docs/quick-reference.md
@@ -1,0 +1,59 @@
+# Quick Reference
+
+This quick reference is a condensed cheat-sheet for the most common commands, the configuration file location, key options, and troubleshooting entry points for Teams for Linux. Each item links to the fuller documentation page for detail.
+
+## Common Commands
+
+Development and build commands, run from the repository root:
+
+| Command | What it does |
+|---------|--------------|
+| `npm start` | Run the app in development mode (with `--trace-warnings`) |
+| `npm run lint` | Run ESLint validation (required before commits) |
+| `npm run test:e2e` | Run the Playwright end-to-end tests |
+| `npm run pack` | Development build without packaging (`electron-builder --dir`) |
+| `npm run dist:linux` | Build Linux packages (AppImage, deb, rpm, snap) |
+| `npm run dist` | Build all configured platforms |
+| `npm run generate-ipc-docs` | Regenerate the IPC API docs after changing an IPC channel |
+| `npm run generate-release-info` | Regenerate the release information file |
+
+See [Contributing](development/contributing.md) for the full development workflow.
+
+## Configuration File Location
+
+User configuration lives in a `config.json` whose path depends on how the app was installed:
+
+| Install type | Path |
+|--------------|------|
+| Vanilla (deb / rpm / AppImage) | `~/.config/teams-for-linux/config.json` |
+| Snap | `~/snap/teams-for-linux/current/.config/teams-for-linux/config.json` |
+| Flatpak | `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/config/teams-for-linux/config.json` |
+
+A system-wide file at `/etc/teams-for-linux/config.json` is also read, with the user file taking precedence. See [Configuration Options](configuration.md) for the complete list of options, types, and defaults.
+
+## Frequently Used Options
+
+Common options and what they control. Names link to the full reference for current types and defaults:
+
+| Option | Purpose |
+|--------|---------|
+| `disableGpu` | Disable GPU acceleration (auto-enabled on Wayland; the main escape hatch for blank-window and rendering issues) |
+| `notificationMethod` | Choose how notifications are delivered: `web`, `electron`, or `custom` |
+| `closeAppOnCross` | Quit the app on window close instead of minimising to tray |
+| `trayIconEnabled` | Show or hide the system tray icon |
+| `emulateWinChromiumPlatform` | Present a Windows Chromium user agent (workaround for Teams gating features by platform) |
+| `proxyServer` | Route traffic through a proxy in `address:port` form |
+
+For every option, including the ones not listed here, see [Configuration Options](configuration.md).
+
+## Troubleshooting Quick Links
+
+Jump straight to the most common fixes in the [Troubleshooting Guide](troubleshooting.md):
+
+| Symptom | Section |
+|---------|---------|
+| Blank or black window on Wayland | [Wayland / Display Issues](troubleshooting.md#wayland--display-issues) |
+| Screen sharing not working | [Screen Sharing](screen-sharing.md) |
+| Notifications missing or disappearing | [Notifications](troubleshooting.md#notifications) |
+| Microsoft login or SSO problems | [Intune / SSO](intune-sso.md) |
+| Custom background not applying | [Custom Backgrounds](custom-backgrounds.md) |

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -16,6 +16,7 @@ const sidebars: SidebarsConfig = {
   // Teams for Linux documentation sidebar
   docsSidebar: [
     'index',
+    'quick-reference',
     {
       type: 'category',
       label: 'Getting Started',
@@ -92,6 +93,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'development/research/README',
             'development/research/configuration-organization-research',
+            'development/research/documentation-and-config-ux-research',
             'development/research/custom-notification-system-research',
             'development/research/graph-api-integration-research',
             'development/research/join-meeting-window-takeover-research',


### PR DESCRIPTION
## What

Phase 0 of the documentation/config-UX initiative (#2597) — the low-risk, drift-and-hygiene starting point. Docs only, no code or runtime changes.

## Changes

- **Fix `msTeamsProtocols` drift.** The documented default in `configuration.md` was the old narrow regex; updated to match the actual code default in `app/config/index.js` (which adds `live.com` / `cloud.microsoft` and the full path set).
- **Fix a broken admonition.** The bare `[!NOTE]` in `configuration.md` (no blockquote marker) rendered as literal text on the site; converted to a Docusaurus `:::note` per the project's Markdown Standards.
- **Add a contributor guide.** New "Adding a Configuration Option" walkthrough in `contributing.md`, mirroring the existing IPC-channel guide: declare the option in the yargs block, optionally share the default, read it, document it, lint and test.
- **Resolve the dangling `quick-reference.md`.** `CLAUDE.md` advertised a Quick Reference page (and a published URL) that did not exist. Created it as a real cheat-sheet (commands, config-file locations, frequently-used options, troubleshooting quick links) and wired it into the sidebar. Option rows link to `configuration.md` rather than duplicating defaults, so the page does not become a new drift source.
- **Wire in an orphaned doc.** The `documentation-and-config-ux-research` doc added in #2598 was not in the sidebar; added it to Research & Analysis.

## Verified

- `npm run build` in `docs-site` succeeds; the new `quick-reference` anchors resolve. The only broken-anchor warnings are pre-existing on `ipc-api` (unrelated to this PR).
- The `mqtt.homeAssistant.*` and `auth.webauthn.debug` drift items flagged in the research doc are already documented on `main`, so no change was needed there.
- Verified every option name and link on the new page against the codebase (dropped a non-existent `minimizeOnClose`).

Refs #2597 (multi-phase initiative; this PR does not close it).
