### PR TITLE
fix(theme): force followOsTheme off to stop HostTheme rejection and theme reset

### DIFF
--- a/app/browser/tools/theme.js
+++ b/app/browser/tools/theme.js
@@ -35,18 +35,24 @@ class ThemeManager {
   #disableTeamsOsThemeFollow() {
     const startedAt = Date.now();
     const timer = setInterval(() => {
-      const clientPreferences = ReactHandler.getTeams2ClientPreferences();
-      if (clientPreferences?.theme) {
-        if (clientPreferences.theme.followOsTheme) {
-          clientPreferences.theme.followOsTheme = false;
-          console.debug(
-            "Theme: disabled Teams followOsTheme to prevent HostTheme rejection"
-          );
+      try {
+        const clientPreferences = ReactHandler.getTeams2ClientPreferences();
+        if (clientPreferences?.theme) {
+          if (clientPreferences.theme.followOsTheme) {
+            clientPreferences.theme.followOsTheme = false;
+            console.debug(
+              "Theme: disabled Teams followOsTheme to prevent HostTheme rejection"
+            );
+          }
+          clearInterval(timer);
+          return;
         }
-        clearInterval(timer);
-        return;
-      }
-      if (Date.now() - startedAt >= CLIENT_PREFERENCES_POLL_TIMEOUT_MS) {
+        if (Date.now() - startedAt >= CLIENT_PREFERENCES_POLL_TIMEOUT_MS) {
+          clearInterval(timer);
+        }
+      } catch (error) {
+        // Never let the poll spin forever on an unexpected error.
+        console.error("Theme: failed to disable Teams followOsTheme:", error);
         clearInterval(timer);
       }
     }, CLIENT_PREFERENCES_POLL_INTERVAL_MS);

--- a/app/browser/tools/theme.js
+++ b/app/browser/tools/theme.js
@@ -1,19 +1,55 @@
 const ReactHandler = require("./reactHandler");
 
+// Teams mounts React asynchronously after preload runs, so its client
+// preferences store is not available immediately. Poll for it, then stop.
+const CLIENT_PREFERENCES_POLL_INTERVAL_MS = 1000;
+const CLIENT_PREFERENCES_POLL_TIMEOUT_MS = 60000;
+
 class ThemeManager {
   init(config, ipcRenderer) {
     this.ipcRenderer = ipcRenderer;
     this.config = config;
 
-    // Deliberately do NOT set Teams' own `clientPreferences.theme.followOsTheme`.
-    // teams-for-linux is not a native Teams host, so enabling it makes the Teams
-    // SPA query a host-provided `HostTheme!` value that nothing answers; that
-    // variable resolves to `undefined` and Teams throws an unhandled GraphQL
-    // rejection (#2662). We follow the OS theme ourselves below by driving
-    // `userTheme` from the main-process `system-theme-changed` events instead.
+    // teams-for-linux is not a native Teams host. When Teams' own
+    // `clientPreferences.theme.followOsTheme` is enabled, the Teams SPA queries
+    // a host-provided `HostTheme!` GraphQL value that nothing answers; the
+    // variable resolves to `undefined`, Teams throws an unhandled rejection
+    // (#2662, #2712), and theme resolution falls back to the default (light)
+    // theme, so the user's chosen theme silently resets and cannot be changed
+    // live (#2692).
+    //
+    // Merely not setting `followOsTheme` (the previous #2673 fix) is not enough:
+    // users who already had it enabled from an earlier version keep the stale
+    // `true` value and keep hitting the crash. We actively force it to `false`
+    // to clear that state and let Teams honour the persisted `userTheme`. We
+    // follow the OS theme ourselves below by driving `userTheme` from the
+    // main-process `system-theme-changed` events instead.
+    this.#disableTeamsOsThemeFollow();
+
     if (config.followSystemTheme) {
       this.ipcRenderer.on("system-theme-changed", this.applyTheme);
     }
+  }
+
+  // Wait for Teams' client preferences to load, then force `followOsTheme` off.
+  #disableTeamsOsThemeFollow() {
+    const startedAt = Date.now();
+    const timer = setInterval(() => {
+      const clientPreferences = ReactHandler.getTeams2ClientPreferences();
+      if (clientPreferences?.theme) {
+        if (clientPreferences.theme.followOsTheme) {
+          clientPreferences.theme.followOsTheme = false;
+          console.debug(
+            "Theme: disabled Teams followOsTheme to prevent HostTheme rejection"
+          );
+        }
+        clearInterval(timer);
+        return;
+      }
+      if (Date.now() - startedAt >= CLIENT_PREFERENCES_POLL_TIMEOUT_MS) {
+        clearInterval(timer);
+      }
+    }, CLIENT_PREFERENCES_POLL_INTERVAL_MS);
   }
 
   async applyTheme(_event, ...args) {


### PR DESCRIPTION
teams-for-linux is not a native Teams host, so when Teams' own
clientPreferences.theme.followOsTheme is enabled the Teams SPA queries a
host-provided HostTheme! GraphQL value that nothing answers. The variable
resolves to undefined, Teams throws an unhandled rejection, and theme
resolution falls back to the default light theme — the theme silently resets
on startup and cannot be changed live.

The previous fix (#2673) only stopped setting followOsTheme, which left users
who already had it enabled still hitting the crash. Actively force it to false
once the client preferences store is available so Teams honours the persisted
userTheme instead.

Refs #2712, #2692

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015uEcDB6Lx6CQxuzbreRcFW