### PR TITLE
chore(deps): bump fast-uri and svgo to patched versions (3 high alerts)

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -11068,9 +11068,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -19782,9 +19782,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears all three open high-severity Dependabot alerts, which block the Gold health tier's "Zero critical/high security findings" check.

| alert | package | before | after | manifest |
|---|---|---|---|---|
| #173 | fast-uri | 3.1.2 | 3.1.4 | `package-lock.json` |
| #170 | fast-uri | 3.1.2 | 3.1.4 | `docs-site/package-lock.json` |
| #172 | svgo | 3.3.3 | 3.3.4 | `docs-site/package-lock.json` |

The alerts span **two separate manifests**, so each was updated in its own directory rather than treating this as one repo-level fix.

No `overrides` entry was needed: every transitive parent already declares a caret range admitting the patched version (`ajv` requiring `fast-uri@^3.0.1`, `@svgr/plugin-svgo@^3.0.2` and `postcss-svgo@^3.2.0` for svgo). Lockfiles only — `package.json` is untouched and the existing `follow-redirects` override is preserved.

### Testing

`npm run test:unit` reports 159 passed / 6 failed locally, but that is **pre-existing and unrelated** — the identical 6 failures occur on the base commit without this change. They are Electron-dependent suites (`commandLine`, `customStickers`, `downloadManager`, `mediaStatusService`, `mqttCommandHandler`, `webauthn`) failing on macOS for a Linux-target app. CI on Linux is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)