### PR TITLE
fix(ci): bump electron-builder to 26.15.7 to fix DOA snap builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.61.1",
         "electron": "42.7.0",
-        "electron-builder": "26.15.3",
+        "electron-builder": "26.15.7",
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
         "http-server": "^14.1.1",
@@ -1081,9 +1081,9 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.7.tgz",
+      "integrity": "sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1133,8 +1133,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.3",
-        "electron-builder-squirrel-windows": "26.15.3"
+        "dmg-builder": "26.15.7",
+        "electron-builder-squirrel-windows": "26.15.7"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/fuses": {
@@ -2182,13 +2182,13 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.7.tgz",
+      "integrity": "sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
+        "app-builder-lib": "26.15.7",
         "builder-util": "26.15.3",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
@@ -2338,18 +2338,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.7.tgz",
+      "integrity": "sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
+        "app-builder-lib": "26.15.7",
         "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.3",
+        "dmg-builder": "26.15.7",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -2364,14 +2364,14 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
-      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.7.tgz",
+      "integrity": "sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.3",
+        "app-builder-lib": "26.15.7",
         "builder-util": "26.15.3",
         "electron-winstaller": "5.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "1.61.1",
     "electron": "42.7.0",
-    "electron-builder": "26.15.3",
+    "electron-builder": "26.15.7",
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Problem

Dependabot #2750 unpinned electron-builder from 26.8.1 to exactly 26.15.3. That version carries electron-userland/electron-builder#10002: the snap template archive is 7z-decompressed but never untarred, so amd64/armv7l snaps ship the raw template tar and no `desktop-init.sh`. `command.sh` then fails at every launch with "No such file or directory". CI stays green because the defect is invisible at build time.

Confirmed against the published artifact: the 2.14.0 candidate-channel amd64 snap (store rev 2180) contains `snap-template-electron-4.0-2-amd64.tar` at the snap root and no `desktop-init.sh`. The arm64 snap builds via snapcraft rather than the template path and is unaffected.

## Fix

Bump to 26.15.7, which includes the upstream fix (electron-userland/electron-builder#10004, backport of #10003, released 2026-07-18).

## Verification

The `snap` job artifact on this PR should contain `desktop-init.sh` and no leftover `snap-template-*.tar`. Will verify on the build artifacts before marking ready.

Follow-up needed outside this PR: the 2.14.0 snap currently on the candidate channel is broken and needs replacing (rebuild after this lands, or revert the channel to the 2.13.0 revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)