### PR TITLE
feat(notifications): add electron.clickAction config for window restore

### DIFF
--- a/app/config/options.js
+++ b/app/config/options.js
@@ -376,9 +376,12 @@ module.exports = {
       notifications: {
         default: {
           timeoutType: "default",
+          electron: {
+            clickAction: "show",
+          },
         },
         describe:
-          "Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon.",
+          "Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon. electron.clickAction: what clicking a notification does to the main window when notificationMethod is `electron`. Choices: `show` (reveal the window, default and current behaviour), `restore` (also un-minimise and focus, which helps on GNOME where a plain show does not raise the window) or `none` (do nothing).",
         type: "object",
         fields: {
           "timeoutType": {
@@ -386,6 +389,12 @@ module.exports = {
             describe:
               "How long notifications stay in the system notification center (Linux/Windows only); may not be honoured by every notification daemon.",
             choices: ["default", "never"],
+          },
+          "electron.clickAction": {
+            type: "string",
+            describe:
+              "What clicking an Electron notification does to the main window (notificationMethod `electron` only): `show` reveals the window (default), `restore` also un-minimises and focuses it (helps on GNOME), `none` does nothing.",
+            choices: ["show", "restore", "none"],
           },
         },
         applyMode: "restart",

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -811,6 +811,11 @@ exports.show = function () {
   window.show();
 };
 
+// Restore if minimised, show if hidden to tray, then focus. Used by the
+// notification click handler when notifications.electron.clickAction is
+// "restore" (issue #2647).
+exports.restoreWindow = restoreWindow;
+
 exports.getWindow = function () {
   return window;
 };

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -85,8 +85,18 @@ class NotificationService {
       const notification = new Notification(notificationConfig);
 
       notification.on("click", () => {
-        console.debug("[NOTIFICATIONS] Notification clicked, showing main window");
-        this.#mainWindow.show();
+        // notifications.electron.clickAction controls window behaviour on click
+        // (issue #2647). Defaults to "show" so existing behaviour is unchanged.
+        const clickAction = this.#config.notifications?.electron?.clickAction ?? "show";
+        console.debug(`[NOTIFICATIONS] Notification clicked, clickAction=${clickAction}`);
+        if (clickAction === "none") return;
+        if (clickAction === "restore") {
+          // restore if minimised, show if in the tray, then focus. Whether the
+          // focus is honoured is window-manager dependent on Linux.
+          this.#mainWindow.restoreWindow();
+        } else {
+          this.#mainWindow.show();
+        }
       });
 
       notification.on("close", () => {

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -43,7 +43,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 | `disableNotificationSound` | `boolean` | `false` | Disable chat/meeting start notification sound | `live` |
 | `disableNotificationSoundIfNotAvailable` | `boolean` | `false` | Disables notification sound unless status is Available (e.g. while in a call, busy, etc.) | `live` |
 | `disableNotificationWindowFlash` | `boolean` | `false` | A flag indicates whether to disable window flashing when there is a notification | `live` |
-| `notifications` | `object` | `{"timeoutType":"default"}` | Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon. | `restart` |
+| `notifications` | `object` | `{"timeoutType":"default","electron":{"clickAction":"show"}}` | Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon. electron.clickAction: what clicking a notification does to the main window when notificationMethod is `electron`. Choices: `show` (reveal the window, default and current behaviour), `restore` (also un-minimise and focus, which helps on GNOME where a plain show does not raise the window) or `none` (do nothing). | `restart` |
 | `disableBadgeCount` | `boolean` | `false` | A flag indicates whether to disable the badge counter on the taskbar/dock icon | `live` |
 | `disableGlobalShortcuts` | `array` | `[]` | Array of global shortcuts to disable while the app is in focus. See https://www.electronjs.org/docs/latest/api/accelerator for available accelerators to use | `restart` |
 | `globalShortcuts` | `array` | `[]` | Global keyboard shortcuts that work system-wide. Disabled by default (opt-in). See configuration docs for details and limitations | `restart` |
@@ -135,6 +135,7 @@ Object options group several related settings. The tables below list each nested
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `notifications.timeoutType` | `string` | `"default"` | How long notifications stay in the system notification center (Linux/Windows only); may not be honoured by every notification daemon. |
+| `notifications.electron.clickAction` | `string` | `"show"` | What clicking an Electron notification does to the main window (notificationMethod `electron` only): `show` reveals the window (default), `restore` also un-minimises and focuses it (helps on GNOME), `none` does nothing. |
 
 ### logConfig
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -139,6 +139,7 @@ Each option's **Apply** mode (whether a change takes effect immediately or after
 | `customNotification` | `object` | `{ toastDuration: 5000 }` | Configuration for custom in-app toast notifications (used when `notificationMethod` is `custom`) |
 | `defaultNotificationUrgency` | `string` | `"normal"` | Default urgency for new notifications. Choices: `low`, `normal`, `critical` |
 | `notifications.timeoutType` | `string` | `"default"` | How long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification `timeoutType`. May not be honoured by every notification daemon. |
+| `notifications.electron.clickAction` | `string` | `"show"` | What clicking a notification does to the main window (`notificationMethod: "electron"` only). Choices: `show` (reveal the window, current behaviour), `restore` (also un-minimise and focus, which helps on GNOME where a plain show does not raise the window) or `none` (do nothing). On Linux whether focus is honoured depends on the window manager. |
 
 ### Incoming Call Handling
 

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -409,9 +409,12 @@
       "name": "notifications",
       "type": "object",
       "default": {
-        "timeoutType": "default"
+        "timeoutType": "default",
+        "electron": {
+          "clickAction": "show"
+        }
       },
-      "description": "Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon.",
+      "description": "Notification behaviour. timeoutType: how long notifications stay in the system notification center (Linux/Windows only). Choices: `default` (auto-clear per system policy) or `never` (persist until the user dismisses, useful on GNOME and other desktops that auto-remove notifications). Mirrors Electron's Notification timeoutType. May not be honoured by every notification daemon. electron.clickAction: what clicking a notification does to the main window when notificationMethod is `electron`. Choices: `show` (reveal the window, default and current behaviour), `restore` (also un-minimise and focus, which helps on GNOME where a plain show does not raise the window) or `none` (do nothing).",
       "applyMode": "restart",
       "fields": [
         {
@@ -422,6 +425,17 @@
           "choices": [
             "default",
             "never"
+          ]
+        },
+        {
+          "path": "electron.clickAction",
+          "type": "string",
+          "default": "show",
+          "description": "What clicking an Electron notification does to the main window (notificationMethod `electron` only): `show` reveals the window (default), `restore` also un-minimises and focuses it (helps on GNOME), `none` does nothing.",
+          "choices": [
+            "show",
+            "restore",
+            "none"
           ]
         }
       ]


### PR DESCRIPTION
## What

Makes the Electron notification click behaviour configurable (issue #2647). Today, clicking an Electron notification calls `mainWindow.show()`, which on GNOME reveals but does not always raise and focus the window. This adds `notifications.electron.clickAction` (default `show`, so existing behaviour is unchanged):

- `show` — reveal the window (current behaviour)
- `restore` — also un-minimise and focus, via the existing `restoreWindow()`; the reporter confirmed this fixes their GNOME (X11) case
- `none` — do nothing

It lives under `notifications.electron.*` because the click handler only exists on the `electron` notification method; `web` hands the click to Teams' own page code and `custom` has its own toast.

## How

- `app/config/options.js`: new `electron.clickAction` field on the existing `notifications` object (enum, default `show`).
- `app/notifications/service.js`: the click handler reads the option and dispatches to `show()` / `restoreWindow()` / no-op.
- `app/mainAppWindow/index.js`: exports the existing `restoreWindow()` (restore-if-minimised + show-if-hidden + focus) so the service can call it.

## Notes

Whether the focus is honoured is window-manager dependent on Linux (a known limitation), which is why `restore` is opt-in rather than the default. Jump-to-conversation is not reachable from the Electron notification path (it is Teams web-app state), and the reporter confirmed window restore alone is acceptable.

## Testing

`npm run lint`, `npm run test:unit` (277 pass), `npm run test:e2e` (14 pass). Default is `show`, so behaviour is unchanged out of the box.

closes #2647

🤖 Generated with [Claude Code](https://claude.com/claude-code)
