### PR TITLE
fix(theme): stop setting followOsTheme to prevent GraphQL rejection

### DIFF
--- a/app/browser/tools/theme.js
+++ b/app/browser/tools/theme.js
@@ -5,13 +5,12 @@ class ThemeManager {
     this.ipcRenderer = ipcRenderer;
     this.config = config;
 
-    const clientPreferences = ReactHandler.getTeams2ClientPreferences();
-    if (clientPreferences) {
-      console.debug("Using react to set the follow system theme");
-      ReactHandler.getTeams2ClientPreferences().theme.followOsTheme =
-        config.followSystemTheme;
-    }
-
+    // Deliberately do NOT set Teams' own `clientPreferences.theme.followOsTheme`.
+    // teams-for-linux is not a native Teams host, so enabling it makes the Teams
+    // SPA query a host-provided `HostTheme!` value that nothing answers; that
+    // variable resolves to `undefined` and Teams throws an unhandled GraphQL
+    // rejection (#2662). We follow the OS theme ourselves below by driving
+    // `userTheme` from the main-process `system-theme-changed` events instead.
     if (config.followSystemTheme) {
       this.ipcRenderer.on("system-theme-changed", this.applyTheme);
     }


### PR DESCRIPTION
## Problem

Since #2566 flipped `followSystemTheme` to default `true`, `app/browser/tools/theme.js` sets Teams' own `clientPreferences.theme.followOsTheme = true` on every startup. teams-for-linux is not a native Teams host, so enabling that flag makes the Teams SPA query a host-provided `HostTheme!` value that nothing answers — `$theme` resolves to `undefined` and Teams throws the intermittent unhandled GraphQL rejection reported in #2662:

```
Unexpected error value: "Variable "$theme" got invalid value undefined;
Expected non-nullable type "HostTheme!" not to be null."
```

Every reporter confirmed that setting `followSystemTheme: false` clears it, which matches: `false` writes `followOsTheme = false` and disables the host query.

## Fix

Stop setting Teams' native `followOsTheme` entirely. The wrapper keeps following the OS theme the way it already did — the main process emits `system-theme-changed` and `applyTheme` drives `clientPreferences.theme.userTheme` (`"dark"` / `"default"`). Nothing else changes.

The `followSystemTheme` default stays `true` (maintainer decision); this PR targets the crash, not the default.

## Known behaviour (unchanged, by design)

With the default still `true`, the wrapper follows the OS theme by setting `userTheme` on startup, so a manually-chosen Teams theme is still overridden to match the OS preference. That is intended behaviour for `followSystemTheme: true`; the opt-out for manual theme control remains `followSystemTheme: false` (per the workaround given on the issue). This PR does not change that trade-off — it only removes the unanswerable host query that crashed.

## Testing

- `npm run lint` clean; `npm run test:unit` 311/311.
- The theme path is DOM/Electron-coupled (needs a logged-in Teams SPA), so there is no unit harness for it. Verified the app boots clean on this base. Manual check recommended: run with `followSystemTheme: true` and restart a few times under debug logging (`--logConfig='{"transports":{"console":{"level":"debug"}}}'`); confirm the `HostTheme!` rejection no longer appears and the OS theme is still followed.

closes #2662
