### PR TITLE
fix(auth): forward pre-login-noise auth signals to reauth recovery

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -350,9 +350,10 @@ if (gotTheLock) {
       // raw (unsanitized) message to auth-failure detection. Rejections carry no
       // source URL, so detection's trusted-source check is skipped (empty source).
       // The pre-login-noise check above only down-levels the LOG; it must not
-      // gate detection. "InteractionRequired"/"login_required" are exactly the
-      // signatures auth recovery acts on, so always forward — maybeSchedule-
-      // AuthRecovery does its own pattern, source and cooldown filtering.
+      // gate detection: the reliable "InteractionRequired" signal arrives inside
+      // these noise-matched messages, so always forward. maybeScheduleAuthRecovery
+      // does its own filtering and only acts on InteractionRequired /
+      // interaction_required (login_required and AuthFailed are logged, not acted on).
       mainAppWindow.notifyRendererError(errorData?.message, undefined);
     } catch (err) {
       console.error("[Renderer] Failed to log unhandled-rejection:", err);

--- a/app/index.js
+++ b/app/index.js
@@ -345,13 +345,15 @@ if (gotTheLock) {
         timestamp: toFiniteNumber(errorData?.timestamp, Date.now()),
       });
       // Some auth failures only surface as unhandled promise rejections from MSAL
-      // token warming (e.g. the lowercase "interaction_required" from
+      // token warming (e.g. "interaction_required"/"InteractionRequired" from
       // acquireTokenV2) and never hit console-message or window-error — feed the
       // raw (unsanitized) message to auth-failure detection. Rejections carry no
       // source URL, so detection's trusted-source check is skipped (empty source).
-      if (!preLoginNoise) {
-        mainAppWindow.notifyRendererError(errorData?.message, undefined);
-      }
+      // The pre-login-noise check above only down-levels the LOG; it must not
+      // gate detection. "InteractionRequired"/"login_required" are exactly the
+      // signatures auth recovery acts on, so always forward — maybeSchedule-
+      // AuthRecovery does its own pattern, source and cooldown filtering.
+      mainAppWindow.notifyRendererError(errorData?.message, undefined);
     } catch (err) {
       console.error("[Renderer] Failed to log unhandled-rejection:", err);
     }
@@ -372,10 +374,10 @@ if (gotTheLock) {
       });
       // Some auth failures only surface as uncaught worker errors (e.g.
       // "Uncaught Error: UPR:") that never hit the console-message path —
-      // feed the raw (unsanitized) message to auth-failure detection.
-      if (!preLoginNoise) {
-        mainAppWindow.notifyRendererError(errorData?.message, errorData?.filename);
-      }
+      // feed the raw (unsanitized) message to auth-failure detection. As with
+      // the unhandled-rejection handler, pre-login-noise down-levelling controls
+      // only the log level, never whether detection sees the signal.
+      mainAppWindow.notifyRendererError(errorData?.message, errorData?.filename);
     } catch (err) {
       console.error("[Renderer] Failed to log window-error:", err);
     }


### PR DESCRIPTION
## Problem

With `auth.reauthRecovery.enabled` on, automatic in-app recovery never fired on a stale session on `teams.cloud.microsoft`. The app stayed stuck on the "sign in again" banner / "We couldn't authenticate you" state until a manual relaunch.

The recovery logic was fine; the signal was being suppressed. The pre-login-noise filter (#2564) down-levels `InteractionRequired` / `login_required` / `AuthFailed` renderer messages to debug. #2622 and #2633 then wrapped the detection call in `if (!preLoginNoise)`, which also withheld those exact signatures from `maybeScheduleAuthRecovery`. On this Teams build a stale session surfaces only as those signatures, so detection saw nothing and never scheduled recovery.

(The banner click itself is separately bypassed on the cloud domain because it no longer opens an interceptable popup — out of scope for this PR.)

## Fix

Decouple log down-levelling from detection in both renderer-error handlers: always forward the message to auth-failure detection; the noise check now controls only the log level. `maybeScheduleAuthRecovery` keeps its own pattern, source and cooldown filtering, and worker `UPR` errors stay correlation-only, so the #2629 churn guard is unaffected.

## Verification (live, instrumented build)

- Stale session, flag on: the full chain now runs — `[AUTH_RECOVERY] Auth failure detected → Clearing auth state → Cleared 42 localStorage entries → Cleaned 3 cookies → Reloading for fresh auth`. It never fired before this change across repeated runs.
- After recovery + interactive login, a cold restart holds auth with zero `InteractionRequired` / `login_required` / `AuthFailed` and no recovery — confirms a healthy session does not churn.
- `npm run lint` clean.

Still behind the `auth.reauthRecovery.enabled` opt-in. Related: #2621, #2622, #2629, #2633, #2564.
