### PR TITLE
docs(install): document the beta apt/rpm channel for pre-releases

### DIFF
--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -35,6 +35,35 @@ sudo curl -1sLf -o /etc/yum.repos.d/teams-for-linux.repo https://repo.teamsforli
 sudo dnf install teams-for-linux
 ```
 
+#### Beta Channel (Pre-releases)
+
+New versions are published to a `beta` channel first and promoted to `stable` after a few days of testing. Follow the beta channel if you want pre-releases and want to help test them before promotion.
+
+**Debian/Ubuntu** — same source as stable, with `Suites: beta`:
+
+```bash
+sudo mkdir -p /etc/apt/keyrings
+sudo wget -qO /etc/apt/keyrings/teams-for-linux.asc https://repo.teamsforlinux.de/teams-for-linux.asc
+sh -c 'echo "Types: deb
+URIs: https://repo.teamsforlinux.de/debian/
+Suites: beta
+Components: main
+Signed-By: /etc/apt/keyrings/teams-for-linux.asc
+Architectures: amd64" | sudo tee /etc/apt/sources.list.d/teams-for-linux-packages.sources'
+sudo apt update && sudo apt install teams-for-linux
+```
+
+**RHEL/Fedora/CentOS** — use the beta repository:
+
+```bash
+curl -1sLf -o /tmp/teams-for-linux.asc https://repo.teamsforlinux.de/teams-for-linux.asc
+sudo rpm --import /tmp/teams-for-linux.asc
+sudo curl -1sLf -o /etc/yum.repos.d/teams-for-linux-beta.repo https://repo.teamsforlinux.de/rpm-beta/teams-for-linux-beta.repo
+sudo dnf install teams-for-linux
+```
+
+To return to stable releases, change `Suites: beta` back to `Suites: stable` (Debian/Ubuntu), or remove `/etc/yum.repos.d/teams-for-linux-beta.repo` and reinstall from the stable repository (RHEL/Fedora/CentOS).
+
 ## Distribution-Specific Packages
 
 ### Arch Linux (AUR)


### PR DESCRIPTION
The package repositories already host a **beta** channel serving pre-releases alongside the **stable** channel, but `installation.md` only documents `stable`. This adds a "Beta Channel (Pre-releases)" subsection so users can opt into pre-releases via their package manager.

## What changed

`docs-site/docs/installation.md` gains a beta-channel subsection covering:

- Debian/Ubuntu: the same deb822 source with `Suites: beta`
- RHEL/Fedora/CentOS: the `teams-for-linux-beta.repo` at `rpm-beta/`
- How to switch back to stable

No server-side change: both channels already exist (verified live, `beta` apt suite serves 2.11.1, `rpm-beta/` is published). This is documentation only.

Context on the intentional pre-release-then-promote flow: #1776.

closes #2637