### PR TITLE
fix(certificate): apply customCACertsFingerprints to every TLS verification

### DIFF
--- a/app/certificate/index.js
+++ b/app/certificate/index.js
@@ -35,9 +35,9 @@ exports.onAppCertificateError = function onAppCertificateError(arg) {
   }
 };
 
-// net::ERR_CERT_AUTHORITY_INVALID. The only failure we are willing to override,
-// so an expired or revoked certificate is still rejected even when its issuer is
-// on the allowlist.
+// net::ERR_CERT_AUTHORITY_INVALID, the only failure we are willing to override.
+// A revoked certificate reports ERR_CERT_REVOKED instead, which ranks higher in
+// Chromium's MapCertStatusToNetError, so it never reaches the accept path.
 const ERR_CERT_AUTHORITY_INVALID = -202;
 
 // Special values accepted by the setCertificateVerifyProc callback.
@@ -57,6 +57,12 @@ const VERIFY_USE_CHROMIUM_RESULT = -3;
  * behaviour is untouched. When a fingerprint is configured we still defer to
  * Chromium for anything that is not an untrusted-authority failure, so this can
  * only ever accept a certificate the user explicitly allowlisted.
+ *
+ * Known limitation: accepting overrides Chromium's whole verification for that
+ * connection, including hostname matching, and a name mismatch is masked by the
+ * authority error because it ranks lower in MapCertStatusToNetError. Trusting the
+ * CA through the NSS database keeps hostname checking intact and remains the
+ * stricter option; see docs-site/docs/certificate.md.
  *
  * @param {Object} config - App configuration containing customCACertsFingerprints
  * @param {Electron.App} app - Electron app, used to catch sessions as they are created
@@ -83,7 +89,18 @@ exports.installCertificateVerifyProc = function installCertificateVerifyProc(
       return;
     }
 
-    if (getChainFingerprints(request.certificate).some((fp) => fingerprints.includes(fp))) {
+    const chain = getChain(request.certificate);
+
+    if (chain.some((cert) => fingerprints.includes(cert.fingerprint))) {
+      // Chromium reports only the most serious error, and CERT_STATUS_DATE_INVALID
+      // ranks below CERT_STATUS_AUTHORITY_INVALID (net/cert/cert_status_flags.cc),
+      // so an untrusted *and* expired certificate arrives here as -202. Check the
+      // validity window ourselves rather than letting the expiry pass unnoticed.
+      if (!chain.every(isCurrentlyValid)) {
+        console.error("[CERT] Allowlisted authority presented an out-of-date certificate");
+        callback(VERIFY_USE_CHROMIUM_RESULT);
+        return;
+      }
       console.debug("[CERT] Accepting allowlisted certificate authority");
       callback(VERIFY_ACCEPT);
       return;
@@ -126,7 +143,7 @@ function isUntrustedAuthority(request) {
 }
 
 /**
- * Collects the fingerprint of every certificate in a presented chain.
+ * Collects every certificate in a presented chain.
  *
  * An intercepting proxy often serves an incomplete chain, in which case the root
  * is not reachable via issuerCert and matching only the root would never succeed.
@@ -134,18 +151,32 @@ function isUntrustedAuthority(request) {
  * of them is as deliberate as matching the root.
  *
  * @param {Electron.Certificate} cert - Leaf certificate
- * @returns {string[]} Fingerprints, leaf first
+ * @returns {Electron.Certificate[]} Certificates, leaf first
  */
-function getChainFingerprints(cert) {
-  const fingerprints = [];
+function getChain(cert) {
+  const chain = [];
   let current = cert;
   while (current) {
-    if (current.fingerprint) {
-      fingerprints.push(current.fingerprint);
-    }
+    chain.push(current);
     current = current.issuerCert === current ? null : current.issuerCert;
   }
-  return fingerprints;
+  return chain;
+}
+
+/**
+ * Whether a certificate's validity window covers the current time. Returns false
+ * when the dates are missing, so an unverifiable certificate is never accepted.
+ * @param {Electron.Certificate} cert
+ * @returns {boolean}
+ */
+function isCurrentlyValid(cert) {
+  const nowInSeconds = Date.now() / 1000;
+  return (
+    typeof cert.validStart === "number" &&
+    typeof cert.validExpiry === "number" &&
+    nowInSeconds >= cert.validStart &&
+    nowInSeconds <= cert.validExpiry
+  );
 }
 
 /**

--- a/app/certificate/index.js
+++ b/app/certificate/index.js
@@ -95,7 +95,11 @@ exports.installCertificateVerifyProc = function installCertificateVerifyProc(
       return;
     }
 
-    const chain = getChain(request.certificate);
+    // validatedCertificate, not certificate. The latter is the chain the server
+    // sent, and Electron links it positionally without checking that each entry
+    // signed the one below, so anyone able to intercept the connection can append
+    // an allowlisted CA's public certificate to a chain it never issued.
+    const chain = getChain(request.validatedCertificate);
 
     if (chain.some((cert) => fingerprints.includes(cert.fingerprint))) {
       // Chromium reports only the most serious error, and CERT_STATUS_DATE_INVALID
@@ -155,12 +159,13 @@ function isUntrustedAuthority(request) {
 }
 
 /**
- * Collects every certificate in a presented chain.
+ * Collects every certificate in a chain.
  *
- * An intercepting proxy often serves an incomplete chain, in which case the root
- * is not reachable via issuerCert and matching only the root would never succeed.
- * Every entry is compared against the user's explicit allowlist, so matching any
- * of them is as deliberate as matching the root.
+ * Call this with request.validatedCertificate, which is the path Chromium built
+ * and signature-checked. Every entry in it genuinely issued the one below, so
+ * matching any of them is as deliberate as matching the root. That matters
+ * because an intercepting proxy often serves an incomplete chain, in which case
+ * the root is absent and matching only the root would never succeed.
  *
  * @param {Electron.Certificate} cert - Leaf certificate
  * @returns {Electron.Certificate[]} Certificates, leaf first

--- a/app/certificate/index.js
+++ b/app/certificate/index.js
@@ -78,6 +78,12 @@ exports.installCertificateVerifyProc = function installCertificateVerifyProc(
     return;
   }
 
+  // This proc runs per handshake, and behind an intercepting proxy a misconfigured
+  // fingerprint fails every one of them. Report each outcome once so a persistent
+  // misconfiguration is still visible without flooding the log.
+  let warnedOutOfDate = false;
+  let warnedNotInAllowlist = false;
+
   const verifyProc = (request, callback) => {
     if (request.verificationResult === "OK") {
       callback(VERIFY_USE_CHROMIUM_RESULT);
@@ -97,7 +103,10 @@ exports.installCertificateVerifyProc = function installCertificateVerifyProc(
       // so an untrusted *and* expired certificate arrives here as -202. Check the
       // validity window ourselves rather than letting the expiry pass unnoticed.
       if (!chain.every(isCurrentlyValid)) {
-        console.error("[CERT] Allowlisted authority presented an out-of-date certificate");
+        if (!warnedOutOfDate) {
+          warnedOutOfDate = true;
+          console.error("[CERT] Allowlisted authority presented an out-of-date certificate");
+        }
         callback(VERIFY_USE_CHROMIUM_RESULT);
         return;
       }
@@ -106,7 +115,10 @@ exports.installCertificateVerifyProc = function installCertificateVerifyProc(
       return;
     }
 
-    console.error("[CERT] Certificate authority not in allowlist for request");
+    if (!warnedNotInAllowlist) {
+      warnedNotInAllowlist = true;
+      console.warn("[CERT] Certificate authority not in allowlist for request");
+    }
     callback(VERIFY_USE_CHROMIUM_RESULT);
   };
 

--- a/app/certificate/index.js
+++ b/app/certificate/index.js
@@ -35,6 +35,119 @@ exports.onAppCertificateError = function onAppCertificateError(arg) {
   }
 };
 
+// net::ERR_CERT_AUTHORITY_INVALID. The only failure we are willing to override,
+// so an expired or revoked certificate is still rejected even when its issuer is
+// on the allowlist.
+const ERR_CERT_AUTHORITY_INVALID = -202;
+
+// Special values accepted by the setCertificateVerifyProc callback.
+const VERIFY_ACCEPT = 0;
+const VERIFY_USE_CHROMIUM_RESULT = -3;
+
+/**
+ * Installs a session-level certificate verify proc so `customCACertsFingerprints`
+ * also applies to connections that never surface a certificate error to a window.
+ *
+ * The `certificate-error` event only fires when a page load reports the error, so
+ * behind a proxy that intercepts every TLS connection the allowlist never got a
+ * chance to act (issue #2762). This proc runs on every server certificate
+ * verification instead.
+ *
+ * Nothing is installed when no fingerprints are configured, so the default
+ * behaviour is untouched. When a fingerprint is configured we still defer to
+ * Chromium for anything that is not an untrusted-authority failure, so this can
+ * only ever accept a certificate the user explicitly allowlisted.
+ *
+ * @param {Object} config - App configuration containing customCACertsFingerprints
+ * @param {Electron.App} app - Electron app, used to catch sessions as they are created
+ * @param {Electron.Session} defaultSession - Session that may already exist
+ */
+exports.installCertificateVerifyProc = function installCertificateVerifyProc(
+  config,
+  app,
+  defaultSession,
+) {
+  const fingerprints = config.customCACertsFingerprints || [];
+  if (fingerprints.length === 0) {
+    return;
+  }
+
+  const verifyProc = (request, callback) => {
+    if (request.verificationResult === "OK") {
+      callback(VERIFY_USE_CHROMIUM_RESULT);
+      return;
+    }
+
+    if (!isUntrustedAuthority(request)) {
+      callback(VERIFY_USE_CHROMIUM_RESULT);
+      return;
+    }
+
+    if (getChainFingerprints(request.certificate).some((fp) => fingerprints.includes(fp))) {
+      console.debug("[CERT] Accepting allowlisted certificate authority");
+      callback(VERIFY_ACCEPT);
+      return;
+    }
+
+    console.error("[CERT] Certificate authority not in allowlist for request");
+    callback(VERIFY_USE_CHROMIUM_RESULT);
+  };
+
+  const applyTo = (targetSession) => {
+    try {
+      targetSession.setCertificateVerifyProc(verifyProc);
+    } catch (error) {
+      console.error("[CERT] Could not install certificate verify proc", {
+        message: error.message,
+      });
+    }
+  };
+
+  if (defaultSession) {
+    applyTo(defaultSession);
+  }
+  // Profile partitions get their own session, so catch them as they appear.
+  app.on("session-created", applyTo);
+
+  console.info("[CERT] Custom CA allowlist active", { count: fingerprints.length });
+};
+
+/**
+ * Whether a failed verification was caused by an untrusted issuing authority.
+ * @param {Object} request - setCertificateVerifyProc request
+ * @returns {boolean}
+ */
+function isUntrustedAuthority(request) {
+  return (
+    request.errorCode === ERR_CERT_AUTHORITY_INVALID ||
+    (typeof request.verificationResult === "string" &&
+      request.verificationResult.includes("CERT_AUTHORITY_INVALID"))
+  );
+}
+
+/**
+ * Collects the fingerprint of every certificate in a presented chain.
+ *
+ * An intercepting proxy often serves an incomplete chain, in which case the root
+ * is not reachable via issuerCert and matching only the root would never succeed.
+ * Every entry is compared against the user's explicit allowlist, so matching any
+ * of them is as deliberate as matching the root.
+ *
+ * @param {Electron.Certificate} cert - Leaf certificate
+ * @returns {string[]} Fingerprints, leaf first
+ */
+function getChainFingerprints(cert) {
+  const fingerprints = [];
+  let current = cert;
+  while (current) {
+    if (current.fingerprint) {
+      fingerprints.push(current.fingerprint);
+    }
+    current = current.issuerCert === current ? null : current.issuerCert;
+  }
+  return fingerprints;
+}
+
 /**
  * Recursively traverses the certificate chain to find the root issuer.
  * This is necessary because certificates can have intermediate CAs,

--- a/app/index.js
+++ b/app/index.js
@@ -715,6 +715,11 @@ async function handleAppReady() {
       clientCertificate.initialize();
     }
 
+    // Custom CA allowlist (issue #2762). Installed before the main window loads
+    // so it covers the very first TLS handshake, and before profile partitions
+    // exist so their sessions are caught by the session-created listener.
+    certificateModule.installCertificateVerifyProc(config, app, session.defaultSession);
+
     await mainAppWindow.onAppReady(appConfig, customBackground, screenSharingService, profilesManager);
 
     // Wire per-profile WebContentsView lifecycle once the main window

--- a/docs-site/docs/certificate.md
+++ b/docs-site/docs/certificate.md
@@ -53,11 +53,12 @@ The practical consequence differs by distribution:
     automatically for every user and no extra step is needed.
 
 :::note
-`customCACertsFingerprints` only applies to certificate errors that surface during a page
-load. Behind a proxy that intercepts every TLS connection, the failure can appear as a
-transport error before that hook runs, in which case the fingerprint allowlist never gets a
-chance to act. Importing the CA into NSS, as below, is the reliable fix for full TLS
-interception.
+`customCACertsFingerprints` is checked on every TLS verification, so it also covers a proxy
+that intercepts every connection. Importing the CA into NSS, as below, is still the stricter
+option: the allowlist accepts the connection outright, which also bypasses Chromium's
+hostname check for it, whereas a CA trusted through NSS keeps every other check in place.
+Prefer the NSS import where you can, and use the allowlist when you cannot modify the trust
+store.
 :::
 
 ### Importing a corporate CA into the NSS database

--- a/tests/unit/certificate.test.js
+++ b/tests/unit/certificate.test.js
@@ -152,12 +152,16 @@ function createHarness(config) {
 }
 
 function createRequest(overrides = {}) {
-	return {
+	const request = {
 		verificationResult: 'CERT_AUTHORITY_INVALID',
 		errorCode: -202,
-		certificate: createCert('AA:BB:CC'),
+		validatedCertificate: createCert('AA:BB:CC'),
 		...overrides,
 	};
+	// The presented chain matches the validated one unless a test sets it apart,
+	// which is what an interception attempt does.
+	request.certificate = request.certificate ?? request.validatedCertificate;
+	return request;
 }
 
 describe('Certificate verify proc - installation', () => {
@@ -182,32 +186,47 @@ describe('Certificate verify proc - verification', () => {
 	it('accepts when an allowlisted fingerprint is in the chain', () => {
 		const { verify } = createHarness({ customCACertsFingerprints: ['ROOT:FP'] });
 		const root = createCert('ROOT:FP');
-		assert.strictEqual(verify(createRequest({ certificate: createCert('LEAF:FP', root) })), 0);
+		assert.strictEqual(verify(createRequest({ validatedCertificate: createCert('LEAF:FP', root) })), 0);
 	});
 
 	it('accepts on a match against an incomplete chain with no reachable root', () => {
 		const { verify } = createHarness({ customCACertsFingerprints: ['LEAF:FP'] });
 		const leafOnly = createCert('LEAF:FP');
 		delete leafOnly.issuerCert;
-		assert.strictEqual(verify(createRequest({ certificate: leafOnly })), 0);
+		assert.strictEqual(verify(createRequest({ validatedCertificate: leafOnly })), 0);
 	});
 
 	it('rejects an expired certificate reported as an authority error', () => {
 		// Chromium ranks CERT_STATUS_AUTHORITY_INVALID above CERT_STATUS_DATE_INVALID,
 		// so an untrusted and expired certificate arrives with errorCode -202.
 		const { verify } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
-		assert.strictEqual(verify(createRequest({ certificate: createExpiredCert('AA:BB:CC') })), -3);
+		assert.strictEqual(verify(createRequest({ validatedCertificate: createExpiredCert('AA:BB:CC') })), -3);
 	});
 
 	it('rejects when an issuer in the chain has expired', () => {
 		const { verify } = createHarness({ customCACertsFingerprints: ['ROOT:FP'] });
 		const expiredRoot = createExpiredCert('ROOT:FP');
-		assert.strictEqual(verify(createRequest({ certificate: createCert('LEAF:FP', expiredRoot) })), -3);
+		assert.strictEqual(verify(createRequest({ validatedCertificate: createCert('LEAF:FP', expiredRoot) })), -3);
 	});
 
 	it('rejects when validity dates are missing and cannot be checked', () => {
 		const { verify } = createHarness({ customCACertsFingerprints: ['BARE:FP'] });
-		assert.strictEqual(verify(createRequest({ certificate: { fingerprint: 'BARE:FP' } })), -3);
+		assert.strictEqual(verify(createRequest({ validatedCertificate: { fingerprint: 'BARE:FP' } })), -3);
+	});
+
+	it('ignores an allowlisted authority appended to the presented chain only', () => {
+		// Electron links request.certificate positionally from the certificates the
+		// server sent, without checking that each one signed the one below. Anyone
+		// able to intercept the connection can append an allowlisted CA's public
+		// certificate to a chain it never issued, so only the chain Chromium built
+		// and signature-checked is trusted here.
+		const { verify } = createHarness({ customCACertsFingerprints: ['ROOT:FP'] });
+		const appendedRoot = createCert('ROOT:FP');
+		const request = createRequest({
+			certificate: createCert('ATTACKER:FP', appendedRoot),
+			validatedCertificate: createCert('ATTACKER:FP'),
+		});
+		assert.strictEqual(verify(request), -3);
 	});
 
 	it('defers to Chromium when no fingerprint matches', () => {

--- a/tests/unit/certificate.test.js
+++ b/tests/unit/certificate.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { onAppCertificateError } = require('../../app/certificate/index');
+const { onAppCertificateError, installCertificateVerifyProc } = require('../../app/certificate/index');
 
 function createCert(fingerprint, issuerCert = null) {
 	const cert = { fingerprint };
@@ -118,6 +118,85 @@ describe('Certificate validation - chain traversal', () => {
 		});
 		onAppCertificateError(arg);
 		assert.strictEqual(getCallbackValue(), true);
+	});
+});
+
+function createHarness(config) {
+	const sessions = [];
+	const listeners = {};
+	const fakeApp = { on: (event, fn) => { listeners[event] = fn; } };
+	const fakeSession = { setCertificateVerifyProc: (fn) => sessions.push(fn) };
+	installCertificateVerifyProc(config, fakeApp, fakeSession);
+	return {
+		sessions,
+		emitSessionCreated: (ses) => listeners['session-created']?.(ses),
+		verify: (request) => {
+			let result = null;
+			sessions[0](request, (value) => { result = value; });
+			return result;
+		},
+	};
+}
+
+function createRequest(overrides = {}) {
+	return {
+		verificationResult: 'CERT_AUTHORITY_INVALID',
+		errorCode: -202,
+		certificate: createCert('AA:BB:CC'),
+		...overrides,
+	};
+}
+
+describe('Certificate verify proc - installation', () => {
+	it('does not install anything when no fingerprints are configured', () => {
+		const { sessions } = createHarness({ customCACertsFingerprints: [] });
+		assert.strictEqual(sessions.length, 0);
+	});
+
+	it('installs on the default session when fingerprints are configured', () => {
+		const { sessions } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		assert.strictEqual(sessions.length, 1);
+	});
+
+	it('installs on sessions created later, such as profile partitions', () => {
+		const harness = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		harness.emitSessionCreated({ setCertificateVerifyProc: (fn) => harness.sessions.push(fn) });
+		assert.strictEqual(harness.sessions.length, 2);
+	});
+});
+
+describe('Certificate verify proc - verification', () => {
+	it('accepts when an allowlisted fingerprint is in the chain', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['ROOT:FP'] });
+		const root = createCert('ROOT:FP');
+		assert.strictEqual(verify(createRequest({ certificate: createCert('LEAF:FP', root) })), 0);
+	});
+
+	it('accepts on a match against an incomplete chain with no reachable root', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['LEAF:FP'] });
+		assert.strictEqual(verify(createRequest({ certificate: { fingerprint: 'LEAF:FP' } })), 0);
+	});
+
+	it('defers to Chromium when no fingerprint matches', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['XX:YY:ZZ'] });
+		assert.strictEqual(verify(createRequest()), -3);
+	});
+
+	it('defers to Chromium when verification already succeeded', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		assert.strictEqual(verify(createRequest({ verificationResult: 'OK', errorCode: 0 })), -3);
+	});
+
+	it('does not accept an expired certificate even when the issuer is allowlisted', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		const request = createRequest({ verificationResult: 'CERT_DATE_INVALID', errorCode: -201 });
+		assert.strictEqual(verify(request), -3);
+	});
+
+	it('does not accept a revoked certificate even when the issuer is allowlisted', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		const request = createRequest({ verificationResult: 'CERT_REVOKED', errorCode: -206 });
+		assert.strictEqual(verify(request), -3);
 	});
 });
 

--- a/tests/unit/certificate.test.js
+++ b/tests/unit/certificate.test.js
@@ -4,9 +4,22 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { onAppCertificateError, installCertificateVerifyProc } = require('../../app/certificate/index');
 
+const NOW_IN_SECONDS = Date.now() / 1000;
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+
 function createCert(fingerprint, issuerCert = null) {
-	const cert = { fingerprint };
+	const cert = {
+		fingerprint,
+		validStart: NOW_IN_SECONDS - ONE_YEAR_IN_SECONDS,
+		validExpiry: NOW_IN_SECONDS + ONE_YEAR_IN_SECONDS,
+	};
 	cert.issuerCert = issuerCert ?? cert; // self-referencing = root
+	return cert;
+}
+
+function createExpiredCert(fingerprint) {
+	const cert = createCert(fingerprint);
+	cert.validExpiry = NOW_IN_SECONDS - 1;
 	return cert;
 }
 
@@ -174,7 +187,27 @@ describe('Certificate verify proc - verification', () => {
 
 	it('accepts on a match against an incomplete chain with no reachable root', () => {
 		const { verify } = createHarness({ customCACertsFingerprints: ['LEAF:FP'] });
-		assert.strictEqual(verify(createRequest({ certificate: { fingerprint: 'LEAF:FP' } })), 0);
+		const leafOnly = createCert('LEAF:FP');
+		delete leafOnly.issuerCert;
+		assert.strictEqual(verify(createRequest({ certificate: leafOnly })), 0);
+	});
+
+	it('rejects an expired certificate reported as an authority error', () => {
+		// Chromium ranks CERT_STATUS_AUTHORITY_INVALID above CERT_STATUS_DATE_INVALID,
+		// so an untrusted and expired certificate arrives with errorCode -202.
+		const { verify } = createHarness({ customCACertsFingerprints: ['AA:BB:CC'] });
+		assert.strictEqual(verify(createRequest({ certificate: createExpiredCert('AA:BB:CC') })), -3);
+	});
+
+	it('rejects when an issuer in the chain has expired', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['ROOT:FP'] });
+		const expiredRoot = createExpiredCert('ROOT:FP');
+		assert.strictEqual(verify(createRequest({ certificate: createCert('LEAF:FP', expiredRoot) })), -3);
+	});
+
+	it('rejects when validity dates are missing and cannot be checked', () => {
+		const { verify } = createHarness({ customCACertsFingerprints: ['BARE:FP'] });
+		assert.strictEqual(verify(createRequest({ certificate: { fingerprint: 'BARE:FP' } })), -3);
 	});
 
 	it('defers to Chromium when no fingerprint matches', () => {


### PR DESCRIPTION
Installs a session-level `setCertificateVerifyProc` so the allowlist also applies to connections that never surface a certificate error to a window, which is why the setting did nothing behind a TLS-inspecting proxy. Nothing is installed when no fingerprints are configured.

A fingerprint match is not enough on its own to accept. Chromium reports only the most serious error, and `CERT_STATUS_AUTHORITY_INVALID` outranks `CERT_STATUS_DATE_INVALID`, so an untrusted *and* expired certificate arrives as `-202`; the validity window of every certificate in the presented chain is checked before accepting. Revoked certificates report `ERR_CERT_REVOKED` and never reach that path.

Known limitation, documented in code and in the certificate docs: accepting overrides Chromium's verification for that connection, including hostname matching, so trusting the CA through the NSS database stays the stricter route.

closes #2777

🤖 Generated with [Claude Code](https://claude.com/claude-code)