### PR TITLE
fix(media): re-apply ignoreSystemMute patch to cloned capture tracks

### DIFF
--- a/app/browser/tools/ignoreSystemMute.js
+++ b/app/browser/tools/ignoreSystemMute.js
@@ -23,6 +23,14 @@
  * Implementation mirrors the getUserMedia interception used by
  * disableAutogain.js / overrideMicConstraints.js, patching tracks per-instance
  * as each stream resolves rather than mutating the shared prototype.
+ *
+ * Clone coverage: Teams does not feed the raw getUserMedia track into its call
+ * pipeline; it calls `MediaStreamTrack.clone()` and sends the clone. A clone is
+ * a fresh object that does not inherit the per-instance patch, so it would once
+ * again follow the OS mute and reintroduce the exact symptom. We therefore also
+ * wrap `MediaStreamTrack.prototype.clone` and re-apply the patch to clones, but
+ * only when the source track was itself patched, so clones of remote
+ * participants' tracks keep their genuine mute state.
  */
 
 const LOG_PREFIX = "[IGNORE_SYSTEM_MUTE]";
@@ -39,7 +47,7 @@ const patchedTracks = new WeakSet();
  */
 function patchTrack(track) {
   if (track?.kind !== "audio" || patchedTracks.has(track)) {
-    return;
+    return track;
   }
   patchedTracks.add(track);
 
@@ -87,6 +95,8 @@ function patchTrack(track) {
       console.debug(`${LOG_PREFIX} Could not redefine ${prop}:`, error.message);
     }
   }
+
+  return track;
 }
 
 /** Patch every audio track on a resolved MediaStream. */
@@ -137,6 +147,19 @@ const applyIgnoreSystemMutePatch = function () {
   patchFunction(navigator, "getUserMedia", patchDeprecatedGetUserMedia);
   patchFunction(navigator, "mozGetUserMedia", patchDeprecatedGetUserMedia);
   patchFunction(navigator, "webkitGetUserMedia", patchDeprecatedGetUserMedia);
+
+  // Teams clones the capture track before sending it into the call; the clone
+  // does not inherit the per-instance patch, so re-apply it to clones of tracks
+  // we already patched. Clones of remote tracks stay untouched so their genuine
+  // mute remains visible.
+  if (typeof MediaStreamTrack !== "undefined") {
+    patchFunction(MediaStreamTrack.prototype, "clone", function (original) {
+      return function clone() {
+        const cloned = original.call(this);
+        return patchedTracks.has(this) ? patchTrack(cloned) : cloned;
+      };
+    });
+  }
 
   console.debug(
     `${LOG_PREFIX} Successfully initialized - system mute will not toggle Teams`

--- a/tests/unit/ignoreSystemMute.test.js
+++ b/tests/unit/ignoreSystemMute.test.js
@@ -30,6 +30,11 @@ class FakeTrack {
   addEventListener(type, listener) {
     (this._listeners[type] ||= []).push(listener);
   }
+  // Mirrors MediaStreamTrack.clone(): a fresh, independent track that does not
+  // inherit any per-instance patch applied to the track it was cloned from.
+  clone() {
+    return new FakeTrack(this.kind);
+  }
   // Simulates the OS muting the source: Chromium flips muted and fires 'mute'.
   simulateSystemMute() {
     this._muted = true;
@@ -37,6 +42,10 @@ class FakeTrack {
     if (this._onmute) this._onmute();
   }
 }
+
+// Pristine clone, restored between tests so the tool's prototype wrap does not
+// stack across the shared FakeTrack class.
+const pristineClone = FakeTrack.prototype.clone;
 
 function makeStream(tracks) {
   return { getAudioTracks: () => tracks.filter((t) => t.kind === 'audio') };
@@ -68,6 +77,7 @@ describe('ignoreSystemMute', () => {
   afterEach(() => {
     delete globalThis.navigator;
     delete globalThis.MediaStreamTrack;
+    FakeTrack.prototype.clone = pristineClone;
   });
 
   it('does nothing when the option is disabled', () => {
@@ -115,6 +125,37 @@ describe('ignoreSystemMute', () => {
     });
     for (const fn of audioTrack._listeners.ended || []) fn();
     assert.strictEqual(endedSeen, true, 'unrelated events must still fire');
+  });
+
+  it('keeps the patch on a clone of the local audio track', async () => {
+    // Teams clones the capture track before sending it into the call.
+    const track = new FakeTrack('audio');
+    setupGlobals(makeStream([track]));
+    loadTool().init({ media: { microphone: { ignoreSystemMute: true } } });
+
+    const [audioTrack] = (await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })).getAudioTracks();
+    const sentTrack = audioTrack.clone();
+
+    let teamsSawMute = false;
+    sentTrack.addEventListener('mute', () => {
+      teamsSawMute = true;
+    });
+    sentTrack.simulateSystemMute();
+
+    assert.strictEqual(sentTrack.muted, false, 'cloned track muted must read false');
+    assert.strictEqual(teamsSawMute, false, 'cloned track mute event must be suppressed');
+  });
+
+  it('does not patch clones of unrelated (remote) tracks', () => {
+    setupGlobals(makeStream([new FakeTrack('audio')]));
+    loadTool().init({ media: { microphone: { ignoreSystemMute: true } } });
+
+    // A track that never came through getUserMedia, e.g. a remote participant's.
+    const remote = new FakeTrack('audio');
+    const remoteClone = remote.clone();
+    remoteClone.simulateSystemMute();
+
+    assert.strictEqual(remoteClone.muted, true, 'remote track clones must keep their genuine mute');
   });
 
   it('does not patch video tracks', async () => {


### PR DESCRIPTION
## Problem

`media.microphone.ignoreSystemMute` (added in #2695, closing #2694) stops Teams' in-app mic button from following the OS microphone mute. It patches the `getUserMedia` audio track per-instance: forces `muted` to read `false` and suppresses `mute`/`unmute` listeners.

In practice the symptom still reproduced after enabling the option. Live debugging over CDP on a real call showed why: **Teams clones the capture track and sends the clone into the call**, not the original `getUserMedia` track. A `MediaStreamTrack.clone()` is a fresh object that does not inherit the per-instance patch, so the clone reported `muted === true` and fired `mute`/`unmute` when the OS source was muted, and the button followed it again.

Captured during a live call (clone wrapper observing Teams):

```
clone  sourcePatched=true  clonePatched=false
clone  sourcePatched=true  clonePatched=false
```

and a synchronized device snapshot with the OS source muted:

```
original (patched)   muted = false
clone    (unpatched) muted = true
```

## Fix

Wrap `MediaStreamTrack.prototype.clone` and re-apply the patch to the returned clone, but only when the source track was itself patched. Clones of remote participants' tracks are left untouched, so their genuine mute stays visible. `patchTrack` now returns the track so it composes in the clone wrapper.

## Tests

Adds unit coverage:
- a clone of the local audio track keeps `muted === false` and suppresses mute events
- a clone of an unrelated (remote) track keeps its genuine mute

`npm run test:unit` passes (323 tests); lint clean on the changed files.

Follow-up to #2694 / #2695.
