### PR TITLE
fix(idle): stop hard-exiting on SIGINT/SIGTERM so shutdown flushes storage

### DIFF
--- a/app/idle/monitor.js
+++ b/app/idle/monitor.js
@@ -28,11 +28,11 @@ class IdleMonitor {
     // Get system idle state to sync with Teams presence
     ipcMain.handle("get-system-idle-state", this.#handleGetSystemIdleState.bind(this));
     
+    // State-file cleanup rides on the normal 'exit' event. Do not register
+    // SIGINT/SIGTERM handlers calling process.exit() here: app/index.js maps
+    // those signals to app.quit(), and a hard exit skips Chromium's storage
+    // flush, losing recently written settings and cookies (#2722).
     process.on('exit', this.#cleanupStateFile.bind(this));
-    
-    ['SIGINT', 'SIGTERM'].forEach(signal => {
-      process.on(signal, () => process.exit(0));
-    });
   }
 
   #cleanupStateFile() {


### PR DESCRIPTION
## Problem

PR #2355 (v2.10.0) registered `process.on('SIGINT'|'SIGTERM', () => process.exit(0))` in the idle monitor, unconditionally for every user. `app/index.js` already maps those signals to `app.quit()` (since #520, 2022), but the hard exit runs in the same signal dispatch and kills the process before the queued graceful quit executes. Any logout or machine shutdown with the app still running therefore skips `flushStorageData()` and Chromium's own storage commit, losing recently written settings and cookies. That matches the intermittent storage-loss reports: localStorage edits reverting, and 1 in 5 launches booting with 0 auth cookies (#2722).

## Fix

Remove the hard-exit handlers and let the existing graceful path handle the signals. The #2355 state-file cleanup is preserved: `app.quit()` ends in a normal process exit, which still fires the `'exit'` event the cleanup is registered on. A comment now guards against re-adding a hard exit there.

Relates to #2722 (storage-loss strand). Likely also behind parts of #2603 and #2681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
