### PR TITLE
fix(tray): clear badge reliably by widening title observation and fixing update race

### DIFF
--- a/app/browser/tools/mutationTitle.js
+++ b/app/browser/tools/mutationTitle.js
@@ -18,6 +18,20 @@ class MutationObserverTitle {
     }
   }
 
+  _involvesTitleElement(mutations) {
+    return mutations.some((mutation) => {
+      const target = mutation.target;
+      // characterData mutations target the text node inside <title>;
+      // childList mutations on <title> target the element itself.
+      if (target.nodeName === "TITLE" || target.parentNode?.nodeName === "TITLE") {
+        return true;
+      }
+      // <title> element added or removed (e.g. React remount)
+      const changedNodes = [...mutation.addedNodes, ...mutation.removedNodes];
+      return changedNodes.some((node) => node.nodeName === "TITLE");
+    });
+  }
+
   _applyMutationToTitleLogic() {
     console.debug("Appliying MutationObserverTitle logic");
     
@@ -39,8 +53,14 @@ class MutationObserverTitle {
         documentReadyState: document.readyState
       });
       
-      const observer = new globalThis.MutationObserver(() => {
+      const observer = new globalThis.MutationObserver((mutations) => {
         try {
+          // Head-wide observation also reports style/meta/script churn;
+          // only react when the <title> element itself is involved.
+          if (!this._involvesTitleElement(mutations)) {
+            return;
+          }
+
           // Validate and sanitize document title
           const title = globalThis.document.title;
           if (typeof title !== 'string') {

--- a/app/browser/tools/mutationTitle.js
+++ b/app/browser/tools/mutationTitle.js
@@ -9,7 +9,7 @@ class MutationObserverTitle {
         // DOM is still loading, wait for DOMContentLoaded
         globalThis.addEventListener(
           "DOMContentLoaded",
-          this._applyMutationToTitleLogic,
+          () => this._applyMutationToTitleLogic(),
         );
       } else {
         // DOM is already loaded, apply logic immediately
@@ -28,15 +28,14 @@ class MutationObserverTitle {
         return;
       }
       
-      const titleElement = globalThis.document.querySelector("title");
-      if (!titleElement) {
-        console.error("MutationTitle: Title element not found");
+      if (!globalThis.document.head) {
+        console.error("MutationTitle: document.head not found");
         return;
       }
-      
+
       // Enhanced debugging for tray icon timing issue (#1795)
       console.debug("MutationTitle: Initial setup", {
-        titleElementExists: !!titleElement,
+        titleElementExists: !!globalThis.document.querySelector("title"),
         documentReadyState: document.readyState
       });
       
@@ -88,10 +87,19 @@ class MutationObserverTitle {
         }
       });
       
-      observer.observe(titleElement, {
+      // Observe document.head with subtree so the observer survives Teams
+      // replacing the <title> element outright (React remount) and sees both
+      // childList (text node swap) and characterData (in-place text edit)
+      // title updates. Watching only the current <title> with childList
+      // misses in-place edits, leaving the badge stuck at a stale count
+      // (#2620). The callback reads document.title, so it does not depend on
+      // which <title> element currently holds the text.
+      observer.observe(globalThis.document.head, {
         childList: true,
+        characterData: true,
+        subtree: true,
       });
-      console.debug("MutationTitle: Observer successfully attached to title element");
+      console.debug("MutationTitle: Observer successfully attached to document.head");
     } catch (error) {
       console.error("MutationTitle: Error setting up mutation observer:", error);
     }

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -1,8 +1,8 @@
 const { nativeImage } = require("electron");
 const TrayIconChooser = require("./trayIconChooser");
 class TrayIconRenderer {
-  #lastActivityCount;
-  #currentProcessingCount;
+  #lastRequestedCount;
+  #updateSequence = 0;
 
   init(config, ipcRenderer) {
     this.ipcRenderer = ipcRenderer;
@@ -18,87 +18,65 @@ class TrayIconRenderer {
 
   async updateActivityCount(event) {
     const count = event.detail.number;
-    
-    // Skip if count hasn't changed to avoid redundant work
-    if (count === this.#lastActivityCount) {
+
+    // Deduplicate against the most recently *requested* count, not the last
+    // one that finished sending. Comparing against the completed count
+    // swallows a clear-to-zero event that arrives while a non-zero render is
+    // still awaiting the canvas, leaving the badge stuck (#2620).
+    if (count === this.#lastRequestedCount) {
       console.debug("[TRAY_DIAG] Activity count unchanged, skipping update");
       return;
     }
+    this.#lastRequestedCount = count;
 
+    // Each update takes a sequence token; any update that finishes its render
+    // after a newer one has started (including the render-free zero path) is
+    // discarded, so out-of-order completions can never overwrite a newer count.
+    const sequence = ++this.#updateSequence;
     const startTime = Date.now();
-    
+
     console.debug("[TRAY_DIAG] Activity count update initiated", {
       newCount: count,
-      previousCount: this.#lastActivityCount || 0,
-      timestamp: new Date().toISOString(),
-      willFlash: count > 0 && !this.config.disableNotificationWindowFlash,
-      suggestion: "Monitor renderTimeMs and totalTimeMs for performance issues"
+      willFlash: count > 0 && !this.config.disableNotificationWindowFlash
     });
-    
-    // Special case for count 0: Use base icon directly to avoid canvas rendering
-    if (count === 0) {
-      console.debug("[TRAY_DIAG] Count is 0, using base icon without rendering");
-      this.ipcRenderer.send("tray-update", {
-        icon: null, // Let main process use the default icon
-        flash: false,
-        count: 0
-      });
-      if (!this.config.disableBadgeCount) {
-        await this.ipcRenderer.invoke("set-badge-count", 0).catch(err => 
-          console.error("[TRAY_DIAG] Failed to set badge count:", err.message)
-        );
+
+    // Count 0 uses the base icon directly, skipping canvas rendering
+    let icon = null;
+    if (count > 0) {
+      try {
+        icon = await this.render(count);
+      } catch (error) {
+        console.error("[TRAY_DIAG] Icon render failed", {
+          error: error.message,
+          count: count,
+          elapsedMs: Date.now() - startTime
+        });
+        // Allow a later event with the same count to retry
+        this.#lastRequestedCount = undefined;
+        return;
       }
-      this.#lastActivityCount = 0;
+    }
+
+    if (sequence !== this.#updateSequence) {
+      console.debug("[TRAY_DIAG] Update superseded while rendering, discarding", {
+        staleCount: count
+      });
       return;
     }
 
-    this.#currentProcessingCount = count;
-    try {
-      const { icon, renderedCount } = await this.render(count);
-      
-      // Prevent race conditions: check if the count has changed since rendering started
-      if (renderedCount !== this.#currentProcessingCount) {
-        console.debug("[TRAY_DIAG] Stale render detected, discarding result", {
-          renderedCount,
-          currentProcessingCount: this.#currentProcessingCount
-        });
-        return;
-      }
+    this.ipcRenderer.send("tray-update", {
+      icon: icon,
+      flash: count > 0 && !this.config.disableNotificationWindowFlash,
+      count: count,
+    });
 
-      const renderTime = Date.now() - startTime;
-      console.debug("[TRAY_DIAG] Icon render completed, sending tray update", {
-        count: count,
-        renderTimeMs: renderTime,
-        iconDataLength: icon?.length || 0,
-        willFlash: count > 0 && !this.config.disableNotificationWindowFlash,
-        performanceNote: renderTime > 100 ? "Slow icon rendering detected" : "Normal rendering speed"
-      });
-      
-      const ipcStartTime = Date.now();
-      this.ipcRenderer.send("tray-update", {
-        icon: icon,
-        flash: count > 0 && !this.config.disableNotificationWindowFlash,
-        count: count,
-      });
-      
-      console.debug("[TRAY_DIAG] Tray update IPC sent", {
-        count: count,
-        totalTimeMs: Date.now() - startTime,
-        ipcCallTimeMs: Date.now() - ipcStartTime,
-        performanceNote: (Date.now() - startTime) > 200 ? "Slow tray update detected" : "Normal tray update speed"
-      });
-      this.#lastActivityCount = count;
-    } catch (error) {
-      console.error("[TRAY_DIAG] Icon render failed", {
-        error: error.message,
-        count: count,
-        elapsedMs: Date.now() - startTime,
-        suggestion: "Check canvas creation and image loading in render method"
-      });
-    }
-    
+    console.debug("[TRAY_DIAG] Tray update IPC sent", {
+      count: count,
+      totalTimeMs: Date.now() - startTime
+    });
+
     if (!this.config.disableBadgeCount) {
-      await this.ipcRenderer.invoke("set-badge-count", count).catch(err => 
+      await this.ipcRenderer.invoke("set-badge-count", count).catch(err =>
         console.error("[TRAY_DIAG] Failed to set badge count:", err.message)
       );
     }
@@ -117,12 +95,9 @@ class TrayIconRenderer {
       // Add error handling for image loading
       image.onerror = () => {
         console.error("Failed to load base icon for tray rendering");
-        resolve({
-          icon: baseIconData,
-          renderedCount: newActivityCount
-        }); // Fallback to base icon
+        resolve(baseIconData); // Fallback to base icon
       };
-      
+
       image.onload = () =>
         this._addRedCircleNotification(
           canvas,
@@ -130,13 +105,10 @@ class TrayIconRenderer {
           newActivityCount,
           resolve,
         );
-      
+
       if (!baseIconData || baseIconData === "data:,") {
         console.error("Base icon toDataURL returned invalid data");
-        resolve({
-          icon: baseIconData,
-          renderedCount: newActivityCount
-        }); // Fallback
+        resolve(baseIconData); // Fallback
         return;
       }
       
@@ -165,10 +137,7 @@ class TrayIconRenderer {
       }
     }
     const resizedCanvas = this._getResizeCanvasWithOriginalIconSize(canvas);
-    resolve({
-      icon: resizedCanvas.toDataURL(),
-      renderedCount: newActivityCount
-    });
+    resolve(resizedCanvas.toDataURL());
   }
 
   _getResizeCanvasWithOriginalIconSize(canvas) {

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -98,13 +98,21 @@ class TrayIconRenderer {
         resolve(baseIconData); // Fallback to base icon
       };
 
-      image.onload = () =>
-        this._addRedCircleNotification(
-          canvas,
-          image,
-          newActivityCount,
-          resolve,
-        );
+      image.onload = () => {
+        // Drawing can throw (e.g. getContext returning null under memory
+        // pressure); resolve with the base icon so the promise never hangs.
+        try {
+          this._addRedCircleNotification(
+            canvas,
+            image,
+            newActivityCount,
+            resolve,
+          );
+        } catch (error) {
+          console.error("[TRAY_DIAG] Canvas drawing failed, using base icon:", error);
+          resolve(baseIconData);
+        }
+      };
 
       if (!baseIconData || baseIconData === "data:,") {
         console.error("Base icon toDataURL returned invalid data");

--- a/tests/e2e/preload-modules.spec.js
+++ b/tests/e2e/preload-modules.spec.js
@@ -14,10 +14,11 @@ import {
 // is not initialised with `ipcRenderer`, `this.ipcRenderer` is undefined
 // and the `unread-count` event handler throws before any IPC is sent.
 //
-// `count: 0` hits the early-return branch in
-// `trayIconRenderer.updateActivityCount`, which sends a `tray-update`
-// IPC without exercising canvas rendering --- the cheapest signal that
-// `init(config, ipcRenderer)` ran correctly.
+// A non-zero count is dispatched first: since the login page title has
+// no `(N)` prefix, only a zero can have been dispatched during startup
+// (the head-wide title observer fires on the login page), so a non-zero
+// value is never swallowed by `updateActivityCount`'s deduplication.
+// The follow-up zero asserts the clear-to-zero path (#2620) lands too.
 
 test('preload passes ipcRenderer to trayIconRenderer (regression #1902)', async () => {
   // `allowEval: true` sets E2E_TESTING=true so `electronApp.evaluate`
@@ -43,33 +44,56 @@ test('preload passes ipcRenderer to trayIconRenderer (regression #1902)', async 
       });
     });
 
+    // The renderer dispatches synchronously, but icon rendering and the
+    // IPC hop are async. Poll up to 15 s for a `tray-update` carrying the
+    // target count at or after `fromIndex` --- successful runs return on
+    // the first iterations; the generous deadline only matters on slow CI
+    // runners. Index-based matching tolerates stray zero updates from the
+    // login page's own title changes.
+    const waitForTrayUpdate = (targetCount, fromIndex) =>
+      ctx.electronApp.evaluate(async (_electron, args) => {
+        const deadline = Date.now() + 15000;
+        let index = -1;
+        while (Date.now() < deadline) {
+          index = globalThis.__capturedTrayUpdates.findIndex(
+            (payload, i) => i >= args.fromIndex && payload.count === args.targetCount
+          );
+          if (index !== -1) {
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        return { index, captured: globalThis.__capturedTrayUpdates };
+      }, { targetCount, fromIndex });
+
+    await mainWindow.evaluate(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent('unread-count', { detail: { number: 2 } })
+      );
+    });
+
+    const first = await waitForTrayUpdate(2, 0);
+    expect(
+      first.index,
+      'trayIconRenderer should send a `tray-update` IPC when `unread-count` fires. ' +
+        'If this fails, check that `modulesRequiringIpc` in `app/browser/preload.js` ' +
+        'still includes "trayIconRenderer" (CLAUDE.md / issue #1902).'
+    ).toBeGreaterThanOrEqual(0);
+    expect(first.captured[first.index]).toMatchObject({ count: 2 });
+
+    // Clear-to-zero must produce a follow-up tray-update (#2620)
     await mainWindow.evaluate(() => {
       globalThis.dispatchEvent(
         new CustomEvent('unread-count', { detail: { number: 0 } })
       );
     });
 
-    // The renderer dispatches synchronously, but the IPC hop is async.
-    // Poll up to 15 s --- successful runs return on the first iteration;
-    // the generous deadline only matters on slow CI runners.
-    const captured = await ctx.electronApp.evaluate(async () => {
-      const deadline = Date.now() + 15000;
-      while (Date.now() < deadline) {
-        if (globalThis.__capturedTrayUpdates.length > 0) {
-          return globalThis.__capturedTrayUpdates;
-        }
-        await new Promise((r) => setTimeout(r, 100));
-      }
-      return globalThis.__capturedTrayUpdates;
-    });
-
+    const second = await waitForTrayUpdate(0, first.index + 1);
     expect(
-      captured.length,
-      'trayIconRenderer should send a `tray-update` IPC when `unread-count` fires. ' +
-        'If this fails, check that `modulesRequiringIpc` in `app/browser/preload.js` ' +
-        'still includes "trayIconRenderer" (CLAUDE.md / issue #1902).'
-    ).toBeGreaterThan(0);
-    expect(captured[0]).toMatchObject({ count: 0 });
+      second.index,
+      'trayIconRenderer should send a `tray-update` clearing the badge (#2620).'
+    ).toBeGreaterThan(first.index);
+    expect(second.captured[second.index]).toMatchObject({ count: 0, icon: null });
   } finally {
     await closeAndCleanup(ctx);
   }


### PR DESCRIPTION
## Summary

The stuck tray badge in #2620 turned out to be two stacked defects:

1. **Title observation too narrow** (`app/browser/tools/mutationTitle.js`): the `MutationObserver` watched only `childList` mutations on the current `<title>` element, so it missed in-place `characterData` updates and died silently if Teams remounted the element. The observer now watches `document.head` with `childList + characterData + subtree` (filtered to mutations involving `<title>`) and keeps reading `document.title`, so it survives both update mechanisms and element replacement. Root cause of this layer was identified by @felipekj in #2625 and validated by user testing on that PR's build — credit to him.

2. **Async update race in the badge renderer** (`app/browser/tools/trayIconRenderer.js`), a regression introduced by PR #2219 (shipped in v2.7.10). `updateActivityCount()` deduplicated incoming counts against the last *completed* update, so when Teams flaps the title (`"Chat"` → `"(1) Chat"` → `"Chat"`, which happens when sending a message), the clear-to-zero event arrived while the non-zero canvas render was still in flight, compared equal to the stale completed value, and was silently dropped — the stale `1` render then landed and stuck. The zero fast path also never invalidated the stale-render guard, so out-of-order completions could overwrite a newer zero. This exactly reproduces the odd/even toggle reported during #2625 testing (first send sticks the badge, second send clears it). Updates now dedup against the last *requested* count and carry a monotonic sequence token; any update superseded while rendering is discarded, including by the render-free zero path.

Also fixes a latent unbound-`this` in the `DOMContentLoaded` fallback of `mutationTitle.js`, and guards canvas drawing in `render()` so the promise can never hang (review feedback).

The #1902 e2e regression test was updated to be dedup-aware: the head-wide observer now legitimately dispatches a zero on the login page, so the test dispatches a non-zero count first and then asserts the clear-to-zero path (#2620) end-to-end.

Deliberately **not** included from #2625: `backgroundThrottling: false` (app-wide CPU cost, unrelated to either root cause) and the main-process `page-title-updated` fallback IPC (redundant once the observer covers element replacement). This PR supersedes the renderer-side portion of #2625.

## Test plan

- `npm run lint` passes
- e2e suite runs in CI (dev container cannot reach the Microsoft login endpoint)
- Real-machine verification per the #2620 reproduction: receive a message, read it → badge clears; send a message → badge must **not** appear/stick (the scenario that failed on the #2625 build)

closes #2620

https://claude.ai/code/session_019JGEKx1Xde2q5JE9gqPdrT