### PR TITLE
ci(snap): pin snapcraft to 8.x in the release workflow (arm64)

### DIFF
--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -96,7 +96,15 @@ jobs:
 
     steps:
       - name: Install Snapcraft
+        # snapcraft 9.0.0 removed the legacy `snap` packing command that
+        # electron-builder's deprecated core22 `snap` target invokes
+        # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
+        # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
+        # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
+        # armv7l jobs pack via app-builder directly and are unaffected.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
+        with:
+          channel: 8.x/stable
 
       - name: Install and initialize LXD
         uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main


### PR DESCRIPTION
## Problem

The `snap-candidate-arm64` job failed in the **v2.12.0 Snap Release** run ([runs/27831626190](https://github.com/IsmaelMartinez/teams-for-linux/actions/runs/27831626190/job/82675515908)) with:

```
Command failed: snapcraft snap --output out.snap
The 'snap' command was renamed to 'pack'. Recommended resolution: Use 'pack' instead.
```

amd64 and armv7l built fine; only arm64 broke.

## Cause

snapcraft 9.0.0 removed the long-deprecated `snap` packing subcommand. electron-builder's `base: core22` snap target packs arm64 by invoking `snapcraft snap --output` (arm64 has no electron-builder mksquashfs template, unlike amd64/armv7l, which never call snapcraft directly — they pack via app-builder). Under snapcraft 8.x the `snap` command was a tolerated deprecation warning and the build continued; 9.0.0 makes it a hard error. The release workflow installs snapcraft from the action's default channel, which is now 9.0.0.

## Why main looked "fixed"

#2649 already pinned the arm64 job to `8.x/stable` — but only in `snap.yml` (the CI / PR Snap Build workflow). The release-publish workflow `snap-release.yml` — the one that actually failed for v2.12.0 — was never patched, so the next release would fail again with the identical error.

## Fix

Mirror the exact `channel: 8.x/stable` pin (and the explanatory comment) from `snap.yml` into the `snap-candidate-arm64` job of `snap-release.yml`. amd64/armv7l jobs are unaffected and stay unpinned.

This is a stopgap; the real fix is the core24 migration (#2590, #2592), which uses `snapcraft pack` and removes the need to pin.

Refs #2649, #2650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)