### PR TITLE
feat(browser): create meeting-started notification detector module

### DIFF
--- a/app/browser/tools/meetingStartedDetector.js
+++ b/app/browser/tools/meetingStartedDetector.js
@@ -1,0 +1,68 @@
+const DEFAULT_PATTERN = /has started the meeting|meeting started|started meeting/i;
+const DEFAULT_DEBOUNCE_MS = 2000;
+
+class MeetingStartedDetector {
+    constructor(options = {}) {
+        this.onMeetingStarted = options.onMeetingStarted || (() => {});
+        this.pattern = options.pattern || DEFAULT_PATTERN;
+        this.debounceMs = options.debounceMs || DEFAULT_DEBOUNCE_MS;
+        this.lastDetectionTime = 0;
+        this.observer = null;
+        this.isRunning = false;
+    }
+
+    start(root = document) {
+        if (this.isRunning) {
+            return;
+        }
+
+        this.isRunning = true;
+        this.observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        this.checkForMeetingStarted(node);
+                    }
+                }
+            }
+        });
+
+        this.observer.observe(root, {
+            childList: true,
+            subtree: true,
+        });
+    }
+
+    stop() {
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+        this.isRunning = false;
+    }
+
+    checkForMeetingStarted(element) {
+        const text = element.textContent || '';
+        if (this.pattern.test(text)) {
+            const now = Date.now();
+            if (now - this.lastDetectionTime >= this.debounceMs) {
+                this.lastDetectionTime = now;
+                this.onMeetingStarted({ timestamp: now, text });
+            }
+        }
+
+        const children = element.querySelectorAll('*');
+        for (const child of children) {
+            const childText = child.textContent || '';
+            if (this.pattern.test(childText)) {
+                const now = Date.now();
+                if (now - this.lastDetectionTime >= this.debounceMs) {
+                    this.lastDetectionTime = now;
+                    this.onMeetingStarted({ timestamp: now, text: childText });
+                }
+            }
+        }
+    }
+}
+
+module.exports = { MeetingStartedDetector };


### PR DESCRIPTION
## New Feature

### Problem
New module that uses MutationObserver to watch the Teams DOM for "started the meeting" toast/notifications. Implements Path A from the issue (notification/DOM/React-store detection). Supports a configurable regex pattern (default: common Teams phrasings) so users can adapt if Microsoft changes the wording. Emits events via a callback when a match is found, with deduplication to avoid firing multiple times for the same meeting (using a debounce/cooldown window). Follows the same module style as the existing incoming-call detector shipped in PR #2572 (Phase 1).

**Severity**: `high`
**File**: `app/browser/tools/meetingStartedDetector.js`

### Solution
New module that uses MutationObserver to watch the Teams DOM for "started the meeting" toast/notifications. Implements Path A from the issue (notification/DOM/React-store detection). Supports a configurable regex pattern (default: common Teams phrasings) so users can adapt if Microsoft changes the wording. Emits events via a callback when a match is found, with deduplication to avoid firing multiple times for the same meeting (using a debounce/cooldown window). Follows the same module style as the existing incoming-call detector shipped in PR #2572 (Phase 1).

### Changes
- `app/browser/tools/meetingStartedDetector.js` (new)



## Summary



closes #NNN

## Testing



## Documentation



## Notes for reviewers


Contributed by Hoàng Anh Vũ

Closes #2587