### PR TITLE
fix: add request timeouts for improved network robustness

### DIFF
--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -229,15 +229,30 @@ function sleep(timeout) {
 
 function isOnlineHttps(testUrl) {
   return new Promise((resolve) => {
+    let resolved = false;
     const req = net.request({
       url: testUrl,
       method: "HEAD",
     });
+    // Timeout to prevent hanging connections
+    req.setTimeout(5000, () => {
+      if (!resolved) {
+        resolved = true;
+        req.abort();
+        resolve(false);
+      }
+    });
     req.on("response", () => {
-      resolve(true);
+      if (!resolved) {
+        resolved = true;
+        resolve(true);
+      }
     });
     req.on("error", () => {
-      resolve(false);
+      if (!resolved) {
+        resolved = true;
+        resolve(false);
+      }
     });
     req.end();
   });

--- a/app/graphApi/index.js
+++ b/app/graphApi/index.js
@@ -103,15 +103,31 @@ class GraphApiClient {
 
       logger.debug('[GRAPH_API] Making request', { method, endpoint: url });
 
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Authorization': `Bearer ${tokenResult.token}`,
-          'Content-Type': 'application/json',
-          ...options.headers
-        },
-        ...(options.body && { body: JSON.stringify(options.body) })
-      });
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30000);
+
+      let response;
+      try {
+        response = await fetch(url, {
+          method,
+          headers: {
+            'Authorization': `Bearer ${tokenResult.token}`,
+            'Content-Type': 'application/json',
+            ...options.headers
+          },
+          ...(options.body && { body: JSON.stringify(options.body) }),
+          signal: controller.signal
+        });
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          logger.error('[GRAPH_API] Request timed out', { endpoint: url });
+          return { success: false, error: 'Request timed out' };
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+
       const responseText = await response.text();
 
       let data = null;


### PR DESCRIPTION
This PR improves the robustness of network operations in the Teams for Linux application by introducing request timeouts. Specifically, it adds a 5-second timeout to the network connectivity check in the ConnectionManager and a 30-second timeout to Graph API requests in the GraphApiClient. These changes prevent operations from hanging indefinitely during network anomalies, improving overall application stability.