### PR TITLE
docs(certificate): document NSS trust store for TLS-inspecting proxies

### DIFF
--- a/docs-site/docs/certificate.md
+++ b/docs-site/docs/certificate.md
@@ -65,8 +65,8 @@ interception.
 Install the NSS tools first: `libnss3-tools` on Debian/Ubuntu, `nss-tools` on Fedora,
 `mozilla-nss-tools` on openSUSE.
 
-If you already have the CA certificate as a file, skip to step 4. Otherwise capture the
-chain the proxy presents:
+If you already have the CA certificate as a file, skip to the import in step 4 and point
+`-i` at your own file. Otherwise capture the chain the proxy presents:
 
 ```bash
 # 1. Capture the chain (any HTTPS host works)
@@ -79,10 +79,15 @@ awk 'BEGIN{n=-1} /-----BEGIN CERTIFICATE-----/{n++} n>=0{print > sprintf("chain-
 # 3. Identify them (the self-signed one, where subject equals issuer, is the root)
 for f in chain-*.pem; do printf "%s : " "$f"; openssl x509 -in "$f" -noout -subject -issuer; done
 
-# 4. Import the root, and any intermediate, into the NSS database
-certutil -d sql:$HOME/.pki/nssdb -A -n "CorpRootCA"  -t "CT,C,C" -a -i chain-02.pem
-certutil -d sql:$HOME/.pki/nssdb -A -n "CorpProxyCA" -t "CT,C,C" -a -i chain-01.pem
+# 4. Import the root as a trusted SSL CA, and any intermediate untrusted
+certutil -d sql:$HOME/.pki/nssdb -A -n "CorpRootCA"  -t "C,,"  -a -i chain-02.pem
+certutil -d sql:$HOME/.pki/nssdb -A -n "CorpProxyCA" -t ",,"   -a -i chain-01.pem
 ```
+
+The trust flags matter. `C,,` marks the root as trusted for issuing SSL server certificates,
+which is the minimum this needs. An intermediate is imported with `,,` so it can be used to
+build the chain without itself becoming a trust anchor. Avoid broader flags such as `CT,C,C`,
+which would additionally trust the certificate for email and object signing.
 
 Restart Teams for Linux afterwards. You can confirm what is trusted with
 `certutil -d sql:$HOME/.pki/nssdb -L`.
@@ -102,10 +107,17 @@ adjust the `-d sql:` path if you want to import there instead.
 
 #### Confined packages
 
-Snap and Flatpak remap `HOME`, so both the config file and the NSS database live elsewhere:
+Snap and Flatpak remap `HOME`, so the database lives inside the app's own directory. Both
+candidate paths above still apply, just relative to the remapped home:
 
-*   **Snap:** `~/snap/teams-for-linux/current/.pki/nssdb`
-*   **Flatpak:** `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/.pki/nssdb`
+*   **Snap:** `~/snap/teams-for-linux/current/.pki/nssdb`, or
+    `~/snap/teams-for-linux/current/.local/share/pki/nssdb`
+*   **Flatpak:** `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/.pki/nssdb`, or
+    `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/data/pki/nssdb`
+
+The config file is remapped the same way, which is a common reason
+`customCACertsFingerprints` looks like it is being ignored on these packages. See
+[Configuration](configuration.md) for the config locations.
 
 ## Corporate Certificate Scenarios
 

--- a/docs-site/docs/certificate.md
+++ b/docs-site/docs/certificate.md
@@ -36,6 +36,77 @@ To have your custom certs recognized on every run, add them to your
 }
 ```
 
+## Linux: the system CA store is not enough
+
+On Linux, Chromium (and therefore Electron, and therefore this app) does not read the
+system OpenSSL trust store. It reads a per-user [NSS shared database](https://wiki.mozilla.org/NSS_Shared_DB_And_LINUX)
+plus a single PKCS#11 module loaded by filename, `libnssckbi.so`.
+
+The practical consequence differs by distribution:
+
+*   **Debian and Ubuntu** ship the stock NSS built-in roots module. Installing a CA into
+    `/usr/local/share/ca-certificates/` and running `update-ca-certificates` has **no effect**
+    on this app. You must import the certificate into the NSS database yourself, as below.
+    ([Debian bug 704180](https://bugs.debian.org/704180) tracks changing this, open since 2013.)
+*   **Fedora, RHEL and openSUSE** replace `libnssckbi.so` with `p11-kit-trust` through
+    `update-alternatives`, so certificates added with `update-ca-trust` are picked up
+    automatically for every user and no extra step is needed.
+
+:::note
+`customCACertsFingerprints` only applies to certificate errors that surface during a page
+load. Behind a proxy that intercepts every TLS connection, the failure can appear as a
+transport error before that hook runs, in which case the fingerprint allowlist never gets a
+chance to act. Importing the CA into NSS, as below, is the reliable fix for full TLS
+interception.
+:::
+
+### Importing a corporate CA into the NSS database
+
+Install the NSS tools first: `libnss3-tools` on Debian/Ubuntu, `nss-tools` on Fedora,
+`mozilla-nss-tools` on openSUSE.
+
+If you already have the CA certificate as a file, skip to step 4. Otherwise capture the
+chain the proxy presents:
+
+```bash
+# 1. Capture the chain (any HTTPS host works)
+openssl s_client -connect teams.cloud.microsoft:443 -servername teams.cloud.microsoft \
+  -showcerts </dev/null 2>/dev/null > raw.txt
+
+# 2. Split it into individual PEM files
+awk 'BEGIN{n=-1} /-----BEGIN CERTIFICATE-----/{n++} n>=0{print > sprintf("chain-%02d.pem",n)}' raw.txt
+
+# 3. Identify them (the self-signed one, where subject equals issuer, is the root)
+for f in chain-*.pem; do printf "%s : " "$f"; openssl x509 -in "$f" -noout -subject -issuer; done
+
+# 4. Import the root, and any intermediate, into the NSS database
+certutil -d sql:$HOME/.pki/nssdb -A -n "CorpRootCA"  -t "CT,C,C" -a -i chain-02.pem
+certutil -d sql:$HOME/.pki/nssdb -A -n "CorpProxyCA" -t "CT,C,C" -a -i chain-01.pem
+```
+
+Restart Teams for Linux afterwards. You can confirm what is trusted with
+`certutil -d sql:$HOME/.pki/nssdb -L`.
+
+Importing the intermediate as well as the root matters when the proxy serves an incomplete
+chain. Chromium only follows plain `http` AIA URLs to fetch a missing issuer, so a proxy
+that publishes an `https` AIA URL (or none) leaves the chain unbuildable unless the
+intermediate is present locally.
+
+#### Which database path to use
+
+Since Chromium 146 the default database is `${XDG_DATA_HOME:-$HOME/.local/share}/pki/nssdb`.
+The legacy `~/.pki/nssdb` is still preferred when that directory already exists, which is why
+the commands above work: `certutil` creates it, and the app then uses it on the next start.
+On a profile where `~/.pki/nssdb` was never created, the app reads the newer location, so
+adjust the `-d sql:` path if you want to import there instead.
+
+#### Confined packages
+
+Snap and Flatpak remap `HOME`, so both the config file and the NSS database live elsewhere:
+
+*   **Snap:** `~/snap/teams-for-linux/current/.pki/nssdb`
+*   **Flatpak:** `~/.var/app/com.github.IsmaelMartinez.teams_for_linux/.pki/nssdb`
+
 ## Corporate Certificate Scenarios
 
 ### Self-Signed Certificates

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -272,6 +272,33 @@ Both locations sit ahead of `/usr/share/applications` in `XDG_DATA_DIRS`, so the
 
 ---
 
+#### Issue: Blank "Waiting for network" screen behind a TLS-inspecting proxy
+
+**Description:** On a corporate network that intercepts TLS (a proxy re-signs every HTTPS
+connection with an internal CA), the window stays on a blank screen titled "Waiting for
+network" and never loads. Debug logs show repeated `net_error -202`
+(`ERR_CERT_AUTHORITY_INVALID`) handshake failures, often alongside AIA fetch errors, ending
+in `ERR_CONNECTION_CLOSED` for the main frame.
+
+**Potential Causes:**
+*   The corporate root CA is installed in the system store only. On Linux, Chromium and
+    Electron read a per-user NSS database, not the system OpenSSL store, so
+    `update-ca-certificates` does not reach the app on Debian and Ubuntu.
+*   The proxy serves an incomplete chain and the intermediate is not trusted locally either.
+
+**Solutions/Workarounds:**
+
+1.  **Import the CA into the NSS database:** see
+    [Certificate Management](certificate.md#linux-the-system-ca-store-is-not-enough) for the
+    `certutil` steps, the correct database path, and the Snap and Flatpak locations.
+
+2.  **On Fedora, RHEL and openSUSE:** `update-ca-trust` is sufficient, because those
+    distributions route NSS trust through `p11-kit-trust`.
+
+**Related GitHub Issues:** [Issue #2762](https://github.com/IsmaelMartinez/teams-for-linux/issues/2762)
+
+---
+
 #### Issue: Third-Party SSO Login Fails (e.g. Symantec VIP)
 
 **Description:** Users with third-party SSO providers like Symantec VIP see a broken or blank login page. Console logs may show `EvalError` or Content Security Policy violations referencing `strict-dynamic` or `nonce-` directives.


### PR DESCRIPTION
On Linux, Chromium reads trust anchors from the per-user NSS database rather than the system OpenSSL store, so `update-ca-certificates` never reaches the app on Debian and Ubuntu. Adds the `certutil` import steps to the certificate page, along with which database path applies since Chromium 146 and the Snap and Flatpak locations, plus a troubleshooting entry for the blank "Waiting for network" screen behind an intercepting proxy.

Refs #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)