### PR TITLE
feat(packaging): register as 1Password trusted browser for autofill

### DIFF
--- a/build/1password-postinstall.sh
+++ b/build/1password-postinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Register teams-for-linux as a trusted browser with 1Password for Linux.
+# This enables the 1Password browser extension (Ctrl+Shift+X) to fill
+# credentials in the Teams login page when 1Password is installed.
+# See: https://support.1password.com/cs/connect-1password-x-linux/
+
+ALLOWED_BROWSERS_FILE="/etc/1password/custom_allowed_browsers"
+
+if [ -f "$ALLOWED_BROWSERS_FILE" ]; then
+  if ! grep -qx "teams-for-linux" "$ALLOWED_BROWSERS_FILE"; then
+    # Ensure there is a trailing newline before appending so we don't
+    # accidentally concatenate with the last line of the file.
+    [ -s "$ALLOWED_BROWSERS_FILE" ] && \
+      tail -c1 "$ALLOWED_BROWSERS_FILE" | grep -qv $'\n' && \
+      echo "" >> "$ALLOWED_BROWSERS_FILE"
+    echo "teams-for-linux" >> "$ALLOWED_BROWSERS_FILE"
+  fi
+fi

--- a/build/1password-preremove.sh
+++ b/build/1password-preremove.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Remove teams-for-linux from the 1Password custom_allowed_browsers list on uninstall.
+
+ALLOWED_BROWSERS_FILE="/etc/1password/custom_allowed_browsers"
+
+if [ -f "$ALLOWED_BROWSERS_FILE" ]; then
+  sed -i '/^teams-for-linux$/d' "$ALLOWED_BROWSERS_FILE"
+fi

--- a/build/1password-setup.sh
+++ b/build/1password-setup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# 1Password browser integration setup for teams-for-linux
+#
+# Use this script when installing via AppImage or tar.gz (formats that have
+# no package manager post-install hook). For deb and rpm packages this runs
+# automatically.
+#
+# Usage (requires sudo):
+#   sudo bash 1password-setup.sh            # register
+#   sudo bash 1password-setup.sh --remove   # unregister
+#
+# What it does:
+#   Adds (or removes) 'teams-for-linux' to 1Password's custom browser
+#   allowlist at /etc/1password/custom_allowed_browsers. This enables
+#   1Password's global autofill shortcut (default: Ctrl+Shift+X) to fill
+#   credentials on the Microsoft login page when your Teams session expires.
+#
+# Reference: https://support.1password.com/cs/connect-1password-x-linux/
+
+set -euo pipefail
+
+ALLOWED_BROWSERS_FILE="/etc/1password/custom_allowed_browsers"
+ENTRY="teams-for-linux"
+
+if [[ "${1:-}" == "--remove" ]]; then
+  if [ ! -f "$ALLOWED_BROWSERS_FILE" ]; then
+    echo "1Password allowlist not found — nothing to remove."
+    exit 0
+  fi
+  sed -i "/^${ENTRY}\$/d" "$ALLOWED_BROWSERS_FILE"
+  echo "Removed '${ENTRY}' from ${ALLOWED_BROWSERS_FILE}"
+  exit 0
+fi
+
+# --- register ---
+if [ ! -f "$ALLOWED_BROWSERS_FILE" ]; then
+  echo "1Password does not appear to be installed (${ALLOWED_BROWSERS_FILE} not found)."
+  echo "Install 1Password for Linux first, then re-run this script."
+  exit 1
+fi
+
+if grep -qx "$ENTRY" "$ALLOWED_BROWSERS_FILE"; then
+  echo "'${ENTRY}' is already registered."
+  exit 0
+fi
+
+# Ensure a trailing newline before appending.
+if [ -s "$ALLOWED_BROWSERS_FILE" ] && \
+   ! tail -c1 "$ALLOWED_BROWSERS_FILE" | grep -qv $'\n'; then
+  :  # file already ends with newline
+else
+  echo "" >> "$ALLOWED_BROWSERS_FILE"
+fi
+
+echo "$ENTRY" >> "$ALLOWED_BROWSERS_FILE"
+echo "Registered '${ENTRY}' in ${ALLOWED_BROWSERS_FILE}"
+echo "Restart 1Password for the change to take effect."

--- a/build/snap-hooks/install
+++ b/build/snap-hooks/install
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Snap install hook — register teams-for-linux with 1Password for Linux.
+#
+# This hook runs when the snap is installed or refreshed.
+# It requires the 'system-files' interface to be connected so that the
+# snap can write to /etc/1password/custom_allowed_browsers.
+#
+# The snap store must approve the interface before it auto-connects on
+# install. Users on locally installed (--dangerous) snaps can connect it
+# manually:
+#
+#   sudo snap connect teams-for-linux:etc-1password :system-files
+#
+# If the interface is not connected, this hook exits silently (snap hooks
+# must not fail on optional integration).
+
+ALLOWED_BROWSERS_FILE="/etc/1password/custom_allowed_browsers"
+
+if [ ! -f "$ALLOWED_BROWSERS_FILE" ]; then
+  # 1Password is not installed — nothing to do.
+  exit 0
+fi
+
+if ! [ -w "$ALLOWED_BROWSERS_FILE" ]; then
+  # system-files interface not connected — skip silently.
+  exit 0
+fi
+
+if ! grep -qx "teams-for-linux" "$ALLOWED_BROWSERS_FILE"; then
+  # Ensure a trailing newline exists before appending.
+  [ -s "$ALLOWED_BROWSERS_FILE" ] && \
+    tail -c1 "$ALLOWED_BROWSERS_FILE" | grep -qv $'\n' && \
+    echo "" >> "$ALLOWED_BROWSERS_FILE"
+  echo "teams-for-linux" >> "$ALLOWED_BROWSERS_FILE"
+fi

--- a/build/snap-hooks/remove
+++ b/build/snap-hooks/remove
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Snap remove hook — clean up the 1Password custom browser entry on uninstall.
+#
+# Mirrors the logic in the install hook. Exits silently if the interface
+# is not connected or 1Password is not installed.
+
+ALLOWED_BROWSERS_FILE="/etc/1password/custom_allowed_browsers"
+
+if [ ! -f "$ALLOWED_BROWSERS_FILE" ] || ! [ -w "$ALLOWED_BROWSERS_FILE" ]; then
+  exit 0
+fi
+
+sed -i '/^teams-for-linux$/d' "$ALLOWED_BROWSERS_FILE"

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
       "confinement": "strict",
       "grade": "stable",
       "base": "core22",
+      "hooks": "build/snap-hooks",
       "executableArgs": [
         "--ozone-platform=x11"
       ],

--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
         "releaseNotesFile": "release-info.json"
       }
     },
+    "deb": {
+      "afterInstall": "build/1password-postinstall.sh",
+      "afterRemove": "build/1password-preremove.sh"
+    },
     "rpm": {
       "depends": [
         "gtk3",
@@ -135,7 +139,9 @@
       ],
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links  none",
-        "--rpm-digest=sha256"
+        "--rpm-digest=sha256",
+        "--after-install=build/1password-postinstall.sh",
+        "--before-remove=build/1password-preremove.sh"
       ]
     },
     "snap": {


### PR DESCRIPTION
## Summary

Register `teams-for-linux` in 1Password's `/etc/1password/custom_allowed_browsers`
allowlist via package install hooks. This enables the 1Password global autofill
shortcut (Ctrl+Shift+X) to fill credentials on the Microsoft login page when
sessions expire.

## Changes

### New files
- `build/1password-postinstall.sh` — deb/rpm post-install hook (idempotent append with trailing-newline guard)
- `build/1password-preremove.sh` — deb/rpm pre-remove hook (sed removal)
- `build/snap-hooks/install` — snap install hook (gracefully skips if system-files interface not connected)
- `build/snap-hooks/remove` — snap remove hook
- `build/1password-setup.sh` — standalone script for AppImage/tar.gz users

### Modified
- `package.json` — wire deb `afterInstall`/`afterRemove`, rpm `fpm` flags, snap `hooks` path

## Key properties

- **No app code changes** — purely packaging scripts
- **Idempotent** — safe to run multiple times  
- **Guarded** — only acts when 1Password is installed
- **Clean uninstall** — entry removed on package removal
- **All formats covered** — deb, rpm (automatic); snap (with system-files interface); AppImage/tar.gz (manual script)

## Testing

- Lint: ✅ clean
- Unit tests: ✅ 273 pass
- E2E tests: ✅ 14 pass
- Manual: verified `teams-for-linux` entry in `/etc/1password/custom_allowed_browsers` and confirmed 1Password recognizes it

## Snap note

The snap hook requires the `system-files` interface to write to `/etc/1password/`.
This needs snap store approval for auto-connect (precedent: `chromium:etc-chromium-browser-policies`).
Until approved, locally installed snaps can connect manually:
```
sudo snap connect teams-for-linux:etc-1password :system-files
```

closes #2609
