### PR TITLE
fix(net): add timeout to connectivity probes to prevent hang after resume

### DIFF
--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -239,10 +239,6 @@ const PROBE_TIMEOUT_MS = 5000;
 
 function isOnlineHttps(testUrl) {
   return new Promise((resolve) => {
-    const req = net.request({
-      url: testUrl,
-      method: "HEAD",
-    });
     let settled = false;
     let timer;
     const finish = (online) => {
@@ -251,17 +247,29 @@ function isOnlineHttps(testUrl) {
       clearTimeout(timer);
       resolve(online);
     };
-    timer = setTimeout(() => {
-      try {
-        req.abort();
-      } catch {
-        /* request already settled or aborted */
-      }
+    try {
+      const req = net.request({
+        url: testUrl,
+        method: "HEAD",
+      });
+      timer = setTimeout(() => {
+        try {
+          req.abort();
+        } catch {
+          /* request already settled or aborted */
+        }
+        finish(false);
+      }, PROBE_TIMEOUT_MS);
+      req.on("response", () => finish(true));
+      req.on("error", () => finish(false));
+      req.end();
+    } catch {
+      // net.request can throw synchronously on a malformed URL or an Electron
+      // net-stack init failure. Treat an unprobeable URL as offline so the
+      // probe always resolves a boolean and isOnline() falls through rather
+      // than rejecting and wedging refresh().
       finish(false);
-    }, PROBE_TIMEOUT_MS);
-    req.on("response", () => finish(true));
-    req.on("error", () => finish(false));
-    req.end();
+    }
   });
 }
 
@@ -276,10 +284,16 @@ function isOnlineDns(testDomain) {
       resolve(online);
     };
     timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
-    net
-      .resolveHost(testDomain)
-      .then(() => finish(true))
-      .catch(() => finish(false));
+    try {
+      net
+        .resolveHost(testDomain)
+        .then(() => finish(true))
+        .catch(() => finish(false));
+    } catch {
+      // resolveHost is promise-based, but guard a synchronous throw so the
+      // probe always resolves a boolean and never rejects.
+      finish(false);
+    }
   });
 }
 

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -227,28 +227,59 @@ function sleep(timeout) {
   return new Promise((r) => setTimeout(r, timeout));
 }
 
+// Electron's net.request / net.resolveHost have no application-level timeout. A
+// stale socket left over from system suspend can leave a probe pending without
+// ever firing 'response' or 'error', which wedges the whole connectivity check:
+// the awaited refresh() never settles, its `finally` never clears the
+// isRefreshing guard, and every subsequent retry is skipped, so the app sits on
+// "Waiting for network..." until it is killed (#2611). Bound each probe so it
+// always settles; a timed-out probe resolves false and isOnline() falls through
+// to the next method (and the retry loop gives a recovering network time).
+const PROBE_TIMEOUT_MS = 5000;
+
 function isOnlineHttps(testUrl) {
   return new Promise((resolve) => {
     const req = net.request({
       url: testUrl,
       method: "HEAD",
     });
-    req.on("response", () => {
-      resolve(true);
-    });
-    req.on("error", () => {
-      resolve(false);
-    });
+    let settled = false;
+    let timer;
+    const finish = (online) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(online);
+    };
+    timer = setTimeout(() => {
+      try {
+        req.abort();
+      } catch {
+        /* request already settled or aborted */
+      }
+      finish(false);
+    }, PROBE_TIMEOUT_MS);
+    req.on("response", () => finish(true));
+    req.on("error", () => finish(false));
     req.end();
   });
 }
 
 function isOnlineDns(testDomain) {
   return new Promise((resolve) => {
+    let settled = false;
+    let timer;
+    const finish = (online) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(online);
+    };
+    timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
     net
       .resolveHost(testDomain)
-      .then(() => resolve(true))
-      .catch(() => resolve(false));
+      .then(() => finish(true))
+      .catch(() => finish(false));
   });
 }
 

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -237,63 +237,58 @@ function sleep(timeout) {
 // to the next method (and the retry loop gives a recovering network time).
 const PROBE_TIMEOUT_MS = 5000;
 
-function isOnlineHttps(testUrl) {
+// Bound a connectivity probe so it always settles. run(finish) performs the
+// probe and calls the idempotent finish(true|false) when it resolves; finish
+// also clears the timeout. If the probe has not settled within PROBE_TIMEOUT_MS,
+// the optional cleanup returned by run() runs (e.g. abort an in-flight request)
+// and the probe resolves false. A synchronous throw from run() (net.request on a
+// malformed URL, a net-stack init failure) is treated as offline, so the probe
+// always resolves a boolean and isOnline() falls through rather than rejecting
+// and wedging refresh().
+function probeWithTimeout(run) {
   return new Promise((resolve) => {
     let settled = false;
     let timer;
+    let cleanup;
     const finish = (online) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       resolve(online);
     };
+    timer = setTimeout(() => {
+      try {
+        cleanup?.();
+      } catch {
+        /* nothing to clean up, or request already settled */
+      }
+      finish(false);
+    }, PROBE_TIMEOUT_MS);
     try {
-      const req = net.request({
-        url: testUrl,
-        method: "HEAD",
-      });
-      timer = setTimeout(() => {
-        try {
-          req.abort();
-        } catch {
-          /* request already settled or aborted */
-        }
-        finish(false);
-      }, PROBE_TIMEOUT_MS);
-      req.on("response", () => finish(true));
-      req.on("error", () => finish(false));
-      req.end();
+      cleanup = run(finish);
     } catch {
-      // net.request can throw synchronously on a malformed URL or an Electron
-      // net-stack init failure. Treat an unprobeable URL as offline so the
-      // probe always resolves a boolean and isOnline() falls through rather
-      // than rejecting and wedging refresh().
       finish(false);
     }
   });
 }
 
+function isOnlineHttps(testUrl) {
+  return probeWithTimeout((finish) => {
+    const req = net.request({ url: testUrl, method: "HEAD" });
+    req.on("response", () => finish(true));
+    req.on("error", () => finish(false));
+    req.end();
+    // On timeout, abort the in-flight request before resolving false.
+    return () => req.abort();
+  });
+}
+
 function isOnlineDns(testDomain) {
-  return new Promise((resolve) => {
-    let settled = false;
-    let timer;
-    const finish = (online) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(online);
-    };
-    timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
-    try {
-      net
-        .resolveHost(testDomain)
-        .then(() => finish(true))
-        .catch(() => finish(false));
-    } catch {
-      // resolveHost is promise-based, but guard a synchronous throw so the
-      // probe always resolves a boolean and never rejects.
-      finish(false);
-    }
+  return probeWithTimeout((finish) => {
+    net
+      .resolveHost(testDomain)
+      .then(() => finish(true))
+      .catch(() => finish(false));
   });
 }
 

--- a/app/graphApi/index.js
+++ b/app/graphApi/index.js
@@ -103,15 +103,31 @@ class GraphApiClient {
 
       logger.debug('[GRAPH_API] Making request', { method, endpoint: url });
 
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Authorization': `Bearer ${tokenResult.token}`,
-          'Content-Type': 'application/json',
-          ...options.headers
-        },
-        ...(options.body && { body: JSON.stringify(options.body) })
-      });
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30000);
+
+      let response;
+      try {
+        response = await fetch(url, {
+          method,
+          headers: {
+            'Authorization': `Bearer ${tokenResult.token}`,
+            'Content-Type': 'application/json',
+            ...options.headers
+          },
+          ...(options.body && { body: JSON.stringify(options.body) }),
+          signal: controller.signal
+        });
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          logger.error('[GRAPH_API] Request timed out', { endpoint: url });
+          return { success: false, error: 'Request timed out' };
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+
       const responseText = await response.text();
 
       let data = null;


### PR DESCRIPTION
## Problem

After system suspend/resume, the app can get stuck showing "Waiting for network..." with a white screen and only recovers via `killall` (#2611).

## Root cause

`refresh()` (`app/connectionManager/index.js`) sets the title, then `await this.isOnline()`. `isOnline()` first tries `isOnlineHttps`, which builds an Electron `net.request` that resolves only on `response`/`error` — **no timeout**. A stale socket carried across suspend can leave that request pending without firing either event, so the `await` never settles. Because the `isRefreshing` guard is only cleared in the `finally`, it stays set, and every subsequent retry (`resume` / `offline-retry` / `did-fail-load`) hits the early-return and is skipped. The app is wedged until killed. `isOnlineDns` had the same untimed shape.

## Fix

Add a bounded 5s timeout to both `isOnlineHttps` and `isOnlineDns`. A timed-out probe resolves `false`, so `isOnline()` falls through to the next method and the `await` settles — clearing `isRefreshing` and re-enabling retries, while the `tries × 500ms` loop gives a recovering network time to come back.

## Testing

`npm run lint` clean; `npm run test:unit` 255/255 pass. The module is Electron-`net`-coupled and has no unit harness, so this is verified by tracing the await/guard path against the maintainer's own diagnosis in the issue.

## Also includes

Cherry-picked from #2656 (authored by @MatrixNeoKozak): a 30s `AbortController` timeout on Graph API requests (`app/graphApi/index.js`), so a stalled Graph call returns rather than hanging. The Graph API client is opt-in (`graphApi.enabled`, default off) and the timeout returns the method's existing `{ success: false }` shape, so callers are unaffected.

## Note on scope

This is the correct, defensive fix for the genuine-hang path and matches the in-thread diagnosis. One honest caveat (from a two-reviewer pass): Electron's `net.request` usually surfaces a stale socket as an `error` (resolving `false`) rather than an indefinite hang, in which case a stuck session would read "No internet connection" instead of "Waiting for network". The reporter's "Waiting for network" fits a genuine hang, but the stuck-morning debug log the issue is already awaiting would confirm whether the probe is truly what hangs. Hence `Relates to #2611` rather than `closes` — recommend confirming with that log before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
