### PR TITLE
chore(idle): away-on-idle diagnostics + dead-code cleanup (#2383)

### DIFF
--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -29,26 +29,19 @@ class ActivityManager {
   }
 
   setStatusAwayWhenScreenLocked(state) {
-    // [IDLE_DIAG] #2383: log the inputs that gate the Away push. The Away branch
-    // below requires userCurrent === 1; if the wrapper never learned the Teams
-    // status, userCurrent stays -1 and this branch never runs.
+    // [IDLE_DIAG] #2383: log the idle inputs so a stuck Away can be localised.
+    // setMachineState drives Teams' idle tracker (handleMonitoredWindowEvent
+    // when active, transitionToIdle when idle), which is what actually flips
+    // presence to/from Away.
     console.debug(
       `[IDLE_DIAG] poll: system=${state.system} userIdle=${state.userIdle} userCurrent=${state.userCurrent}`
     );
     activityHub.setMachineState(state.system === "active" ? 1 : 2);
-    const timeOut =
+    return (
       (state.system === "active"
         ? this.config.appIdleTimeoutCheckInterval
-        : this.config.appActiveCheckInterval) * 1000;
-
-    if (state.system === "active" && state.userIdle === 1) {
-      console.debug("[IDLE_DIAG] branch: active + userIdle===1 -> setUserStatus(1)");
-      activityHub.setUserStatus(1);
-    } else if (state.system !== "active" && state.userCurrent === 1) {
-      console.debug("[IDLE_DIAG] branch: idle + userCurrent===1 -> setUserStatus(3)");
-      activityHub.setUserStatus(3);
-    }
-    return timeOut;
+        : this.config.appActiveCheckInterval) * 1000
+    );
   }
 
   keepStatusAvailableWhenScreenLocked(state) {

--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -29,6 +29,12 @@ class ActivityManager {
   }
 
   setStatusAwayWhenScreenLocked(state) {
+    // [IDLE_DIAG] #2383: log the inputs that gate the Away push. The Away branch
+    // below requires userCurrent === 1; if the wrapper never learned the Teams
+    // status, userCurrent stays -1 and this branch never runs.
+    console.debug(
+      `[IDLE_DIAG] poll: system=${state.system} userIdle=${state.userIdle} userCurrent=${state.userCurrent}`
+    );
     activityHub.setMachineState(state.system === "active" ? 1 : 2);
     const timeOut =
       (state.system === "active"
@@ -36,8 +42,10 @@ class ActivityManager {
         : this.config.appActiveCheckInterval) * 1000;
 
     if (state.system === "active" && state.userIdle === 1) {
+      console.debug("[IDLE_DIAG] branch: active + userIdle===1 -> setUserStatus(1)");
       activityHub.setUserStatus(1);
     } else if (state.system !== "active" && state.userCurrent === 1) {
+      console.debug("[IDLE_DIAG] branch: idle + userCurrent===1 -> setUserStatus(3)");
       activityHub.setUserStatus(3);
     }
     return timeOut;

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -97,16 +97,24 @@ class ActivityHub {
 
   setMachineState(state) {
     const teams2IdleTracker = ReactHandler.getTeams2IdleTracker();
+    // [IDLE_DIAG] #2383: surface whether the Teams idle tracker is reachable at
+    // the moment we try to drive it. A null tracker here means the away/active
+    // transition is silently dropped, which is the leading suspect for
+    // away-on-idle not firing until the user interacts with Teams.
     if (teams2IdleTracker) {
       try {
         if (state === 1) {
+          console.debug("[IDLE_DIAG] setMachineState -> handleMonitoredWindowEvent (active)");
           teams2IdleTracker.handleMonitoredWindowEvent();
         } else {
+          console.debug("[IDLE_DIAG] setMachineState -> transitionToIdle (idle)");
           teams2IdleTracker.transitionToIdle();
         }
       } catch (e) {
         console.error("Failed to set teams2 Machine State", e);
       }
+    } else {
+      console.debug(`[IDLE_DIAG] setMachineState(${state}) skipped: teams2IdleTracker unavailable`);
     }
   }
 
@@ -115,13 +123,17 @@ class ActivityHub {
     if (teams2IdleTracker) {
       try {
         if (status === 1) {
+          console.debug("[IDLE_DIAG] setUserStatus -> handleMonitoredWindowEvent (active)");
           teams2IdleTracker.handleMonitoredWindowEvent();
         } else {
+          console.debug("[IDLE_DIAG] setUserStatus -> transitionToIdle (idle)");
           teams2IdleTracker.transitionToIdle();
         }
       } catch (e) {
         console.error("Failed to set teams2 User Status", e);
       }
+    } else {
+      console.debug(`[IDLE_DIAG] setUserStatus(${status}) skipped: teams2IdleTracker unavailable`);
     }
   }
 

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -98,9 +98,10 @@ class ActivityHub {
   setMachineState(state) {
     const teams2IdleTracker = ReactHandler.getTeams2IdleTracker();
     // [IDLE_DIAG] #2383: surface whether the Teams idle tracker is reachable at
-    // the moment we try to drive it. A null tracker here means the away/active
-    // transition is silently dropped, which is the leading suspect for
-    // away-on-idle not firing until the user interacts with Teams.
+    // the moment we try to drive it. transitionToIdle() / handleMonitoredWindowEvent()
+    // are what actually move Teams presence to/from Away; a null tracker here means
+    // the transition is silently dropped (the suspected cause when away-on-idle
+    // never fires in a given environment).
     if (teams2IdleTracker) {
       try {
         if (state === 1) {
@@ -115,25 +116,6 @@ class ActivityHub {
       }
     } else {
       console.debug(`[IDLE_DIAG] setMachineState(${state}) skipped: teams2IdleTracker unavailable`);
-    }
-  }
-
-  setUserStatus(status) {
-    const teams2IdleTracker = ReactHandler.getTeams2IdleTracker();
-    if (teams2IdleTracker) {
-      try {
-        if (status === 1) {
-          console.debug("[IDLE_DIAG] setUserStatus -> handleMonitoredWindowEvent (active)");
-          teams2IdleTracker.handleMonitoredWindowEvent();
-        } else {
-          console.debug("[IDLE_DIAG] setUserStatus -> transitionToIdle (idle)");
-          teams2IdleTracker.transitionToIdle();
-        }
-      } catch (e) {
-        console.error("Failed to set teams2 User Status", e);
-      }
-    } else {
-      console.debug(`[IDLE_DIAG] setUserStatus(${status}) skipped: teams2IdleTracker unavailable`);
     }
   }
 

--- a/tests/unit/idleMonitor.test.js
+++ b/tests/unit/idleMonitor.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const electronPath = require.resolve('electron');
+const idleMonitorPath = require.resolve('../../app/idle/monitor');
+
+// Controls for the electron mock, mutated per-test.
+let registeredHandlers;
+let systemIdleState;
+let systemIdleTime;
+
+function installElectronMock() {
+  registeredHandlers = {};
+  systemIdleState = 'active';
+  systemIdleTime = 0;
+
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: {
+      ipcMain: {
+        handle: (channel, handler) => {
+          registeredHandlers[channel] = handler;
+        },
+      },
+      powerMonitor: {
+        getSystemIdleState: () => systemIdleState,
+        getSystemIdleTime: () => systemIdleTime,
+      },
+    },
+  };
+}
+
+function restoreElectronMock() {
+  delete require.cache[electronPath];
+  delete require.cache[idleMonitorPath];
+}
+
+function loadFreshIdleMonitor() {
+  delete require.cache[idleMonitorPath];
+  return require(idleMonitorPath);
+}
+
+const baseConfig = {
+  appIdleTimeout: 300,
+  appIdleTimeoutCheckInterval: 10,
+  appActiveCheckInterval: 2,
+};
+
+describe('IdleMonitor - system idle state handling', () => {
+  let handler;
+  let userStatus;
+
+  beforeEach(() => {
+    installElectronMock();
+    const IdleMonitor = loadFreshIdleMonitor();
+    userStatus = -1;
+    const monitor = new IdleMonitor(baseConfig, () => userStatus);
+    monitor.initialize();
+    handler = registeredHandlers['get-system-idle-state'];
+  });
+
+  afterEach(() => {
+    restoreElectronMock();
+  });
+
+  it('registers the get-system-idle-state IPC handler on initialize', () => {
+    assert.strictEqual(typeof handler, 'function');
+  });
+
+  it('reports userCurrent from the injected status while active', async () => {
+    userStatus = 1; // Available
+    systemIdleState = 'active';
+
+    const result = await handler();
+
+    assert.strictEqual(result.system, 'active');
+    assert.strictEqual(result.userIdle, -1);
+    assert.strictEqual(result.userCurrent, 1);
+  });
+
+  it('captures the user status at the moment of transition to idle', async () => {
+    userStatus = 1; // Available when the machine goes idle
+    systemIdleState = 'idle';
+
+    const result = await handler();
+
+    assert.strictEqual(result.system, 'idle');
+    // userIdle is the status snapshot taken when idle began; the renderer
+    // uses userCurrent === 1 to decide whether to push the user to Away.
+    assert.strictEqual(result.userIdle, 1);
+    assert.strictEqual(result.userCurrent, 1);
+  });
+
+  it('resets the idle snapshot when the machine becomes active again', async () => {
+    userStatus = 1;
+
+    systemIdleState = 'idle';
+    await handler();
+
+    systemIdleState = 'active';
+    const result = await handler();
+
+    assert.strictEqual(result.system, 'active');
+    assert.strictEqual(result.userIdle, -1);
+    assert.strictEqual(result.userCurrent, 1);
+  });
+
+  // Regression guard for #2383: when the wrapper never learns the user's
+  // Teams status, userStatus stays at its -1 sentinel, so userCurrent is -1
+  // on idle and the renderer's Away branch (which requires userCurrent === 1)
+  // never fires. This pins the observable gap rather than asserting it is
+  // correct behaviour.
+  it('reports userCurrent as -1 on idle when the status was never learned', async () => {
+    userStatus = -1; // never learned (no MQTT, no status change observed)
+    systemIdleState = 'idle';
+
+    const result = await handler();
+
+    assert.strictEqual(result.system, 'idle');
+    assert.strictEqual(result.userIdle, -1);
+    assert.strictEqual(result.userCurrent, -1);
+  });
+});


### PR DESCRIPTION
Adds idle diagnostics and removes dead code in the away-on-idle path. This does not change behaviour and is not, on its own, a fix for #2383 — it is the instrument to pin down the per-environment cause, plus a cleanup of the code that misled the original diagnosis.

## What the investigation found

Driving the live Teams renderer over CDP confirmed that away-on-idle actually works on a healthy session. Teams' idle tracker (`coreServices.clientState._idleTracker`) exposes `transitionToIdle()` (sets state `Inactive`) and `handleMonitoredWindowEvent()` (sets `Active`). Calling `transitionToIdle()` directly flips presence from Available to Away (verified by reading the me-control avatar's aria-label), and `handleMonitoredWindowEvent()` restores Available. The wrapper already calls exactly these through `setMachineState`, and an end-to-end run on genuine OS idle showed the wrapper drive presence to Away and hold it for several minutes with no intervention.

So the call the wrapper makes is correct. When away-on-idle appears not to work, the cause is environmental: the OS not reporting sustained idle (media playback or other HID wakeups), or the idle tracker not being reachable in a given Teams load.

## Changes

`[IDLE_DIAG]` debug-level logging in `activityHub.setMachineState` and `activityManager.setStatusAwayWhenScreenLocked`, showing per poll whether the idle tracker is reachable and whether `transitionToIdle` fires. A reporter runs this to localise their own failure: `transitionToIdle (idle)` means it is working (so the cause is environmental), while `teams2IdleTracker unavailable` means the tracker lookup fails for them, which is a real fix target.

A unit test (`tests/unit/idleMonitor.test.js`) pinning `IdleMonitor`'s `get-system-idle-state` output.

Removal of the dead `setUserStatus` branch in `activityManager` and the now-unused `activityHub.setUserStatus` method. It was gated on a status the wrapper never learns, so it never ran, and it was redundant with `setMachineState`. This dead branch is what pointed the original diagnosis at a "read status at startup" fix that would not have helped.

## For reporters

A diagnostic build from this PR lets #2383 reporters paste their `[IDLE_DIAG]` lines, so we can separate an environmental cause from a real tracker-lookup bug.

Refs #2383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
