### PR TITLE
fix(frameless): restore search box click in frameless mode after Teams top-bar restructure

### DIFF
--- a/app/browser/tools/frameless.js
+++ b/app/browser/tools/frameless.js
@@ -15,7 +15,8 @@ function init(config, ipcRenderer) {
 		const style = document.createElement('style');
 		style.id = 'frameless-tweaks';
 		style.textContent = `
-            #ms-searchux-search-box-2-0,
+            [data-tid="search-f6-navigation-region"],
+            [role="search"],
             button[data-tid="waffle-open-button"],
             .tfl-nav-button {
               -webkit-app-region: no-drag;


### PR DESCRIPTION
## Problem

With `"frame": false` (frameless mode), clicking the Teams search bar does not focus it. Other top-bar controls (back, forward, waffle, three-dots, profile) react to clicks, and the keyboard shortcut to focus search still works. Reported in #2703.

## Cause

In frameless mode the Teams top bar acts as the window title bar and is `-webkit-app-region: drag`. `app/browser/tools/frameless.js` carves out `no-drag` exceptions for the clickable controls so they stay interactive. The search-box exception targeted the old element id `#ms-searchux-search-box-2-0`, which Teams renamed in the same top-bar restructure that #2672 fixed for the navigation buttons. That selector no longer matches, so the search box stays inside the drag region and swallows the click, while the waffle and `.tfl-nav-button` exceptions still match and keep working. The keyboard shortcut works because it bypasses the drag region.

This is not specific to the reporter's 2.10.0: `frameless.js` has not changed since it was added in #2009, so the selector is stale on current builds too.

## Fix

Repoint the `no-drag` rule at the current search region using the same anchor `navigationButtons.js` already relies on (`[data-tid="search-f6-navigation-region"]`, with `[role="search"]` as a fallback).

## Test plan

With `"frame": false` in `config.json`: click the search bar and confirm it focuses and accepts input, and confirm the window can still be dragged by the rest of the top bar.

closes #2703
