### PR TITLE
fix(screen-sharing): pass picker source directly to avoid Wayland ID mismatch

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -83,7 +83,6 @@ function handleScreenSourceSelection(source, callback) {
     // the picker's enumeration never matched a second enumeration and
     // sharing always failed. See #2713 (and #2207 for the original attempt).
     setupScreenSharing(source);
-    callback({ video: { id: source.id, name: source.name || "" } });
   } catch (error) {
     console.error("[SCREEN_SHARE] Failed to setup screen sharing:", {
       error: error.message,
@@ -96,6 +95,15 @@ function handleScreenSourceSelection(source, callback) {
         console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
       }
     });
+    return;
+  }
+
+  // Kept out of the try above so a throwing callback is not mistaken for a
+  // setup failure and answered with a second callback.
+  try {
+    callback({ video: { id: source.id, name: source.name || "" } });
+  } catch {
+    console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
   }
 }
 

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -6,7 +6,6 @@ const {
   dialog,
   webFrameMain,
   nativeImage,
-  desktopCapturer,
   ipcMain,
   MessageChannelMain,
 } = require("electron");
@@ -49,10 +48,6 @@ let menus = null;
 
 const isMac = os.platform() === "darwin";
 
-function findSelectedSource(sources, source) {
-  return sources.find((s) => s.id === source.id);
-}
-
 function setupScreenSharing(selectedSource) {
   screenSharingService.setSelectedSource(selectedSource);
   createScreenSharePreviewWindow();
@@ -81,41 +76,27 @@ function bindDisplayMediaHandler(targetSession) {
 }
 
 function handleScreenSourceSelection(source, callback) {
-  desktopCapturer
-    .getSources({ types: ["window", "screen"] })
-    .then((sources) => {
-      const selectedSource = findSelectedSource(sources, source);
-      if (selectedSource) {
-        setupScreenSharing(selectedSource);
-        callback({ video: selectedSource });
-      } else {
-        // Source not found - use setImmediate and try-catch to allow retry
-        setImmediate(() => {
-          try {
-            callback({});
-          } catch {
-            console.debug("[SCREEN_SHARE] Selected source not found");
-          }
-        });
-      }
-    })
-    .catch((error) => {
-      // Handle desktopCapturer failures gracefully - can crash on certain hardware
-      // configurations (USB-C docking stations, DisplayLink drivers, etc.)
-      // See issues #2058, #2041
-      console.error("[SCREEN_SHARE] Failed to get sources for selection:", {
-        error: error.message,
-        stack: error.stack,
-        sourceId: source?.id
-      });
-      setImmediate(() => {
-        try {
-          callback({});
-        } catch {
-          console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
-        }
-      });
+  try {
+    // Use the picker's source directly instead of re-querying
+    // desktopCapturer.getSources(). On Wayland/PipeWire every getSources()
+    // call opens a fresh portal session with new source IDs, so an ID from
+    // the picker's enumeration never matched a second enumeration and
+    // sharing always failed. See #2713 (and #2207 for the original attempt).
+    setupScreenSharing(source);
+    callback({ video: { id: source.id, name: source.name || "" } });
+  } catch (error) {
+    console.error("[SCREEN_SHARE] Failed to setup screen sharing:", {
+      error: error.message,
+      sourceId: source?.id,
     });
+    setImmediate(() => {
+      try {
+        callback({});
+      } catch {
+        console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
+      }
+    });
+  }
 }
 
 function createScreenSharePreviewWindow() {

--- a/app/screenSharing/README.md
+++ b/app/screenSharing/README.md
@@ -67,4 +67,6 @@ The picker is a modal overlay over the main Teams window. Issue #2524.
 
 **Wayland:** Requires source IDs in `screen:x:y` or `window:x:y` format from desktopCapturer. MediaStream UUIDs will fail.
 
+**Single enumeration rule:** the ID the picker returns must be passed straight to the `setDisplayMediaRequestHandler` callback. Never re-query `desktopCapturer.getSources()` to "refresh" the selected source: on Wayland/PipeWire every `getSources()` call opens a fresh portal session with new source IDs, so an ID from one enumeration never matches another and the share fails (#2713).
+
 See [ADR 001](../../docs-site/docs/development/adr/001-use-desktopcapturer-source-id-format.md) for technical details.

--- a/app/screenSharing/README.md
+++ b/app/screenSharing/README.md
@@ -69,4 +69,4 @@ The picker is a modal overlay over the main Teams window. Issue #2524.
 
 **Single enumeration rule:** the ID the picker returns must be passed straight to the `setDisplayMediaRequestHandler` callback. Never re-query `desktopCapturer.getSources()` to "refresh" the selected source: on Wayland/PipeWire every `getSources()` call opens a fresh portal session with new source IDs, so an ID from one enumeration never matches another and the share fails (#2713).
 
-See [ADR 001](../../docs-site/docs/development/adr/001-use-desktopcapturer-source-id-format.md) for technical details.
+See [ADR 001](../../docs-site/docs/development/adr/001-desktopcapturer-source-id-format.md) for technical details.

--- a/app/screenSharing/browser.js
+++ b/app/screenSharing/browser.js
@@ -627,8 +627,10 @@ function pickClosestAligned(items, cur, aligned) {
 function shareSelection() {
   if (!state.selectedId) return;
   const quality = QUALITY_OPTIONS.find((q) => q.id === state.quality) || DEFAULT_QUALITY;
+  const selected = state.sources.find((s) => s.id === state.selectedId);
   globalThis.api.selectedSource({
     id: state.selectedId,
+    name: selected?.name || "",
     screen: { width: quality.width, height: quality.height, name: quality.label },
   });
 }


### PR DESCRIPTION
## Problem

Selecting a source in the in-app picker always fails on Wayland/PipeWire. The picker enumerates sources once, then `handleScreenSourceSelection` re-queries `desktopCapturer.getSources()` and matches by exact ID. On PipeWire each `getSources()` call opens a fresh portal session with new source IDs, so the second enumeration never contains the picker's ID, the callback fires empty, and Teams shows the generic camera error.

## Fix

Pass the picker's source straight to the `setDisplayMediaRequestHandler` callback (`{ id, name }` is all Electron needs, and all downstream consumers only use `.id`). Same shape as the earlier attempt in #2207, adapted to the current picker. The picker payload now carries the source `name`, and the screenSharing README documents the single-enumeration rule so the re-query pattern does not come back.

## Testing

- `npm run lint` clean
- `npm run test:e2e` 15/15 passing
- Wayland verification pending: reporter (sway + xdg-desktop-portal-wlr) to confirm via the PR build artifacts. The open question is portal session lifetime across the handoff, which only a real Wayland box answers.

closes #2713

🤖 Generated with [Claude Code](https://claude.com/claude-code)