### PR TITLE
feat(menus): context-menu attachment download and Save Open Document

### DIFF
--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -32,6 +32,10 @@ exports = module.exports = (Menus) => ({
       accelerator: "ctrl+R",
       click: () => Menus.reload(),
     },
+    {
+      label: "Save Open Document to File…",
+      click: () => Menus.saveOpenDocument(),
+    },
     ...(process.env.APPIMAGE
       ? [
           {

--- a/app/menus/attachmentDownload.js
+++ b/app/menus/attachmentDownload.js
@@ -1,0 +1,687 @@
+const { app, BrowserWindow, Notification, clipboard } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+// Attachment download pipeline used by the context menu (app/menus/index.js).
+// Downloads a Teams/SharePoint/OneDrive link or a generic http(s) URL, saves it
+// into Documents/Teams-Downloads (or a caller-chosen path) and places a native
+// file reference on the clipboard. Microsoft hosts and HTML responses are
+// fetched through a locked-down hidden window so the authenticated session and
+// viewer redirects work; direct binary responses are streamed straight from
+// `session.fetch`.
+
+// Microsoft 365 / SharePoint / OneDrive hosts get the hidden-window download
+// treatment (they need the authenticated session and viewer redirects).
+// Suffix matching only — a substring test would also match lookalike hosts
+// like "mymicrosoft.evil.com". "mcas.ms" covers Defender for Cloud Apps
+// proxied hosts ("contoso.sharepoint.com.<region>.mcas.ms").
+const MS_HOST_SUFFIXES = [
+  "sharepoint.com",
+  "sharepoint-df.com",
+  "officeapps.live.com",
+  "office.com",
+  "office.net",
+  "microsoft.com",
+  "onedrive.com",
+  "1drv.ms",
+  "svc.ms",
+  "mcas.ms",
+];
+
+function isMicrosoftHost(urlStr) {
+  try {
+    const url = new URL(urlStr);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return false;
+    }
+    const host = url.hostname.toLowerCase();
+    return MS_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith("." + suffix));
+  } catch {
+    return false;
+  }
+}
+
+// Strip any path components from a filename coming from an untrusted source
+// (Content-Disposition header, page title, URL path) so it can never escape
+// the target directory.
+function sanitizeFilename(candidate, fallback = "attachment") {
+  if (typeof candidate !== "string") {
+    return fallback;
+  }
+  const base = path.basename(candidate.replaceAll("\\", "/")).trim();
+  if (!base || base === "." || base === "..") {
+    return fallback;
+  }
+  return base;
+}
+
+// Mirror Chromium's "name (1).ext" de-duplication for direct writes into
+// Teams-Downloads, so an existing file is never silently overwritten.
+function uniqueFilePath(directory, filename) {
+  const ext = path.extname(filename);
+  const stem = path.basename(filename, ext);
+  let candidate = path.join(directory, filename);
+  for (let i = 1; fs.existsSync(candidate); i++) {
+    candidate = path.join(directory, `${stem} (${i})${ext}`);
+  }
+  return candidate;
+}
+
+// Strip the viewer suffix from a page title ("notes.txt - SharePoint" →
+// "notes.txt"). Plain string operations instead of regexes: the title is
+// page-controlled and the previous /\s+-\s+…$/ patterns were flagged as
+// backtracking-prone (Sonar S5852).
+const VIEWER_TITLE_SUFFIXES = new Set(["sharepoint", "onedrive", "microsoft 365"]);
+
+function stripViewerTitleSuffix(title) {
+  const trimmed = title.trim();
+  const idx = trimmed.lastIndexOf(" - ");
+  if (idx > 0) {
+    const suffix = trimmed.slice(idx + 3).trim().toLowerCase();
+    if (VIEWER_TITLE_SUFFIXES.has(suffix)) {
+      return trimmed.slice(0, idx).trim();
+    }
+  }
+  return trimmed;
+}
+
+// Electron's clipboard.write() has no cross-platform "file" type (an unknown
+// key like `filenames` is silently ignored), so write the platform-native
+// format that file managers actually paste from.
+function copyFilePathToClipboard(filePath) {
+  try {
+    if (process.platform === "darwin") {
+      const escaped = filePath
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+      const plist =
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' +
+        `<plist version="1.0"><array><string>${escaped}</string></array></plist>`;
+      clipboard.writeBuffer("NSFilenamesPboardType", Buffer.from(plist));
+    } else if (process.platform === "linux") {
+      const uri = pathToFileURL(filePath).toString();
+      clipboard.writeBuffer("text/uri-list", Buffer.from(uri + "\n"));
+    } else {
+      clipboard.writeText(filePath);
+    }
+  } catch (error) {
+    console.warn("[CopyAttachment] Could not place file on clipboard", {
+      message: error?.message,
+    });
+  }
+}
+
+function getDirectDownloadUrl(urlStr) {
+  try {
+    if (isMicrosoftHost(urlStr)) {
+      const url = new URL(urlStr);
+      if (!url.searchParams.has("download")) {
+        url.searchParams.set("download", "1");
+        return url.toString();
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return urlStr;
+}
+
+// Download `linkURL` and copy the saved file to the clipboard.
+// `options.destinationPath` (when set) saves to that exact path instead of
+// Documents/Teams-Downloads — used by the "Save Attachment As…" menu item,
+// where the user already picked the location in a save dialog.
+async function copyAttachmentAsFile(linkURL, session, mainWindowUrl = "", options = {}) {
+  const destinationPath = options.destinationPath || null;
+  const progressNotification = new Notification({
+    title: "Downloading attachment...",
+    body: "Downloading attachment in the background...",
+    silent: true,
+  });
+  progressNotification.show();
+
+  try {
+    let downloadURL = getDirectDownloadUrl(linkURL);
+    
+    // Convert direct path view URLs to direct layout download URLs if possible
+    const spDownloadURL = getSharePointDownloadUrl(downloadURL);
+    if (spDownloadURL) {
+      downloadURL = spDownloadURL;
+    }
+
+    // Apply corporate MCAS proxy if active
+    if (mainWindowUrl) {
+      downloadURL = applyMcasProxy(downloadURL, mainWindowUrl);
+    }
+    
+    const isMS = isMicrosoftHost(downloadURL);
+
+    // Both the M365 path and an HTML response from a generic host go through
+    // a hidden window: viewer text extraction for text files (so the Monaco
+    // editor renders), navigation download otherwise. Only a direct binary
+    // response is saved straight from fetch.
+    const fetchViaHiddenWindow = () => {
+      if (isTextFile(downloadURL)) {
+        let viewerURL = linkURL;
+        if (mainWindowUrl) {
+          viewerURL = applyMcasProxy(viewerURL, mainWindowUrl);
+        }
+        return extractTextFromBrowserWindow(viewerURL, session, destinationPath);
+      }
+      return downloadWithBrowserWindow(downloadURL, session, destinationPath);
+    };
+
+    let result;
+    if (isMS) {
+      result = await fetchViaHiddenWindow();
+    } else {
+      const response = await session.fetch(downloadURL);
+      if (!response.ok) {
+        throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("text/html")) {
+        result = await fetchViaHiddenWindow();
+      } else {
+        let filename = "attachment";
+        const contentDisposition = response.headers.get("content-disposition");
+        if (contentDisposition) {
+          const match = contentDisposition.match(/filename\*?=["']?(?:UTF-8'')?([^;"']+)["']?/i);
+          if (match && match[1]) {
+            filename = decodeURIComponent(match[1]);
+          } else {
+            const fallbackMatch = contentDisposition.match(/filename=["']?([^;"']+)["']?/i);
+            if (fallbackMatch && fallbackMatch[1]) {
+              filename = fallbackMatch[1];
+            }
+          }
+        } else {
+          try {
+            const urlObj = new URL(linkURL);
+            const pathname = urlObj.pathname;
+            const lastPart = pathname.substring(pathname.lastIndexOf('/') + 1);
+            if (lastPart) {
+              filename = decodeURIComponent(lastPart);
+            }
+          } catch (e) {
+            // ignore
+          }
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+
+        let targetFilePath;
+        if (destinationPath) {
+          // The user already chose the exact path in the save dialog (which
+          // confirms its own overwrites), so honour it verbatim.
+          fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+          targetFilePath = destinationPath;
+        } else {
+          const documentsDir = path.join(app.getPath("documents"), "Teams-Downloads");
+          fs.mkdirSync(documentsDir, { recursive: true });
+          // The filename came from a server header or URL — never let it carry
+          // path segments out of the target directory.
+          filename = sanitizeFilename(filename);
+          targetFilePath = uniqueFilePath(documentsDir, filename);
+        }
+        fs.writeFileSync(targetFilePath, buffer);
+
+        copyFilePathToClipboard(targetFilePath);
+        result = { filename: path.basename(targetFilePath), targetFilePath };
+      }
+    }
+
+    const savedLocation = destinationPath
+      ? result.targetFilePath
+      : `Documents/Teams-Downloads/${result.filename}`;
+    const successNotification = new Notification({
+      title: "Downloaded & Copied!",
+      body: `Saved to ${savedLocation} and copied to clipboard.`,
+    });
+    successNotification.show();
+  } catch (error) {
+    // Log the message only — the full error can embed the download URL.
+    console.error("[CopyAttachment] Error:", error?.message);
+    const errorNotification = new Notification({
+      title: "Download Error",
+      body: `Failed to save attachment: ${error.message}`,
+    });
+    errorNotification.show();
+  } finally {
+    // Always dismiss the progress toast, also when the download failed.
+    progressNotification.close();
+  }
+}
+
+function isTextFile(urlStr) {
+  try {
+    const url = new URL(urlStr);
+    const pathname = url.pathname;
+    
+    if (pathname.includes("/:t:/")) {
+      return true;
+    }
+    
+    const lastPart = pathname.substring(pathname.lastIndexOf('/') + 1);
+    const extMatch = lastPart.match(/\.([a-zA-Z0-9]+)$/);
+    if (extMatch) {
+      const ext = extMatch[1].toLowerCase();
+      const TEXT_EXTENSIONS = [
+        "txt", "json", "csv", "log", "xml", "html", "htm", "css", "js", "ts",
+        "py", "sh", "bat", "ps1", "yml", "yaml", "md", "ini", "conf", "sql"
+      ];
+      return TEXT_EXTENSIONS.includes(ext);
+    }
+  } catch (e) {
+    // ignore
+  }
+  return false;
+}
+
+// Shared scaffolding for the two hidden-window flows (viewer text extraction
+// and navigation download). The window shares the authenticated Teams
+// session, so the renderer stays fully locked down: same-origin policy,
+// context isolation, and the sandbox all enabled — executeJavaScript still
+// works with all of these. The desktop-browser UA keeps the SharePoint
+// viewer from serving a mobile or unsupported-browser page.
+const HIDDEN_WINDOW_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+function createHiddenDownloadWindow(activeSession) {
+  const tempWin = new BrowserWindow({
+    show: false,
+    width: 800,
+    height: 600,
+    webPreferences: {
+      session: activeSession,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      backgroundThrottling: false,
+      webSecurity: true,
+    },
+  });
+  tempWin.webContents.setUserAgent(HIDDEN_WINDOW_USER_AGENT);
+
+  const documentsDir = path.join(app.getPath("documents"), "Teams-Downloads");
+  fs.mkdirSync(documentsDir, { recursive: true });
+
+  return { tempWin, documentsDir };
+}
+
+function extractTextFromBrowserWindow(downloadURL, activeSession, destinationPath = null) {
+  return new Promise((resolve, reject) => {
+    const { tempWin, documentsDir } = createHiddenDownloadWindow(activeSession);
+    if (destinationPath) {
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    }
+
+    let resolved = false;
+    let cleanupTimeout;
+
+    const cleanup = () => {
+      if (cleanupTimeout) {
+        clearTimeout(cleanupTimeout);
+      }
+      if (!tempWin.isDestroyed()) {
+        tempWin.destroy();
+      }
+    };
+
+    cleanupTimeout = setTimeout(() => {
+      if (!resolved) {
+        cleanup();
+        reject(new Error("Text extraction timed out (30 seconds)"));
+      }
+    }, 30000);
+
+    tempWin.webContents.on("did-finish-load", async () => {
+      try {
+        let pageInfo = { success: false };
+        for (let i = 0; i < 40; i++) {
+          if (tempWin.isDestroyed()) return;
+          
+          pageInfo = await tempWin.webContents.executeJavaScript(`
+            (function() {
+              let textVal = "";
+              let found = false;
+              
+              try {
+                if (typeof monaco !== 'undefined' && monaco.editor) {
+                  const models = monaco.editor.getModels();
+                  if (models && models.length > 0) {
+                    const val = models[0].getValue();
+                    if (val) {
+                      textVal = val;
+                      found = true;
+                    }
+                  }
+                }
+              } catch (e) {}
+              
+              if (!found) {
+                try {
+                  const pre = document.querySelector('pre');
+                  if (pre && pre.innerText && pre.innerText.trim().length > 0) {
+                    textVal = pre.innerText;
+                    found = true;
+                  }
+                } catch (e) {}
+              }
+              
+              if (!found) {
+                try {
+                  const container = document.querySelector('.text-container') || document.querySelector('.file-viewer');
+                  if (container && container.innerText && container.innerText.trim().length > 0) {
+                    textVal = container.innerText;
+                    found = true;
+                  }
+                } catch (e) {}
+              }
+              
+              if (found) {
+                return { success: true, text: textVal, title: document.title };
+              }
+              
+              return { success: false };
+            })()
+          `);
+
+          if (pageInfo && pageInfo.success) {
+            break;
+          }
+          await new Promise(r => setTimeout(r, 500));
+        }
+
+        if (pageInfo && pageInfo.success) {
+          let filename = stripViewerTitleSuffix(pageInfo.title || "attachment.txt");
+          // The title is page-controlled — strip any path segments before
+          // building the save path.
+          filename = sanitizeFilename(filename, "attachment.txt");
+          if (!filename.includes(".")) {
+            filename += ".txt";
+          }
+
+          const targetFilePath = destinationPath || uniqueFilePath(documentsDir, filename);
+          fs.writeFileSync(targetFilePath, pageInfo.text, "utf8");
+
+          // Copy the extracted text; a file reference would overwrite it
+          // (the clipboard holds one payload at a time).
+          clipboard.writeText(pageInfo.text);
+
+          resolved = true;
+          cleanup();
+          resolve({ filename: path.basename(targetFilePath), targetFilePath });
+        }
+      } catch (e) {
+        console.error("[TextExtract] Error during extraction:", e?.message);
+        // Settle now instead of leaving the caller to hit the 30s timeout
+        // (or hang forever once `resolved` is set).
+        if (!resolved) {
+          resolved = true;
+          cleanup();
+          reject(e);
+        }
+      }
+    });
+
+    tempWin.loadURL(downloadURL).catch((err) => {
+      setTimeout(() => {
+        if (!resolved) {
+          cleanup();
+          reject(new Error(`Failed to load URL: ${err.message}`));
+        }
+      }, 500);
+    });
+  });
+}
+
+function getSharePointDownloadUrl(urlStr) {
+  try {
+    const url = new URL(urlStr);
+    const host = url.hostname.toLowerCase();
+    
+    // Only target SharePoint and OneDrive domains
+    if (host.includes("sharepoint.com") || host.includes("onedrive.com") || host.includes("mcas.ms")) {
+      const pathname = url.pathname;
+      // Match viewer prefix: /:x:/r/ or /:w:/g/ etc. (supporting sites or personal)
+      const viewerRegex = /^\/:[a-z]:\/[rg]\/(personal|sites)\/([^\/]+)\/(.+)$/i;
+      const match = pathname.match(viewerRegex);
+      
+      if (match) {
+        const filePath = match[3];
+        // Only convert if the file path has a standard file extension
+        const hasExtension = /\.[a-zA-Z0-9]{2,5}$/.test(filePath);
+        if (hasExtension) {
+          const type = match[1];
+          const ownerOrSite = match[2];
+          
+          const directPath = `${url.origin}/${type}/${ownerOrSite}/${filePath}`;
+          const siteRoot = `${url.origin}/${type}/${ownerOrSite}`;
+          
+          const downloadUrl = new URL(`${siteRoot}/_layouts/15/download.aspx`);
+          downloadUrl.searchParams.set("SourceUrl", directPath);
+          return downloadUrl.toString();
+        }
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+  return null;
+}
+
+function applyMcasProxy(urlStr, mainWindowUrl) {
+  try {
+    const mainUrl = new URL(mainWindowUrl);
+    if (mainUrl.hostname.endsWith(".mcas.ms")) {
+      const targetUrl = new URL(urlStr);
+      const origHost = targetUrl.hostname;
+      if (!origHost.endsWith(".mcas.ms")) {
+        const proxiedHost = origHost + ".mcas.ms";
+        // String replace to rewrite both the main domain and any URL-encoded SourceUrl domains
+        return urlStr.replaceAll(origHost, proxiedHost);
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+  return urlStr;
+}
+
+function downloadWithBrowserWindow(downloadURL, activeSession, destinationPath = null) {
+  return new Promise((resolve, reject) => {
+    const { tempWin, documentsDir } = createHiddenDownloadWindow(activeSession);
+    if (destinationPath) {
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    }
+
+    let downloadInitiated = false;
+    let settled = false;
+    let cleanupTimeout;
+
+    const cleanup = () => {
+      if (cleanupTimeout) {
+        clearTimeout(cleanupTimeout);
+        cleanupTimeout = null;
+      }
+      activeSession.removeListener("will-download", handleWillDownload);
+      if (!tempWin.isDestroyed()) {
+        tempWin.destroy();
+      }
+    };
+
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    cleanupTimeout = setTimeout(() => {
+      fail(new Error("Download timed out (no download started within 30 seconds)"));
+    }, 30000);
+
+    const handleWillDownload = (event, item, webContents) => {
+      if (webContents && webContents.id === tempWin.webContents.id) {
+        downloadInitiated = true;
+        // The navigation did its job; give the transfer itself a longer
+        // backstop so a stalled download can't leak the hidden window and
+        // the session listener forever.
+        if (cleanupTimeout) {
+          clearTimeout(cleanupTimeout);
+        }
+        cleanupTimeout = setTimeout(() => {
+          fail(new Error("Download timed out"));
+        }, 10 * 60 * 1000);
+
+        // Tell DownloadManager (which listens on the same session) to skip
+        // its own save path, notifications and openWhenDone for this item.
+        item.teamsForLinuxExternallyManaged = true;
+
+        const filename = sanitizeFilename(item.getFilename(), "attachment");
+        const targetFilePath = destinationPath || uniqueFilePath(documentsDir, filename);
+
+        item.setSavePath(targetFilePath);
+
+        // A transient "interrupted" in `updated` can auto-resume; only the
+        // final state in `done` decides the outcome.
+        item.once("done", (event, state) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          if (state === "completed") {
+            copyFilePathToClipboard(targetFilePath);
+            resolve({ filename: path.basename(targetFilePath), targetFilePath });
+          } else {
+            reject(new Error(`Download failed with state: ${state}`));
+          }
+        });
+      }
+    };
+
+    activeSession.on("will-download", handleWillDownload);
+
+    tempWin.loadURL(downloadURL).catch((err) => {
+      setTimeout(() => {
+        if (!downloadInitiated) {
+          fail(new Error(`Failed to load URL: ${err.message}`));
+        }
+      }, 500);
+    });
+  });
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+// Frames that host an Office / SharePoint document viewer. The rendered Word /
+// Excel / PowerPoint content lives in one of these nested (cross-origin)
+// frames, not in the top Teams frame.
+const OFFICE_FRAME_RE =
+  /officeapps\.live\.com|sharepoint\.com|sharepoint-df\.com|office\.com|office\.net|onedrive|1drv|\.svc\.ms|\.mcas\.ms|wopi|wacviewer|powerpoint|excel|word/i;
+
+// Capture the rendered content of the document currently open in `webContents`
+// and write it to `destinationPath`. This is the "let the app do the Cmd+A /
+// Cmd+C for me and paste it into a file" path — it reads what Teams already
+// rendered in the viewer frame instead of triggering Teams' native download.
+// .txt destinations get plain text; anything else gets a standalone HTML
+// document (which Word/Pages/LibreOffice open with formatting preserved).
+async function saveRenderedDocument(webContents, destinationPath) {
+  // Probe every reachable frame for how much text it renders, and whether it
+  // looks like an Office viewer. Cross-origin frames we cannot script throw
+  // and are skipped.
+  const probe = `(() => {
+    const text = (document.body && document.body.innerText) || "";
+    return { url: location.href, len: text.replace(/\\s+/g, " ").trim().length };
+  })()`;
+
+  const frames = webContents.mainFrame.framesInSubtree;
+  let best = null;
+  for (const frame of frames) {
+    let info;
+    try {
+      info = await frame.executeJavaScript(probe, true);
+    } catch {
+      continue; // frame detached or not scriptable
+    }
+    if (!info || !info.len) continue;
+    // An Office viewer frame always beats a plain frame; within each class the
+    // one rendering the most text wins.
+    const office = OFFICE_FRAME_RE.test(info.url);
+    const score = info.len + (office ? 1e9 : 0);
+    if (!best || score > best.score) {
+      best = { frame, score, ...info };
+    }
+  }
+
+  if (!best) {
+    throw new Error("No rendered document content found in any frame");
+  }
+
+  // Select the whole document body and clone the selection so we keep the
+  // rendered HTML (formatting), plus a plain-text fallback.
+  const capture = `(() => {
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(document.body);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    const holder = document.createElement("div");
+    for (let i = 0; i < sel.rangeCount; i++) holder.appendChild(sel.getRangeAt(i).cloneContents());
+    const html = holder.innerHTML;
+    const text = sel.toString();
+    sel.removeAllRanges();
+    return { html, text, title: document.title };
+  })()`;
+  const captured = await best.frame.executeJavaScript(capture, true);
+
+  const ext = path.extname(destinationPath).toLowerCase();
+  const output =
+    ext === ".txt"
+      ? captured.text || ""
+      : `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+        `<title>${escapeHtml(captured.title || "document")}</title></head>` +
+        `<body>${captured.html || escapeHtml(captured.text || "")}</body></html>`;
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.writeFileSync(destinationPath, output, "utf8");
+
+  let host = "";
+  try {
+    host = new URL(best.url).host;
+  } catch {
+    host = "the document";
+  }
+  const chars = (captured.text || "").length;
+  const notification = new Notification({
+    title: "Document saved",
+    body: `Saved ${chars} characters from ${host} to ${destinationPath}.`,
+  });
+  notification.show();
+
+  return { savedTo: destinationPath, chars, frameHost: host };
+}
+
+module.exports = {
+  copyAttachmentAsFile,
+  saveRenderedDocument,
+  // Exported for unit tests:
+  getDirectDownloadUrl,
+  getSharePointDownloadUrl,
+  applyMcasProxy,
+  isTextFile,
+  sanitizeFilename,
+  uniqueFilePath,
+  isMicrosoftHost,
+  stripViewerTitleSuffix,
+  copyFilePathToClipboard,
+};

--- a/app/menus/attachmentDownload.js
+++ b/app/menus/attachmentDownload.js
@@ -2,6 +2,8 @@ const { app, BrowserWindow, Notification, clipboard } = require("electron");
 const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
+const { Readable } = require("node:stream");
+const { finished } = require("node:stream/promises");
 
 // Attachment download pipeline used by the context menu (app/menus/index.js).
 // Downloads a Teams/SharePoint/OneDrive link or a generic http(s) URL, saves it
@@ -211,9 +213,6 @@ async function copyAttachmentAsFile(linkURL, session, mainWindowUrl = "", option
           }
         }
 
-        const arrayBuffer = await response.arrayBuffer();
-        const buffer = Buffer.from(arrayBuffer);
-
         let targetFilePath;
         if (destinationPath) {
           // The user already chose the exact path in the save dialog (which
@@ -228,7 +227,16 @@ async function copyAttachmentAsFile(linkURL, session, mainWindowUrl = "", option
           filename = sanitizeFilename(filename);
           targetFilePath = uniqueFilePath(documentsDir, filename);
         }
-        fs.writeFileSync(targetFilePath, buffer);
+
+        // Stream the body to disk rather than buffering the whole file in
+        // memory — a large attachment via response.arrayBuffer() could OOM the
+        // main process.
+        if (!response.body) {
+          throw new Error("Response body is empty");
+        }
+        await finished(
+          Readable.fromWeb(response.body).pipe(fs.createWriteStream(targetFilePath))
+        );
 
         copyFilePathToClipboard(targetFilePath);
         result = { filename: path.basename(targetFilePath), targetFilePath };
@@ -416,6 +424,12 @@ function extractTextFromBrowserWindow(downloadURL, activeSession, destinationPat
           resolved = true;
           cleanup();
           resolve({ filename: path.basename(targetFilePath), targetFilePath });
+        } else if (!resolved) {
+          // The poll loop exhausted its attempts without finding text — settle
+          // now instead of letting the caller wait out the 30s timeout.
+          resolved = true;
+          cleanup();
+          reject(new Error("No text content could be extracted from the viewer"));
         }
       } catch (e) {
         console.error("[TextExtract] Error during extraction:", e?.message);
@@ -511,6 +525,7 @@ function downloadWithBrowserWindow(downloadURL, activeSession, destinationPath =
       }
       activeSession.removeListener("will-download", handleWillDownload);
       if (!tempWin.isDestroyed()) {
+        tempWin.webContents.removeListener("did-finish-load", handleDidFinishLoad);
         tempWin.destroy();
       }
     };
@@ -525,6 +540,18 @@ function downloadWithBrowserWindow(downloadURL, activeSession, destinationPath =
     cleanupTimeout = setTimeout(() => {
       fail(new Error("Download timed out (no download started within 30 seconds)"));
     }, 30000);
+
+    // A real file URL fires will-download during navigation; if the page just
+    // finishes loading as a normal document (expired link, login, error page)
+    // no download ever starts. Fail fast after a short grace window instead of
+    // waiting out the 30s timeout.
+    const handleDidFinishLoad = () => {
+      setTimeout(() => {
+        if (!downloadInitiated && !settled) {
+          fail(new Error("The URL loaded as a page without starting a download"));
+        }
+      }, 1000);
+    };
 
     const handleWillDownload = (event, item, webContents) => {
       if (webContents && webContents.id === tempWin.webContents.id) {
@@ -565,6 +592,7 @@ function downloadWithBrowserWindow(downloadURL, activeSession, destinationPath =
     };
 
     activeSession.on("will-download", handleWillDownload);
+    tempWin.webContents.on("did-finish-load", handleDidFinishLoad);
 
     tempWin.loadURL(downloadURL).catch((err) => {
       setTimeout(() => {
@@ -627,20 +655,15 @@ async function saveRenderedDocument(webContents, destinationPath) {
     throw new Error("No rendered document content found in any frame");
   }
 
-  // Select the whole document body and clone the selection so we keep the
-  // rendered HTML (formatting), plus a plain-text fallback.
+  // Read the rendered body directly. Going through window.getSelection() would
+  // capture the same HTML/text but clobber whatever the user had selected in
+  // the viewer (and can fire selectionchange listeners on the page).
   const capture = `(() => {
-    const sel = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(document.body);
-    sel.removeAllRanges();
-    sel.addRange(range);
-    const holder = document.createElement("div");
-    for (let i = 0; i < sel.rangeCount; i++) holder.appendChild(sel.getRangeAt(i).cloneContents());
-    const html = holder.innerHTML;
-    const text = sel.toString();
-    sel.removeAllRanges();
-    return { html, text, title: document.title };
+    return {
+      html: document.body.innerHTML,
+      text: document.body.innerText,
+      title: document.title,
+    };
   })()`;
   const captured = await best.frame.executeJavaScript(capture, true);
 

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -6,10 +6,12 @@ const {
   dialog,
   session,
   ipcMain,
+  Notification,
 } = require("electron");
 const fs = require("node:fs"),
   path = require("node:path");
 const appMenu = require("./appMenu");
+const { copyAttachmentAsFile, saveRenderedDocument } = require("./attachmentDownload");
 const Tray = require("./tray");
 const { SpellCheckProvider } = require("../spellCheckProvider");
 const DocumentationWindow = require("../documentationWindow");
@@ -149,14 +151,38 @@ class Menus {
     this.window.hide();
   }
 
+  // Capture the rendered content of the document currently open in the Teams
+  // viewer (Word/Excel/PowerPoint) and write it to a file the user picks —
+  // the "let the app do the select-all/copy and paste it into a file" flow,
+  // bypassing Teams' native download.
+  async saveOpenDocument() {
+    const { canceled, filePath } = await dialog.showSaveDialog(this.window, {
+      title: "Save Open Document to File",
+      defaultPath: path.join(app.getPath("downloads"), "document.html"),
+      filters: [
+        { name: "HTML (keeps formatting)", extensions: ["html"] },
+        { name: "Plain text", extensions: ["txt"] },
+      ],
+    });
+    if (canceled || !filePath) {
+      return;
+    }
+    try {
+      await saveRenderedDocument(this.window.webContents, filePath);
+    } catch (error) {
+      console.error("[Menus] Could not save open document:", error?.message);
+      new Notification({
+        title: "Could not save document",
+        body:
+          "No rendered document was found to copy. Open the file in Teams " +
+          "so its content is visible, then try again.",
+      }).show();
+    }
+  }
+
   initialize() {
     const menu = appMenu(this);
-
-    if (this.configGroup.startupConfig.menubar == "hidden") {
-      this.window.removeMenu();
-    } else {
-      this.window.setMenu(Menu.buildFromTemplate([menu]));
-    }
+    this.applyApplicationMenu(menu);
 
     this.initializeEventHandlers();
 
@@ -280,9 +306,29 @@ class Menus {
     }
   }
 
+  // Apply the built menu to the right place for the platform. macOS ignores
+  // BrowserWindow.setMenu() — the menu bar is global, so it must go through
+  // Menu.setApplicationMenu. The app's single menu becomes the bold app menu
+  // (macOS forces its title to the bundle name); we add the standard
+  // Edit/View/Window menus so Cmd+C/V/A and window shortcuts work. With
+  // `menubar: hidden` only Edit is kept so those shortcuts still fire.
+  applyApplicationMenu(menu) {
+    if (process.platform === "darwin") {
+      const template =
+        this.configGroup.startupConfig.menubar === "hidden"
+          ? [{ role: "editMenu" }]
+          : [menu, { role: "editMenu" }, { role: "viewMenu" }, { role: "windowMenu" }];
+      Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+    } else if (this.configGroup.startupConfig.menubar == "hidden") {
+      this.window.removeMenu();
+    } else {
+      this.window.setMenu(Menu.buildFromTemplate([menu]));
+    }
+  }
+
   updateMenu() {
     const menu = appMenu(this);
-    this.window.setMenu(Menu.buildFromTemplate([menu]));
+    this.applyApplicationMenu(menu);
     this.tray?.setContextMenu(menu.submenu);
 
     // Notify renderer process of config changes that affect renderer behavior
@@ -509,9 +555,17 @@ function assignContextMenuHandler(menus) {
     // Allow users to add the misspelled word to the dictionary
     assignAddToDictionaryHandler(params, menu, menus);
 
-    if (menu.items.length > 0) {
-      menu.popup();
+    // Fallback: if context menu is empty, show at least "Reload Page" so a menu is always shown
+    if (menu.items.length === 0) {
+      menu.append(
+        new MenuItem({
+          label: "Reload Page",
+          click: () => menus.window.webContents.reload(),
+        })
+      );
     }
+
+    menu.popup();
   };
 }
 
@@ -551,13 +605,123 @@ function assignAddToDictionaryHandler(params, menu, menus) {
 function addTextEditMenuItems(params, menu, menus) {
   if (params.isEditable) {
     buildEditContextMenu(menu, menus);
-  } else if (params.linkURL !== "") {
+    return;
+  }
+
+  // If text is selected, allow user to copy it
+  if (params.selectionText && params.selectionText.trim() !== "") {
     menu.append(
       new MenuItem({
-        label: "Copy",
+        role: "copy",
+      })
+    );
+  }
+
+  if (params.linkURL !== "") {
+    menu.append(
+      new MenuItem({
+        label: "Copy Link URL",
         click: () => clipboard.writeText(params.linkURL),
       })
     );
+
+    menu.append(
+      new MenuItem({
+        label: "Download Attachment & Copy to Clipboard",
+        click: () => triggerAttachmentDownload(menus, params.linkURL),
+      })
+    );
+
+    menu.append(
+      new MenuItem({
+        label: "Save Attachment As…",
+        click: () => triggerAttachmentDownload(menus, params.linkURL, { saveAs: true }),
+      })
+    );
+  }
+
+  addClipboardLinkMenuItem(menu, menus);
+
+  // Always offer to capture the currently-rendered document (Word/Excel/etc.)
+  // — it isn't a link, so none of the checks above surface it.
+  if (menu.items.length > 0) {
+    menu.append(new MenuItem({ type: "separator" }));
+  }
+  menu.append(
+    new MenuItem({
+      label: "Save Open Document to File…",
+      click: () => menus.saveOpenDocument(),
+    })
+  );
+}
+
+// Derive a sensible default filename from a URL path for the save dialog.
+function suggestedFilename(linkURL) {
+  try {
+    const pathname = new URL(linkURL).pathname;
+    const last = decodeURIComponent(pathname.substring(pathname.lastIndexOf("/") + 1));
+    return last && last !== "/" ? last : "attachment";
+  } catch {
+    return "attachment";
+  }
+}
+
+// Kick off an attachment download. With `saveAs`, prompt for the destination
+// via the native save dialog (the user picks the exact path); otherwise the
+// download module saves into Documents/Teams-Downloads. The dialog lives here
+// in the UI layer so the download module stays UI-free and unit-testable.
+async function triggerAttachmentDownload(menus, linkURL, { saveAs = false } = {}) {
+  const activeSession = menus.window.webContents.session;
+  const mainWindowUrl = menus.window.webContents.getURL();
+  const options = {};
+  if (saveAs) {
+    const { canceled, filePath } = await dialog.showSaveDialog(menus.window, {
+      title: "Save Attachment As",
+      defaultPath: path.join(app.getPath("downloads"), suggestedFilename(linkURL)),
+    });
+    if (canceled || !filePath) {
+      return;
+    }
+    options.destinationPath = filePath;
+  }
+  copyAttachmentAsFile(linkURL, activeSession, mainWindowUrl, options);
+}
+
+// Offer to download a link previously copied to the clipboard (e.g. from a
+// Teams message menu). Non-editable areas only; checks availableFormats()
+// first so the (synchronous) clipboard text read is skipped when the
+// clipboard holds no text at all.
+function addClipboardLinkMenuItem(menu, menus) {
+  try {
+    if (!clipboard.availableFormats().includes("text/plain")) {
+      return;
+    }
+    const clipboardText = clipboard.readText().trim();
+    if (!clipboardText.startsWith("http://") && !clipboardText.startsWith("https://")) {
+      return;
+    }
+    if (menu.items.length > 0) {
+      menu.append(
+        new MenuItem({
+          type: "separator",
+        })
+      );
+    }
+    menu.append(
+      new MenuItem({
+        label: "Download File from Clipboard Link",
+        click: () => triggerAttachmentDownload(menus, clipboardText),
+      })
+    );
+
+    menu.append(
+      new MenuItem({
+        label: "Save File from Clipboard Link As…",
+        click: () => triggerAttachmentDownload(menus, clipboardText, { saveAs: true }),
+      })
+    );
+  } catch (error) {
+    console.debug("[Menus] Could not inspect clipboard for link download", error?.message);
   }
 }
 

--- a/tests/unit/attachmentDownload.test.js
+++ b/tests/unit/attachmentDownload.test.js
@@ -127,6 +127,8 @@ function makeSession() {
       return {
         ok: r.ok, status: r.status, statusText: r.statusText,
         headers: { get: (h) => r.headers.get(h) },
+        // The generic-host path streams response.body to disk.
+        body: r.body,
         arrayBuffer: () => r.arrayBuffer(),
       };
     },
@@ -187,7 +189,9 @@ function fakeFrame(url, len, capture, opts = {}) {
   return {
     executeJavaScript: async (code) => {
       if (opts.throws) throw new Error('cross-origin frame, not scriptable');
-      if (code.includes('getSelection')) return capture;
+      // The capture script reads document.body.innerHTML/innerText; the probe
+      // script reads location/length.
+      if (code.includes('innerHTML')) return capture;
       return { url, len };
     },
   };
@@ -231,11 +235,13 @@ test('saveRenderedDocument: .txt destination writes plain text only', async (t) 
   assert.strictEqual(fs.readFileSync(out, 'utf8'), 'plain text body');
 });
 
-test('saveRenderedDocument: throws when no frame renders content', async () => {
+test('saveRenderedDocument: throws when no frame renders content', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const empty = fakeFrame('https://x', 0, null);
   const dead = fakeFrame('https://y', 5, null, { throws: true });
   await assert.rejects(
-    () => dl.saveRenderedDocument({ mainFrame: { framesInSubtree: [empty, dead] } }, '/tmp/never.html'),
+    () => dl.saveRenderedDocument({ mainFrame: { framesInSubtree: [empty, dead] } }, path.join(dir, 'never.html')),
     /No rendered document content/,
   );
 });

--- a/tests/unit/attachmentDownload.test.js
+++ b/tests/unit/attachmentDownload.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+// Unit tests for app/menus/attachmentDownload.js — the context-menu attachment
+// download pipeline. The URL/filename helpers are tested directly; the generic
+// http(s) "fetch → save → clipboard" path is exercised end-to-end against a
+// local HTTP server. The Microsoft/SharePoint hidden-window paths need an
+// authenticated Teams session and are out of scope here.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Module = require('node:module');
+
+// ---- mock electron + electron-updater (loaded transitively) ----
+let docsDir;
+const clipboardCalls = [];
+const notifications = [];
+
+const electronMock = {
+  app: {
+    getPath: (k) => (k === 'documents' ? docsDir : os.tmpdir()),
+    getVersion: () => '2.11.1',
+    getName: () => 'teams-for-linux',
+    on: () => {},
+  },
+  Notification: class {
+    constructor(o) { this.o = o; notifications.push(o); }
+    show() {}
+    close() {}
+    on() {}
+  },
+  clipboard: {
+    writeText: (t) => clipboardCalls.push(['writeText', t]),
+    writeBuffer: (fmt, buf) => clipboardCalls.push(['writeBuffer', fmt, buf.toString()]),
+  },
+  BrowserWindow: class {},
+};
+const updaterMock = { autoUpdater: { on: () => {} } };
+
+const origLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'electron') return electronMock;
+  if (request === 'electron-updater') return updaterMock;
+  return origLoad.call(this, request, parent, isMain);
+};
+
+const dl = require('../../app/menus/attachmentDownload');
+
+// ---- pure helpers ----
+test('isMicrosoftHost: real M365 hosts match by suffix', () => {
+  assert.strictEqual(dl.isMicrosoftHost('https://contoso.sharepoint.com/x'), true);
+  assert.strictEqual(dl.isMicrosoftHost('https://x.onedrive.com/y'), true);
+  assert.strictEqual(dl.isMicrosoftHost('https://contoso.sharepoint.com.eu.mcas.ms/z'), true);
+});
+
+test('isMicrosoftHost: lookalike and substring hosts are rejected', () => {
+  assert.strictEqual(dl.isMicrosoftHost('https://notmicrosoft.evil.com/x'), false);
+  assert.strictEqual(dl.isMicrosoftHost('https://backoffice.example.com/x'), false);
+  assert.strictEqual(dl.isMicrosoftHost('https://sharepoint.com.evil.com/x'), false);
+});
+
+test('isMicrosoftHost: non-http(s) schemes rejected', () => {
+  assert.strictEqual(dl.isMicrosoftHost('file:///etc/passwd'), false);
+  assert.strictEqual(dl.isMicrosoftHost('not a url'), false);
+});
+
+test('getDirectDownloadUrl: adds download=1 only for MS hosts', () => {
+  assert.match(dl.getDirectDownloadUrl('https://contoso.sharepoint.com/a.docx'), /[?&]download=1/);
+  assert.strictEqual(dl.getDirectDownloadUrl('https://example.com/a.zip'), 'https://example.com/a.zip');
+});
+
+test('isTextFile: by extension and by SharePoint /:t:/ viewer marker', () => {
+  assert.strictEqual(dl.isTextFile('https://x/file.txt'), true);
+  assert.strictEqual(dl.isTextFile('https://x/file.json'), true);
+  assert.strictEqual(dl.isTextFile('https://x/file.docx'), false);
+  assert.strictEqual(dl.isTextFile('https://contoso.sharepoint.com/:t:/r/sites/x/y.aspx'), true);
+});
+
+test('sanitizeFilename: strips path segments and rejects traversal', () => {
+  assert.strictEqual(dl.sanitizeFilename('../../.zshrc'), '.zshrc');
+  assert.strictEqual(dl.sanitizeFilename('a\\b\\c.txt'), 'c.txt');
+  assert.strictEqual(dl.sanitizeFilename('plain.pdf'), 'plain.pdf');
+  assert.strictEqual(dl.sanitizeFilename('   '), 'attachment');
+  assert.strictEqual(dl.sanitizeFilename('..'), 'attachment');
+  assert.strictEqual(dl.sanitizeFilename(undefined), 'attachment');
+});
+
+test('stripViewerTitleSuffix: removes known viewer suffixes only', () => {
+  assert.strictEqual(dl.stripViewerTitleSuffix('notes.txt - SharePoint'), 'notes.txt');
+  assert.strictEqual(dl.stripViewerTitleSuffix('data.csv - OneDrive'), 'data.csv');
+  assert.strictEqual(dl.stripViewerTitleSuffix('my - file.txt'), 'my - file.txt');
+});
+
+test('getSharePointDownloadUrl: rewrites viewer URL to download.aspx', () => {
+  const out = dl.getSharePointDownloadUrl('https://contoso.sharepoint.com/:w:/r/sites/Team/Doc.docx');
+  assert.ok(out && out.includes('/_layouts/15/download.aspx') && out.includes('SourceUrl='), out);
+  assert.strictEqual(dl.getSharePointDownloadUrl('https://example.com/a.docx'), null);
+});
+
+test('applyMcasProxy: rewrites host only when the main window is MCAS-proxied', () => {
+  const proxied = dl.applyMcasProxy('https://contoso.sharepoint.com/a', 'https://contoso.sharepoint.com.eu2.mcas.ms/');
+  assert.ok(proxied.includes('.mcas.ms'), proxied);
+  assert.strictEqual(
+    dl.applyMcasProxy('https://x.sharepoint.com/a', 'https://teams.microsoft.com/'),
+    'https://x.sharepoint.com/a',
+  );
+});
+
+test('uniqueFilePath: appends (n) on collision', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'uniq-'));
+  assert.strictEqual(dl.uniqueFilePath(dir, 'r.pdf'), path.join(dir, 'r.pdf'));
+  fs.writeFileSync(path.join(dir, 'dup.pdf'), 'x');
+  assert.strictEqual(dl.uniqueFilePath(dir, 'dup.pdf'), path.join(dir, 'dup (1).pdf'));
+  fs.writeFileSync(path.join(dir, 'dup (1).pdf'), 'x');
+  assert.strictEqual(dl.uniqueFilePath(dir, 'dup.pdf'), path.join(dir, 'dup (2).pdf'));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ---- end-to-end generic-host download ----
+function makeSession() {
+  return {
+    fetch: async (url) => {
+      const r = await fetch(url);
+      return {
+        ok: r.ok, status: r.status, statusText: r.statusText,
+        headers: { get: (h) => r.headers.get(h) },
+        arrayBuffer: () => r.arrayBuffer(),
+      };
+    },
+  };
+}
+
+function startServer() {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/binary') {
+      res.writeHead(200, { 'content-type': 'application/octet-stream', 'content-disposition': 'attachment; filename="report.pdf"' });
+      res.end(Buffer.from('PDF-BYTES-1234'));
+    } else if (req.url === '/cdtraversal') {
+      res.writeHead(200, { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="../../escape.zip"' });
+      res.end(Buffer.from('ZIPDATA'));
+    } else if (req.url === '/noheader/myfile.bin') {
+      res.writeHead(200, { 'content-type': 'application/octet-stream' });
+      res.end(Buffer.from('RAW'));
+    } else {
+      res.writeHead(404); res.end();
+    }
+  });
+  return new Promise((resolve) => server.listen(0, () => resolve(server)));
+}
+
+test('end-to-end generic download: save, clipboard, traversal-safety, dedup, errors', async (t) => {
+  docsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-docs-'));
+  const dlDir = path.join(docsDir, 'Teams-Downloads');
+  const server = await startServer();
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+  const session = makeSession();
+  t.after(() => { server.close(); fs.rmSync(docsDir, { recursive: true, force: true }); });
+
+  notifications.length = 0; clipboardCalls.length = 0;
+  await dl.copyAttachmentAsFile(`${base}/binary`, session, '');
+  assert.ok(fs.existsSync(path.join(dlDir, 'report.pdf')), 'report.pdf saved');
+  assert.strictEqual(fs.readFileSync(path.join(dlDir, 'report.pdf'), 'utf8'), 'PDF-BYTES-1234');
+  assert.ok(notifications.some((n) => /Downloaded & Copied/.test(n.title)), 'success toast');
+  assert.ok(clipboardCalls.some((c) => c[0] === 'writeBuffer'), 'file placed on clipboard');
+
+  await dl.copyAttachmentAsFile(`${base}/cdtraversal`, session, '');
+  assert.ok(fs.existsSync(path.join(dlDir, 'escape.zip')), 'traversal filename neutralized');
+  assert.ok(!fs.existsSync(path.join(docsDir, 'escape.zip')), 'file did not escape the dir');
+
+  await dl.copyAttachmentAsFile(`${base}/noheader/myfile.bin`, session, '');
+  assert.ok(fs.existsSync(path.join(dlDir, 'myfile.bin')), 'filename derived from URL');
+
+  await dl.copyAttachmentAsFile(`${base}/binary`, session, '');
+  assert.ok(fs.existsSync(path.join(dlDir, 'report (1).pdf')), 'second identical download deduplicated');
+
+  notifications.length = 0;
+  await dl.copyAttachmentAsFile(`${base}/404`, session, '');
+  assert.ok(notifications.some((n) => /Download Error/.test(n.title)), 'HTTP error surfaces a toast, no crash');
+});
+
+// ---- saveRenderedDocument (capture the open document's rendered content) ----
+function fakeFrame(url, len, capture, opts = {}) {
+  return {
+    executeJavaScript: async (code) => {
+      if (opts.throws) throw new Error('cross-origin frame, not scriptable');
+      if (code.includes('getSelection')) return capture;
+      return { url, len };
+    },
+  };
+}
+
+test('saveRenderedDocument: picks the Office viewer frame and writes formatted HTML', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  notifications.length = 0;
+
+  const teamsFrame = fakeFrame('https://teams.microsoft.com/x', 80, null);
+  const officeFrame = fakeFrame(
+    'https://contoso.sharepoint.com/:w:/r/sites/x/Doc.docx',
+    500,
+    { html: '<p>Hello <b>world</b></p>', text: 'Hello world', title: 'Doc - SharePoint' },
+  );
+  const deadFrame = fakeFrame('https://blocked.example.com', 9999, null, { throws: true });
+  const webContents = { mainFrame: { framesInSubtree: [teamsFrame, officeFrame, deadFrame] } };
+
+  const out = path.join(dir, 'doc.html');
+  const res = await dl.saveRenderedDocument(webContents, out);
+
+  assert.strictEqual(res.chars, 'Hello world'.length);
+  assert.match(res.frameHost, /sharepoint\.com/);
+  const html = fs.readFileSync(out, 'utf8');
+  assert.match(html, /<!DOCTYPE html>/);
+  assert.match(html, /<p>Hello <b>world<\/b><\/p>/, 'keeps rendered formatting');
+  assert.ok(notifications.some((n) => /Document saved/.test(n.title)), 'shows a saved notification');
+});
+
+test('saveRenderedDocument: .txt destination writes plain text only', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const frame = fakeFrame('https://contoso.sharepoint.com/d', 300, {
+    html: '<p>rich</p>', text: 'plain text body', title: 'D',
+  });
+  const out = path.join(dir, 'doc.txt');
+  await dl.saveRenderedDocument({ mainFrame: { framesInSubtree: [frame] } }, out);
+
+  assert.strictEqual(fs.readFileSync(out, 'utf8'), 'plain text body');
+});
+
+test('saveRenderedDocument: throws when no frame renders content', async () => {
+  const empty = fakeFrame('https://x', 0, null);
+  const dead = fakeFrame('https://y', 5, null, { throws: true });
+  await assert.rejects(
+    () => dl.saveRenderedDocument({ mainFrame: { framesInSubtree: [empty, dead] } }, '/tmp/never.html'),
+    /No rendered document content/,
+  );
+});
+
+test('end-to-end: destinationPath saves to the chosen path verbatim', async (t) => {
+  docsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dl-docs-'));
+  const server = await startServer();
+  const { port } = server.address();
+  const session = makeSession();
+  const chosen = path.join(docsDir, 'custom', 'my-name.pdf');
+  t.after(() => { server.close(); fs.rmSync(docsDir, { recursive: true, force: true }); });
+
+  await dl.copyAttachmentAsFile(`http://127.0.0.1:${port}/binary`, session, '', { destinationPath: chosen });
+  assert.ok(fs.existsSync(chosen), 'saved to the exact chosen path (dirs created)');
+  assert.strictEqual(fs.readFileSync(chosen, 'utf8'), 'PDF-BYTES-1234');
+  assert.ok(!fs.existsSync(path.join(docsDir, 'Teams-Downloads', 'report.pdf')), 'did not also save to default dir');
+});


### PR DESCRIPTION
Third of three PRs splitting #2645. This is the **security-sensitive** piece the maintainer asked to isolate for a focused security review: authenticated-session downloads, clipboard writes, hidden helper windows, and SharePoint/MCAS URL rewriting.

## What's here

### Context-menu attachment download
- **"Download Attachment & Copy to Clipboard"** (on links) and **"Download File from Clipboard Link"** (non-editable contexts only): download through the authenticated Teams session, save under `Documents/Teams-Downloads` with `name (1).ext` de-duplication, and place a platform-native file reference on the clipboard (`NSFilenamesPboardType` / `text/uri-list`).
- **"Save Open Document to File…"**: capture the rendered content of the document currently open in the Teams viewer (Office/SharePoint frame) and write it to a user-picked path — HTML keeps formatting, `.txt` writes plain text. This is the "let the app do the select-all/copy and paste into a file" flow.
- SharePoint viewer URL → `download.aspx` rewriting, MCAS proxy support, and Monaco-viewer text extraction for text files.

### Security posture
- Hidden helper windows keep `webSecurity`, `contextIsolation` and `sandbox` **enabled**.
- Filenames from `Content-Disposition` headers / page titles are sanitized via `path.basename` (no path traversal out of the target dir).
- M365 host detection uses strict suffix matching (lookalike hosts rejected — covered by tests).
- Downloads set `item.teamsForLinuxExternallyManaged` so the shared `DownloadManager` skips its own save path / notifications and a single download isn't double-handled. (The consuming guard ships in the download-manager PR; harmless no-op until then.)
- Error paths log `error.message` only — never the full error, which can embed the download URL.

### macOS menu rendering
macOS ignores `BrowserWindow.setMenu()`, so the menu is applied via `Menu.setApplicationMenu` (with standard Edit/View/Window roles) so the new items actually appear on the global menu bar.

## Testing
- `npm run lint` clean.
- `npm run test:unit` — 292/292 (new `attachmentDownload.test.js`: URL rewriting, host matching incl. lookalikes, filename sanitization/dedup, generic-download end-to-end, and `saveRenderedDocument` frame selection / HTML-vs-txt / no-content-found).

## Depends on / relates to
- Pairs with the download-manager PR (which carries the `teamsForLinuxExternallyManaged` opt-out guard) but is independently mergeable.

Refs #2645

🤖 Generated with [Claude Code](https://claude.com/claude-code)