### PR TITLE
fix(auth): don't divert main-frame navigations through about:blank handler

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -809,8 +809,10 @@ function onBeforeRequestHandler(details, callback) {
     // cancels the navigation (ERR_BLOCKED_BY_CLIENT) and leaves a blank page,
     // e.g. the guest / number-matching MFA sign-in where the main frame
     // navigates to the authorize URL right after an about:blank popup bumped
-    // the counter (#2591). Consume the counter and let the page load.
-    aboutBlankRequestCount -= 1;
+    // the counter (#2591). A new top-level navigation also makes any pending
+    // interceptions stale, so reset the counter to 0 rather than decrementing
+    // it: that way a leftover count cannot divert the new page's sub-resources.
+    aboutBlankRequestCount = 0;
     callback({});
   } else {
     // Open request in hidden child window for authentication

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -803,6 +803,15 @@ function onBeforeRequestHandler(details, callback) {
   else if (aboutBlankRequestCount < 1) {
     // Proceed normally
     callback({});
+  } else if (details.resourceType === "mainFrame") {
+    // A top-level navigation is never the about:blank popup's own request, so
+    // it must not be diverted into the hidden child window below. Diverting it
+    // cancels the navigation (ERR_BLOCKED_BY_CLIENT) and leaves a blank page,
+    // e.g. the guest / number-matching MFA sign-in where the main frame
+    // navigates to the authorize URL right after an about:blank popup bumped
+    // the counter (#2591). Consume the counter and let the page load.
+    aboutBlankRequestCount -= 1;
+    callback({});
   } else {
     // Open request in hidden child window for authentication
     const child = new BrowserWindow({ parent: window, show: false });


### PR DESCRIPTION
## Problem

Guest sign-in to an external org blanks at the number-matching MFA step (#2591). The reporter's log pins it to our side:

```
[CONNECTION] Main frame failed to load: ERR_BLOCKED_BY_CLIENT (code: -20)
electron: Failed to load URL: https://login.microsoftonline.com/.../oauth2/v2.0/authorize?... with error: ERR_BLOCKED_BY_CLIENT
```

`ERR_BLOCKED_BY_CLIENT` is the wrapper cancelling the request, not Microsoft. The cause is the legacy `about:blank` popup interception in `onBeforeRequestHandler` (`app/mainAppWindow/index.js`, dating to #206). When a sign-in step opens an `about:blank` popup, `onNewWindow` denies it and increments `aboutBlankRequestCount`. The next HTTPS request then gets diverted into a hidden child window and cancelled. On the guest / number-matching flow that next request is the **main frame** navigating to the authorize URL, so the page the user should see is cancelled and left blank.

## Fix

A top-level navigation is never the popup's own request, so it must not be diverted. Guard `details.resourceType === "mainFrame"` in the counter branch: consume the counter and let the navigation load normally. Sub-resource diversion for the legacy flow is unchanged.

## Status

Suspected fix. The mechanism is confirmed from the log (the cancel can only come from this branch for a non-telemetry URL), but the `about:blank` increment itself was not in the partial log the reporter pasted. I have asked them for the full "before" log and to test this branch build. Holding for that confirmation before merge.

## Test plan

- `npm run lint` passes.
- Reporter to confirm on the PR branch build that the number-matching MFA screen renders instead of blanking.

closes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
