### PR TITLE
Add menu option to choose custom app icon

### DIFF
--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -14,6 +14,13 @@ class TrayIconRenderer {
       "unread-count",
       this.updateActivityCount.bind(this),
     );
+    ipcRenderer.on('config-changed', (_event, changes) => {
+      if ('appIcon' in changes) {
+        this.baseIcon = nativeImage.createFromPath(new TrayIconChooser(this.config).getFile());
+        this.iconSize = this.baseIcon.getSize();
+        this.#lastRequestedCount = undefined;
+      }
+    });
   }
 
   async updateActivityCount(event) {

--- a/app/config/options.js
+++ b/app/config/options.js
@@ -66,7 +66,7 @@ module.exports = {
       },
       appIcon: {
         default: "",
-        describe: "Teams app icon to show in the tray",
+        describe: "Custom app icon (PNG) used for the tray, window, and dock",
         type: "string",
         applyMode: "restart",
       },

--- a/app/index.js
+++ b/app/index.js
@@ -649,7 +649,8 @@ function loadMenuToggleSettings() {
     'disableNotificationSoundIfNotAvailable',
     'disableNotificationWindowFlash',
     'disableBadgeCount',
-    'defaultNotificationUrgency'
+    'defaultNotificationUrgency',
+    'appIcon'
   ];
 
   for (const setting of menuToggleSettings) {

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -63,6 +63,9 @@ exports = module.exports = (Menus) => ({
       type: "separator",
     },
     getSettingsMenu(Menus),
+    ...(Menus.configGroup.startupConfig.trayIconEnabled
+      ? [getAppIconMenu(Menus)]
+      : []),
     getPreferencesMenu(),
     getNotificationsMenu(Menus),
     ...(Menus.configGroup.startupConfig.multiAccount?.enabled
@@ -110,6 +113,24 @@ function getSettingsMenu(Menus) {
       {
         label: "Restore",
         click: () => Menus.restoreSettings(),
+      },
+    ],
+  };
+}
+
+function getAppIconMenu(Menus) {
+  const hasCustomIcon = !!Menus.configGroup.startupConfig.appIcon;
+  return {
+    label: "App Icon",
+    submenu: [
+      {
+        label: "Choose App Icon...",
+        click: () => Menus.chooseAppIcon(),
+      },
+      {
+        label: "Reset to default",
+        enabled: hasCustomIcon,
+        click: () => Menus.resetAppIcon(),
       },
     ],
   };

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -63,9 +63,7 @@ exports = module.exports = (Menus) => ({
       type: "separator",
     },
     getSettingsMenu(Menus),
-    ...(Menus.configGroup.startupConfig.trayIconEnabled
-      ? [getAppIconMenu(Menus)]
-      : []),
+    getAppIconMenu(Menus),
     getPreferencesMenu(),
     getNotificationsMenu(Menus),
     ...(Menus.configGroup.startupConfig.multiAccount?.enabled

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -4,6 +4,7 @@ const {
   MenuItem,
   clipboard,
   dialog,
+  nativeImage,
   session,
   ipcMain,
 } = require("electron");
@@ -228,6 +229,37 @@ class Menus {
       this.tray?.close();
       this.window.webContents.session.flushStorageData();
     }
+  }
+
+  chooseAppIcon() {
+    const result = dialog.showOpenDialogSync(this.window, {
+      title: 'Choose App Icon',
+      filters: [{ name: 'Images', extensions: ['png'] }],
+      properties: ['openFile'],
+    });
+    if (result && result.length > 0) {
+      const selectedPath = result[0];
+      this.configGroup.startupConfig.appIcon = selectedPath;
+      this.configGroup.legacyConfigStore.set('appIcon', selectedPath);
+      this.tray?.setBaseIconPath(selectedPath);
+      this.#updateWindowIcon(selectedPath);
+    }
+  }
+
+  resetAppIcon() {
+    this.configGroup.startupConfig.appIcon = '';
+    this.configGroup.legacyConfigStore.set('appIcon', '');
+    const TrayIconChooser = require('../browser/tools/trayIconChooser');
+    const iconChooser = new TrayIconChooser(this.configGroup.startupConfig);
+    const iconPath = iconChooser.getFile();
+    this.tray?.setBaseIconPath(iconPath);
+    this.#updateWindowIcon(iconPath);
+  }
+
+  #updateWindowIcon(iconPath) {
+    const icon = nativeImage.createFromPath(iconPath);
+    this.window.setIcon(icon);
+    app.dock?.setIcon(icon);
   }
 
   saveSettings() {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -328,6 +328,7 @@ class Menus {
       disableNotificationWindowFlash: this.configGroup.startupConfig.disableNotificationWindowFlash,
       disableBadgeCount: this.configGroup.startupConfig.disableBadgeCount,
       defaultNotificationUrgency: this.configGroup.startupConfig.defaultNotificationUrgency,
+      appIcon: this.configGroup.startupConfig.appIcon,
     });
   }
 

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -243,6 +243,7 @@ class Menus {
       this.configGroup.legacyConfigStore.set('appIcon', selectedPath);
       this.tray?.setBaseIconPath(selectedPath);
       this.#updateWindowIcon(selectedPath);
+      this.updateMenu();
     }
   }
 
@@ -254,6 +255,7 @@ class Menus {
     const iconPath = iconChooser.getFile();
     this.tray?.setBaseIconPath(iconPath);
     this.#updateWindowIcon(iconPath);
+    this.updateMenu();
   }
 
   #updateWindowIcon(iconPath) {

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -72,6 +72,13 @@ class ApplicationTray {
     }
   }
 
+  setBaseIconPath(iconPath) {
+    this.iconPath = iconPath;
+    if (this.tray && !this.tray.isDestroyed()) {
+      this.tray.setImage(this.getIconImage(iconPath));
+    }
+  }
+
   close() {
     if (!this.tray.isDestroyed()) {
       this.tray.destroy();

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -12,7 +12,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 |--------|------|---------|-------------|-------|
 | `appActiveCheckInterval` | `number` | `2` | A numeric value in seconds as poll interval to check if the system is active from being idle | `restart` |
 | `screenSharing` | `object` | `{"thumbnail":{"enabled":true,"alwaysOnTop":true},"lockInhibitionMethod":"Electron"}` | Screen sharing configuration. thumbnail: controls the preview window shown during active sharing. lockInhibitionMethod: screen lock inhibition method (Electron/WakeLockSentinel). | `restart` |
-| `appIcon` | `string` | `""` | Teams app icon to show in the tray | `restart` |
+| `appIcon` | `string` | `""` | Custom app icon (PNG) used for the tray, window, and dock | `restart` |
 | `appIconType` | `string` | `"default"` | Type of tray icon to be used | `restart` |
 | `appIdleTimeout` | `number` | `300` | A numeric value in seconds as duration before app considers the system as idle | `restart` |
 | `appIdleTimeoutCheckInterval` | `number` | `10` | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | `restart` |

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -51,7 +51,7 @@
       "name": "appIcon",
       "type": "string",
       "default": "",
-      "description": "Teams app icon to show in the tray",
+      "description": "Custom app icon (PNG) used for the tray, window, and dock",
       "applyMode": "restart"
     },
     {


### PR DESCRIPTION
## Summary

Since 162ae6cf replaced the bundled icon with the project's own logo for trademark reasons, users who prefer a different icon (e.g. the original Teams icon) have no way to change it through the UI. This PR adds an **App Icon** submenu to the application menu (only shown when `trayIconEnabled` is `true`) with two entries:

- **Choose App Icon…** — opens a PNG file picker and applies the icon immediately to both the tray and the window/dock without a restart
- **Reset to default** — restores the bundled icon (only enabled when a custom icon is set)

The selected path is persisted via `legacyConfigStore` and restored on startup, consistent with other runtime-toggleable settings.

## Testing

- [x] `npm run lint` (required)
- [x] Ran the app manually (`npm start`) and exercised the affected path

## Documentation

- [ ] N/A

## Notes for reviewers

Tested on **Linux (NixOS)** only. The macOS dock path (`app.dock?.setIcon()`) follows the existing pattern in `mainAppWindow/index.js` but has not been verified. Windows is also untested.

closes #2792
