### PR TITLE
chore(deps-dev): bump electron from 42.5.1 to 42.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@electron/fuses": "^2.1.3",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.61.1",
-        "electron": "42.5.1",
+        "electron": "42.7.0",
         "electron-builder": "26.8.1",
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.5.1.tgz",
-      "integrity": "sha512-2VFNJcHHbrhIpGsJHdkLoi/nWPZPxN3GHVPe+9At3Oz3/TJRwpr+7JL97ddBDbKyLmHGx3GfI2jvzcEQL28uFw==",
+      "version": "42.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.0.tgz",
+      "integrity": "sha512-Uu5p03M5o7aqulT8QxFYYg3eJVDfuNEUuasBU1qFl05ghVRRH7UHL7na8S3GhxVScZQ2D7j9DCMsc+qT5FuxtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "devDependencies": {
     "@electron/fuses": "^2.1.3",
     "@eslint/js": "^10.0.1",
-    "electron": "42.5.1",
     "@playwright/test": "1.61.1",
+    "electron": "42.7.0",
     "electron-builder": "26.8.1",
     "eslint": "^10.7.0",
     "globals": "^17.7.0",


### PR DESCRIPTION
Supersedes #2731: staying on the 42.x line, taking its latest patch instead of moving to 43 (majors only when proven stable or carrying a change we need; dependabot told to ignore the 43 major).

Notable in 42.5.1..42.7.0: fix for a crash when replacing an open application menu (42.6.1), fix for a browser-process crash when app.asar is replaced on disk while running, e.g. by an updater (42.6.2), and main-process net.WebSocket (42.7.0). No breaking changes within the major.

Verified locally: lint clean, full e2e suite 14/14 against 42.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)