### PR TITLE
ci(snap): pin arm64 snapcraft below 9.0.0 to fix the snap build

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -135,7 +135,15 @@ jobs:
 
     steps:
       - name: Install Snapcraft
+        # snapcraft 9.0.0 removed the legacy `snap` packing command that
+        # electron-builder's deprecated core22 `snap` target invokes
+        # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
+        # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
+        # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
+        # armv7l jobs pack via app-builder directly and are unaffected.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
+        with:
+          channel: 8.x/stable
 
       - name: Install and initialize LXD
         uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main


### PR DESCRIPTION
### What broke

The `snap-arm64` CI job fails with `Command failed: snapcraft snap --output out.snap` and "The 'snap' command was renamed to 'pack'." It is failing on `main` too, not just on PRs.

### Root cause

snapcraft 9.0.0 removed the long-deprecated `snap` packing subcommand (previously a warning, now a hard error pointing at `pack`). electron-builder's deprecated `build.snap` target, which we use with `base: core22`, packs by invoking `snapcraft snap --output out.snap`. CI installs snapcraft unpinned via `action-snapcraft` (default `stable`), so the runners pulled 9.0.0 and the call started failing.

This is not a regression on our side. `snap.yml` and the snap build config have only had dependency bumps, no change to the build invocation. The break came entirely from snapcraft's 9.0.0 release, which we picked up because the toolchain was unpinned.

### Why only arm64

All three snap jobs install the same snapcraft 9.0.0, but only the native-arm64 job (`ubuntu-24.04-arm`, LXD) delegates packing to `snapcraft snap`. The amd64 and armv7l jobs pack the squashfs through electron-builder's app-builder helper directly and never call `snapcraft snap`, so they still pass on 9.0.0.

### Why it went unnoticed

`snap-arm64` is a non-required check, so its failure does not block merges, and an unpinned snapcraft meant the external change landed silently. It only surfaced because the failure is now consistent on every run.

### The fix (stopgap)

Pin the arm64 job's snapcraft to `8.x/stable`, the last track where the legacy `snap` command still resolves (it aliases to `pack`). Scoped to the arm64 job only; amd64 and armv7l are left on the default channel since they do not hit the removed command. CI on this PR is the validation.

### The real fix

Migrate the snap build from the deprecated `snap` (core22) target to the `snapcraft` (core24) target, which uses `snapcraft pack` and works on snapcraft 9+. That is already tracked in #2590 and started in draft #2592. Once it lands, this pin can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
