### PR TITLE
feat(docs): interactive config explorer (#2597 Phase 2)

### DIFF
--- a/docs-site/docs/configuration-explorer.mdx
+++ b/docs-site/docs/configuration-explorer.mdx
@@ -1,0 +1,9 @@
+import ConfigExplorer from '@site/src/components/ConfigExplorer';
+
+# Configuration Explorer
+
+Browse every Teams for Linux configuration option, filter by name or type, and assemble a `config.json` you can copy straight into your config directory. Tick the options you want, adjust their values, and copy the result.
+
+This explorer is built from the same schema as the [Configuration Options Reference](configuration-generated.md), which is generated directly from the code, so it always matches the current release. For configuration file locations and examples, see the [Configuration Options](configuration.md) guide.
+
+<ConfigExplorer />

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -3,7 +3,7 @@
 This document details all available configuration options for the Teams for Linux application. These options can be set via command-line arguments or in a `config.json` file located in the application's configuration directory.
 
 :::note
-For a complete, always-up-to-date list of every option generated directly from the code, see the [Configuration Options Reference](configuration-generated.md). This guide adds examples, file locations, and platform notes on top of that reference.
+For a complete, always-up-to-date list of every option generated directly from the code, see the [Configuration Options Reference](configuration-generated.md), or use the interactive [Configuration Explorer](configuration-explorer.mdx) to search the options and build a `config.json`. This guide adds examples, file locations, and platform notes on top of those.
 :::
 
 {/* toc */}

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'uninstall',
         'configuration',
         'configuration-generated',
+        'configuration-explorer',
         'multiple-instances',
         'intune-sso',
       ],

--- a/docs-site/src/components/ConfigExplorer/index.jsx
+++ b/docs-site/src/components/ConfigExplorer/index.jsx
@@ -5,7 +5,12 @@ import styles from './styles.module.css';
 // Fed by the schema generated in Phase 1 (scripts/generateConfigDocs.js). The
 // explorer never hardcodes the option list, so it stays in sync with the code.
 const OPTIONS = schemaData.options;
-const TYPES = ['all', ...Array.from(new Set(OPTIONS.map((o) => o.type).filter(Boolean))).sort()];
+const TYPES = [
+  'all',
+  ...Array.from(new Set(OPTIONS.map((o) => o.type).filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b),
+  ),
+];
 
 export default function ConfigExplorer() {
   const [query, setQuery] = useState('');

--- a/docs-site/src/components/ConfigExplorer/index.jsx
+++ b/docs-site/src/components/ConfigExplorer/index.jsx
@@ -159,6 +159,9 @@ export default function ConfigExplorer() {
             <div className={styles.editors}>
               {selectedNames.map((name) => {
                 const opt = OPTIONS.find((o) => o.name === name);
+                if (!opt) {
+                  return null;
+                }
                 const val = selected[name];
                 return (
                   <label key={name} className={styles.editorRow}>

--- a/docs-site/src/components/ConfigExplorer/index.jsx
+++ b/docs-site/src/components/ConfigExplorer/index.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useMemo} from 'react';
+import React, {useState, useMemo, useEffect} from 'react';
 import schemaData from '@site/static/config-schema.json';
 import styles from './styles.module.css';
 
@@ -13,6 +13,16 @@ export default function ConfigExplorer() {
   // name -> chosen value (seeded from the option's default when first included)
   const [selected, setSelected] = useState({});
   const [copied, setCopied] = useState(false);
+
+  // Reset the "Copied!" label after a moment, clearing the timer if the
+  // component unmounts first so we never set state on an unmounted component.
+  useEffect(() => {
+    if (!copied) {
+      return undefined;
+    }
+    const id = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(id);
+  }, [copied]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -47,16 +57,25 @@ export default function ConfigExplorer() {
   }
 
   const selectedNames = Object.keys(selected);
-  const json = JSON.stringify(selected, null, 2);
+
+  // Coerce empty number inputs (kept as '' for typing UX) back to the option
+  // default, so the emitted JSON never has an invalid `"name": ""` for a number.
+  const configForOutput = useMemo(() => {
+    const out = {};
+    for (const name of Object.keys(selected)) {
+      const opt = OPTIONS.find((o) => o.name === name);
+      const val = selected[name];
+      out[name] = opt && opt.type === 'number' && val === '' ? opt.default : val;
+    }
+    return out;
+  }, [selected]);
+  const json = JSON.stringify(configForOutput, null, 2);
 
   function copy() {
     if (typeof navigator === 'undefined' || !navigator.clipboard) {
       return;
     }
-    navigator.clipboard.writeText(json).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    navigator.clipboard.writeText(json).then(() => setCopied(true));
   }
 
   return (
@@ -155,7 +174,7 @@ export default function ConfigExplorer() {
                     ) : opt.type === 'number' ? (
                       <input
                         type="number"
-                        value={val}
+                        value={val ?? ''}
                         onChange={(e) =>
                           setValue(name, e.target.value === '' ? '' : Number(e.target.value))
                         }

--- a/docs-site/src/components/ConfigExplorer/index.jsx
+++ b/docs-site/src/components/ConfigExplorer/index.jsx
@@ -1,0 +1,190 @@
+import React, {useState, useMemo} from 'react';
+import schemaData from '@site/static/config-schema.json';
+import styles from './styles.module.css';
+
+// Fed by the schema generated in Phase 1 (scripts/generateConfigDocs.js). The
+// explorer never hardcodes the option list, so it stays in sync with the code.
+const OPTIONS = schemaData.options;
+const TYPES = ['all', ...Array.from(new Set(OPTIONS.map((o) => o.type).filter(Boolean))).sort()];
+
+export default function ConfigExplorer() {
+  const [query, setQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState('all');
+  // name -> chosen value (seeded from the option's default when first included)
+  const [selected, setSelected] = useState({});
+  const [copied, setCopied] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return OPTIONS.filter((o) => {
+      if (typeFilter !== 'all' && o.type !== typeFilter) {
+        return false;
+      }
+      if (!q) {
+        return true;
+      }
+      return (
+        o.name.toLowerCase().includes(q) ||
+        (o.description || '').toLowerCase().includes(q)
+      );
+    });
+  }, [query, typeFilter]);
+
+  function toggle(opt) {
+    setSelected((prev) => {
+      const next = {...prev};
+      if (opt.name in next) {
+        delete next[opt.name];
+      } else {
+        next[opt.name] = opt.default;
+      }
+      return next;
+    });
+  }
+
+  function setValue(name, value) {
+    setSelected((prev) => ({...prev, [name]: value}));
+  }
+
+  const selectedNames = Object.keys(selected);
+  const json = JSON.stringify(selected, null, 2);
+
+  function copy() {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      return;
+    }
+    navigator.clipboard.writeText(json).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className={styles.explorer}>
+      <div className={styles.controls}>
+        <input
+          type="search"
+          className={styles.search}
+          placeholder={`Search ${OPTIONS.length} options by name or description...`}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search configuration options"
+        />
+        <select
+          className={styles.typeFilter}
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          aria-label="Filter by type"
+        >
+          {TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t === 'all' ? 'All types' : t}
+            </option>
+          ))}
+        </select>
+        <span className={styles.count}>{filtered.length} shown</span>
+      </div>
+
+      <div className={styles.layout}>
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th aria-label="Include in config" />
+                <th>Option</th>
+                <th>Type</th>
+                <th>Default</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((o) => (
+                <tr key={o.name}>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={o.name in selected}
+                      onChange={() => toggle(o)}
+                      aria-label={`Include ${o.name}`}
+                    />
+                  </td>
+                  <td>
+                    <code>{o.name}</code>
+                  </td>
+                  <td>{o.type}</td>
+                  <td>
+                    <code>{JSON.stringify(o.default)}</code>
+                  </td>
+                  <td>{o.description}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={5} className={styles.empty}>
+                    No options match your search.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <aside className={styles.builder}>
+          <h3>Your config.json</h3>
+          {selectedNames.length === 0 ? (
+            <p className={styles.hint}>
+              Tick options on the left to add them. Boolean, string, and number values are
+              editable here; object defaults are included as-is for you to tweak after copying.
+            </p>
+          ) : (
+            <div className={styles.editors}>
+              {selectedNames.map((name) => {
+                const opt = OPTIONS.find((o) => o.name === name);
+                const val = selected[name];
+                return (
+                  <label key={name} className={styles.editorRow}>
+                    <code>{name}</code>
+                    {opt.type === 'boolean' ? (
+                      <select
+                        value={String(val)}
+                        onChange={(e) => setValue(name, e.target.value === 'true')}
+                      >
+                        <option value="true">true</option>
+                        <option value="false">false</option>
+                      </select>
+                    ) : opt.type === 'number' ? (
+                      <input
+                        type="number"
+                        value={val}
+                        onChange={(e) =>
+                          setValue(name, e.target.value === '' ? '' : Number(e.target.value))
+                        }
+                      />
+                    ) : opt.type === 'string' ? (
+                      <input
+                        type="text"
+                        value={val ?? ''}
+                        onChange={(e) => setValue(name, e.target.value)}
+                      />
+                    ) : (
+                      <span className={styles.readonly}>{JSON.stringify(val)}</span>
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+          )}
+          <pre className={styles.json}>{json}</pre>
+          <button
+            type="button"
+            className={styles.copy}
+            onClick={copy}
+            disabled={selectedNames.length === 0}
+          >
+            {copied ? 'Copied!' : 'Copy config.json'}
+          </button>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/docs-site/src/components/ConfigExplorer/styles.module.css
+++ b/docs-site/src/components/ConfigExplorer/styles.module.css
@@ -1,0 +1,147 @@
+.explorer {
+  margin: 1rem 0;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.search {
+  flex: 1 1 18rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+}
+
+.typeFilter {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+}
+
+.count {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+}
+
+.layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.tableWrap {
+  flex: 1 1 28rem;
+  max-height: 70vh;
+  overflow: auto;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+}
+
+.table {
+  width: 100%;
+  margin: 0;
+  font-size: 0.9rem;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--ifm-background-surface-color);
+  z-index: 1;
+}
+
+.empty {
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  padding: 1.5rem;
+}
+
+.builder {
+  flex: 1 1 20rem;
+  position: sticky;
+  top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+}
+
+.builder h3 {
+  margin-top: 0;
+}
+
+.hint {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+}
+
+.editors {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.editorRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.editorRow input,
+.editorRow select {
+  flex: 0 1 11rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.readonly {
+  color: var(--ifm-color-emphasis-600);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.85rem;
+}
+
+.json {
+  max-height: 16rem;
+  overflow: auto;
+  margin-bottom: 0.75rem;
+}
+
+.copy {
+  width: 100%;
+  padding: 0.5rem;
+  border: none;
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-color-primary);
+  color: var(--ifm-button-color, #fff);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.copy:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## What
Phase 2 of the config/docs UX initiative (#2597), docs-site only with no app or runtime changes. It adds a Configuration Explorer page at `docs-site/docs/configuration-explorer.mdx`, powered by a React component in `docs-site/src/components/ConfigExplorer`. The component imports the `config-schema.json` generated in Phase 1, so the option list is never hardcoded and stays in sync with the code automatically.

## How it works
The explorer is wired into the sidebar and linked from `configuration.md` alongside the generated reference. Users can search options by name or description, filter by type, and tick options to include in a `config.json`. Boolean, string, and number values are editable inline; object defaults are included as-is for tweaking after copying. A copy button writes the assembled `config.json` to the clipboard.

## Verified
The docs site builds with `onBrokenLinks: throw`, and the page server-renders with the option names and the copy button present, confirming the schema import and component compile correctly. The only build warning is a pre-existing broken anchor on `ipc-api-generated`, unrelated to this PR.

Refs #2597 (multi-phase initiative; this PR does not close it).
