### PR TITLE
fix(theme): revert followSystemTheme default to false

### DIFF
--- a/app/config/options.js
+++ b/app/config/options.js
@@ -447,9 +447,9 @@ module.exports = {
         applyMode: "restart",
       },
       followSystemTheme: {
-        default: true,
+        default: false,
         describe:
-          "Follow the operating-system dark/light theme preference. Default is true; set false to keep Teams's own theme regardless of OS changes.",
+          "Follow the operating-system dark/light theme preference. Default is false; set true to drive Teams's theme from the OS preference.",
         type: "boolean",
         applyMode: "restart",
       },

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -50,7 +50,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 | `electronCLIFlags` | `array` | `[]` | Electron CLI flags | `restart` |
 | `emulateWinChromiumPlatform` | `boolean` | `false` | Use windows platform information in chromium. This is helpful if MFA app does not support Linux. | `restart` |
 | `enableIncomingCallToast` | `boolean` | `false` | Enable incoming call toast | `restart` |
-| `followSystemTheme` | `boolean` | `true` | Follow the operating-system dark/light theme preference. Default is true; set false to keep Teams's own theme regardless of OS changes. | `restart` |
+| `followSystemTheme` | `boolean` | `false` | Follow the operating-system dark/light theme preference. Default is false; set true to drive Teams's theme from the OS preference. | `restart` |
 | `frame` | `boolean` | `true` | Specify false to create a Frameless Window. Default is true | `restart` |
 | `incomingCallCommand` | `string` | `null` | Command to execute on an incoming call. (caution: "~" in path is not supported) | `restart` |
 | `incomingCallCommandArgs` | `array` | `[]` | Arguments for the incoming call command. | `restart` |

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -115,7 +115,7 @@ Each option's **Apply** mode (whether a change takes effect immediately or after
 |--------|------|---------|-------------|
 | `customCSSName` | `string` | `""` | Custom CSS name. Options: "compactDark", "compactLight", "tweaks", "condensedDark", "condensedLight" |
 | `customCSSLocation` | `string` | `""` | Custom CSS styles file location |
-| `followSystemTheme` | `boolean` | `true` | Follow the operating-system dark/light theme preference. Set `false` to keep Teams's own theme regardless of OS changes. |
+| `followSystemTheme` | `boolean` | `false` | Follow the operating-system dark/light theme preference. Set `true` to drive Teams's theme from the OS preference. |
 
 ### Tray Icon
 

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -488,8 +488,8 @@
     {
       "name": "followSystemTheme",
       "type": "boolean",
-      "default": true,
-      "description": "Follow the operating-system dark/light theme preference. Default is true; set false to keep Teams's own theme regardless of OS changes.",
+      "default": false,
+      "description": "Follow the operating-system dark/light theme preference. Default is false; set true to drive Teams's theme from the OS preference.",
       "applyMode": "restart"
     },
     {


### PR DESCRIPTION
## Problem

2.11.0 flipped the `followSystemTheme` default to `true` (#2566). With it on, the wrapper drives Teams's theme from the OS preference at startup, overwriting the theme the user picked inside Teams. Anyone with a light system theme gets their dark choice reset on every boot. Field evidence: #2692 (empty config, 2.10 works, 2.11 through 2.13 broken, the #2715 followOsTheme fix did not help), #2691, and the theme half of #2603.

## Changes

- `app/config/options.js`: `followSystemTheme` default `true` -> `false`, describe text updated
- `docs-site/docs/configuration-generated.md` and `docs-site/static/config-schema.json` regenerated via `npm run generate-config-docs`
- `docs-site/docs/configuration.md`: defaults table row updated

OS-driven theming stays available as an explicit opt-in with `"followSystemTheme": true`.

## Testing

`npm run lint` and `npm run test:unit` pass; config docs regenerated cleanly.

Relates to #2692, #2691, #2603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
