### PR TITLE
fix(navigation): keep back/forward working after Teams top-bar restructure

### DIFF
--- a/app/browser/tools/navigationButtons.js
+++ b/app/browser/tools/navigationButtons.js
@@ -8,35 +8,68 @@ class NavigationButtons {
   #initialized = false;
   #backButton = null;
   #forwardButton = null;
+  #observer = null;
+  #checkScheduled = false;
 
-  init(config) {
+  init() {
     if (this.#initialized) {
       return;
     }
 
-    // Note: config parameter kept for API consistency with other modules
-    // but not currently used by navigation buttons functionality
     this.#initialized = true;
-
-    // Inject buttons with retry logic for Teams UI elements
-    // Note: DOM is already ready (preload.js waits for DOMContentLoaded)
-    // but Teams-specific elements may not be rendered yet
-    this.#waitForTeamsAndInject();
+    this.#startInjecting();
   }
 
-  #waitForTeamsAndInject() {
-    const maxRetries = 3;
-    let retries = 0;
+  // Teams renders its top bar after load and Microsoft restructures it without
+  // notice, which previously left the buttons missing once a fixed 3-retry
+  // budget ran out (#2671). Inject immediately, then keep a debounced
+  // MutationObserver running so the buttons (re)appear whenever the anchor
+  // mounts or a Teams re-render removes our container.
+  #startInjecting() {
+    this.injectNavigationButtons();
 
-    const tryInject = () => {
-      if (this.injectNavigationButtons() || retries >= maxRetries) {
-        return;
+    const target =
+      globalThis.document.body || globalThis.document.documentElement;
+    if (!target || typeof globalThis.MutationObserver === "undefined") {
+      return;
+    }
+
+    this.#observer = new globalThis.MutationObserver(() =>
+      this.#scheduleInjectCheck(),
+    );
+    this.#observer.observe(target, { childList: true, subtree: true });
+  }
+
+  // Coalesce Teams' frequent DOM mutations into at most one cheap check per
+  // interval; only re-inject when our container is actually absent.
+  #scheduleInjectCheck() {
+    if (this.#checkScheduled) {
+      return;
+    }
+    this.#checkScheduled = true;
+    setTimeout(() => {
+      this.#checkScheduled = false;
+      if (!globalThis.document.getElementById("tfl-nav-buttons-container")) {
+        this.injectNavigationButtons();
       }
-      retries++;
-      setTimeout(tryInject, 1000 * retries);
-    };
+    }, 250);
+  }
 
-    tryInject();
+  // The Teams search region is the injection anchor; buttons go immediately
+  // before it. Try the known data-tid first, then fall back to the search
+  // landmark so a top-bar restructure does not drop the buttons entirely.
+  #findInjectionAnchor() {
+    const selectors = [
+      '[data-tid="search-f6-navigation-region"]',
+      '[role="search"]',
+    ];
+    for (const selector of selectors) {
+      const el = globalThis.document.querySelector(selector);
+      if (el?.parentNode) {
+        return el;
+      }
+    }
+    return null;
   }
 
   createNavigationButton(id, label, svgPath) {
@@ -76,11 +109,12 @@ class NavigationButtons {
       return false;
     }
 
-    // Find the search navigation region - we'll insert buttons BEFORE it (as a sibling)
-    const searchRegion = document.querySelector('[data-tid="search-f6-navigation-region"]');
+    // Find the injection anchor (the Teams search region); buttons go
+    // immediately before it as a sibling.
+    const searchRegion = this.#findInjectionAnchor();
 
     if (!searchRegion) {
-      console.debug('Search navigation region not found, buttons not injected yet');
+      console.debug('Search region anchor not found, buttons not injected yet');
       return false;
     }
 

--- a/app/browser/tools/navigationButtons.js
+++ b/app/browser/tools/navigationButtons.js
@@ -22,26 +22,30 @@ class NavigationButtons {
 
   // Teams renders its top bar after load and Microsoft restructures it without
   // notice, which previously left the buttons missing once a fixed 3-retry
-  // budget ran out (#2671). Inject immediately, then keep a debounced
-  // MutationObserver running so the buttons (re)appear whenever the anchor
-  // mounts or a Teams re-render removes our container.
+  // budget ran out (#2671). Inject immediately, then keep a MutationObserver
+  // running so the buttons (re)appear whenever the anchor mounts or a Teams
+  // re-render removes our container.
   #startInjecting() {
     this.injectNavigationButtons();
 
-    const target =
-      globalThis.document.body || globalThis.document.documentElement;
-    if (!target || typeof globalThis.MutationObserver === "undefined") {
+    const target = document.body || document.documentElement;
+    if (!target || typeof MutationObserver === "undefined") {
       return;
     }
 
-    this.#observer = new globalThis.MutationObserver(() =>
-      this.#scheduleInjectCheck(),
-    );
+    this.#observer = new MutationObserver(() => {
+      // Only react when our container is actually missing, so a present,
+      // healthy injection does not arm a re-check timer on every Teams
+      // mutation for the lifetime of the session.
+      if (!document.getElementById("tfl-nav-buttons-container")) {
+        this.#scheduleInjectCheck();
+      }
+    });
     this.#observer.observe(target, { childList: true, subtree: true });
   }
 
-  // Coalesce Teams' frequent DOM mutations into at most one cheap check per
-  // interval; only re-inject when our container is actually absent.
+  // Coalesce a burst of mutations into a single debounced re-injection; the
+  // observer only calls this while our container is absent.
   #scheduleInjectCheck() {
     if (this.#checkScheduled) {
       return;
@@ -49,7 +53,7 @@ class NavigationButtons {
     this.#checkScheduled = true;
     setTimeout(() => {
       this.#checkScheduled = false;
-      if (!globalThis.document.getElementById("tfl-nav-buttons-container")) {
+      if (!document.getElementById("tfl-nav-buttons-container")) {
         this.injectNavigationButtons();
       }
     }, 250);
@@ -64,7 +68,7 @@ class NavigationButtons {
       '[role="search"]',
     ];
     for (const selector of selectors) {
-      const el = globalThis.document.querySelector(selector);
+      const el = document.querySelector(selector);
       if (el?.parentNode) {
         return el;
       }

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -1333,8 +1333,33 @@ function getWebRequestFilterFromURL() {
   return filter;
 }
 
-function onBeforeInput(_event, input) {
+function onBeforeInput(event, input) {
   isControlPressed = input.control;
+
+  // Alt+Left / Alt+Right drive history navigation independently of the Teams
+  // DOM. The on-screen back/forward controls are injected into Teams' own top
+  // bar (navigationButtons.js) and break whenever Microsoft restructures it
+  // (#2671); these accelerators keep back/forward working regardless of layout.
+  if (
+    input.type !== "keyDown" ||
+    !input.alt ||
+    input.control ||
+    input.meta ||
+    input.shift
+  ) {
+    return;
+  }
+  const history = window?.webContents?.navigationHistory;
+  if (!history) {
+    return;
+  }
+  if (input.key === "ArrowLeft" && history.canGoBack()) {
+    event.preventDefault();
+    history.goBack();
+  } else if (input.key === "ArrowRight" && history.canGoForward()) {
+    event.preventDefault();
+    history.goForward();
+  }
 }
 
 function secureOpenLink(details) {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -1336,27 +1336,36 @@ function getWebRequestFilterFromURL() {
 function onBeforeInput(event, input) {
   isControlPressed = input.control;
 
-  // Alt+Left / Alt+Right drive history navigation independently of the Teams
-  // DOM. The on-screen back/forward controls are injected into Teams' own top
-  // bar (navigationButtons.js) and break whenever Microsoft restructures it
-  // (#2671); these accelerators keep back/forward working regardless of layout.
-  if (
-    input.type !== "keyDown" ||
-    !input.alt ||
-    input.control ||
-    input.meta ||
-    input.shift
-  ) {
+  if (input.type !== "keyDown") {
     return;
   }
   const history = window?.webContents?.navigationHistory;
   if (!history) {
     return;
   }
-  if (input.key === "ArrowLeft" && history.canGoBack()) {
+
+  // Keyboard history navigation, independent of the Teams DOM. The injected
+  // on-screen back/forward controls (navigationButtons.js) break whenever
+  // Microsoft restructures the top bar (#2671); these accelerators are the
+  // layout-independent fallback. Keys are platform-specific: on macOS,
+  // Option(Alt)+Left/Right is the system word-navigation shortcut inside text
+  // fields, so stealing it would break message editing — macOS uses the
+  // standard Cmd+[ / Cmd+] instead, while other platforms use the
+  // browser-standard Alt+Left / Alt+Right.
+  const isMac = process.platform === "darwin";
+  const modifierActive = isMac
+    ? input.meta && !input.control && !input.alt && !input.shift
+    : input.alt && !input.control && !input.meta && !input.shift;
+  if (!modifierActive) {
+    return;
+  }
+
+  const backKey = isMac ? "[" : "ArrowLeft";
+  const forwardKey = isMac ? "]" : "ArrowRight";
+  if (input.key === backKey && history.canGoBack()) {
     event.preventDefault();
     history.goBack();
-  } else if (input.key === "ArrowRight" && history.canGoForward()) {
+  } else if (input.key === forwardKey && history.canGoForward()) {
     event.preventDefault();
     history.goForward();
   }


### PR DESCRIPTION
## Problem

Microsoft restructured the Teams top bar (new panel-toggle button, controls moved) and the injected back/forward buttons disappeared. They were also the *only* back/forward path — no keyboard, mouse, or menu fallback existed — so navigation was completely lost (#2671).

`navigationButtons.js` anchored injection to a single selector (`[data-tid="search-f6-navigation-region"]`) and gave up after 3 retries (~6s), so a renamed or late-mounting anchor left the buttons missing for good.

## Fix

Two independent changes:

1. **Self-healing injection** (`app/browser/tools/navigationButtons.js`): replace the fixed 3-retry budget with a debounced `MutationObserver` that (re)injects whenever the anchor mounts or a Teams re-render removes our container, and broaden the anchor lookup with a `[role="search"]` fallback.
2. **DOM-independent accelerators** (`app/mainAppWindow/index.js`, `onBeforeInput`): wire Alt+Left / Alt+Right to `webContents.navigationHistory` back/forward, so core navigation keeps working regardless of Teams' layout — the robust safety net if the injected buttons ever break again.

## Testing

- `npm run lint` clean, `npm run test:unit` 311/311.
- The injection and accelerator paths are DOM/Electron-coupled with no unit harness, so they need manual verification on a live session: confirm the back/forward buttons reappear in the current Teams top bar, and that Alt+Left / Alt+Right navigate history.

## Caveat

I could not confirm the *new* top-bar `data-tid` from here (needs the live Teams DOM). If Microsoft renamed the search region outright, the buttons rely on the `[role="search"]` fallback until the selector is updated; the Alt+Left / Alt+Right accelerators work regardless.

closes #2671
