### PR TITLE
feat(webauthn): log timeout, phase timings and page aborts

### DIFF
--- a/app/browser/tools/webauthnOverride.js
+++ b/app/browser/tools/webauthnOverride.js
@@ -84,16 +84,14 @@ function init(config, ipcRenderer) {
     // #2719. Wiring the signal through to cancel the call is a behaviour change
     // and belongs with the touch-prompt work, not here.
     const startedAt = Date.now();
+    let onAbort = null;
     if (!options.signal) {
       console.info("[WEBAUTHN] credentials.get() called without an AbortSignal");
     } else if (options.signal.aborted) {
       console.info("[WEBAUTHN] credentials.get() called with an already-aborted signal");
     } else {
-      options.signal.addEventListener(
-        "abort",
-        () => console.info("[WEBAUTHN] Page aborted credentials.get()", { elapsedMs: Date.now() - startedAt }),
-        { once: true },
-      );
+      onAbort = () => console.info("[WEBAUTHN] Page aborted credentials.get()", { elapsedMs: Date.now() - startedAt });
+      options.signal.addEventListener("abort", onAbort, { once: true });
     }
 
     try {
@@ -114,6 +112,11 @@ function init(config, ipcRenderer) {
       console.error("[WEBAUTHN] credentials.get() error:", err.message, { elapsedMs: Date.now() - startedAt });
       if (err instanceof DOMException) throw err;
       throw new DOMException(err.message, "NotAllowedError");
+    } finally {
+      // Scope the listener to the call. Left attached it outlives the ceremony
+      // and would log a stale "Page aborted" if the page aborts the signal
+      // afterwards for unrelated reasons.
+      if (onAbort) options.signal.removeEventListener("abort", onAbort);
     }
   };
 

--- a/app/browser/tools/webauthnOverride.js
+++ b/app/browser/tools/webauthnOverride.js
@@ -78,19 +78,40 @@ function init(config, ipcRenderer) {
 
     console.info("[WEBAUTHN] Intercepting credentials.get()");
 
+    // Observe only, never act on it. Knowing whether the page gives up on a
+    // ceremony (and after how long) is what separates "the user was slow to
+    // touch the key" from "the sign-in failed for an unrelated reason". See
+    // #2719. Wiring the signal through to cancel the call is a behaviour change
+    // and belongs with the touch-prompt work, not here.
+    const startedAt = Date.now();
+    if (!options.signal) {
+      console.info("[WEBAUTHN] credentials.get() called without an AbortSignal");
+    } else if (options.signal.aborted) {
+      console.info("[WEBAUTHN] credentials.get() called with an already-aborted signal");
+    } else {
+      options.signal.addEventListener(
+        "abort",
+        () => console.info("[WEBAUTHN] Page aborted credentials.get()", { elapsedMs: Date.now() - startedAt }),
+        { once: true },
+      );
+    }
+
     try {
       const serialized = serializeGetOptions(options.publicKey);
       const result = await ipcRenderer.invoke("webauthn:get", serialized);
 
       if (!result.success) {
-        console.error("[WEBAUTHN] credentials.get() failed:", result.error);
+        console.error("[WEBAUTHN] credentials.get() failed:", result.error, { elapsedMs: Date.now() - startedAt });
         throw mapError(result.error);
       }
 
-      console.info("[WEBAUTHN] credentials.get() succeeded");
+      console.info("[WEBAUTHN] credentials.get() succeeded", {
+        elapsedMs: Date.now() - startedAt,
+        aborted: options.signal?.aborted ?? false,
+      });
       return reconstructGetResponse(result.data);
     } catch (err) {
-      console.error("[WEBAUTHN] credentials.get() error:", err.message);
+      console.error("[WEBAUTHN] credentials.get() error:", err.message, { elapsedMs: Date.now() - startedAt });
       if (err instanceof DOMException) throw err;
       throw new DOMException(err.message, "NotAllowedError");
     }

--- a/app/webauthn/README.md
+++ b/app/webauthn/README.md
@@ -42,8 +42,8 @@ Enable in `config.json`:
 
 Every ceremony logs a `[WEBAUTHN]` line at each step, so `grep WEBAUTHN` over a session log shows the whole flow. Four fields matter when a sign-in fails but the ceremony itself reports success:
 
-- `timeoutSec` on `Processing request` is how long the login page is prepared to wait. Compare it against `totalMs` below: a ceremony that outlasts it was abandoned by the page, whatever our side reports.
-- `pinMs` and `keyMs` on `Succeeded` split the wall-clock between the user typing a PIN and the key waiting to be touched. A large `keyMs` is someone not realising the key wants a touch, not a slow device, since each call is a fresh process paying the same fixed costs.
+- `timeoutSec` on `Processing request` is how long the login page is prepared to wait. It is in seconds while every other timing here is in milliseconds, so compare it against `totalMs / 1000`: a ceremony that outlasts it was abandoned by the page, whatever our side reports.
+- `pinMs` and `touchMs` on `Succeeded` split the wall-clock between the user typing a PIN and the key waiting to be touched. A large `touchMs` is someone not realising the key wants a touch, not a slow device, since each call is a fresh process paying the same fixed costs. The field is `touchMs` rather than `keyMs` because the log sanitizer redacts any field name containing "key".
 - `elapsedMs` on the renderer's `credentials.get() succeeded` is the same window measured from the page's side, so a gap against `totalMs` is IPC or PIN-window overhead.
 - `aborted` on that line, plus a `Page aborted credentials.get()` line, say whether the page gave up before we answered. `called without an AbortSignal` means the page never offered a way to cancel, so its own timeout is the only limit.
 

--- a/app/webauthn/README.md
+++ b/app/webauthn/README.md
@@ -38,6 +38,17 @@ Enable in `config.json`:
 }
 ```
 
+## Reading a sign-in log
+
+Every ceremony logs a `[WEBAUTHN]` line at each step, so `grep WEBAUTHN` over a session log shows the whole flow. Four fields matter when a sign-in fails but the ceremony itself reports success:
+
+- `timeoutSec` on `Processing request` is how long the login page is prepared to wait. Compare it against `totalMs` below: a ceremony that outlasts it was abandoned by the page, whatever our side reports.
+- `pinMs` and `keyMs` on `Succeeded` split the wall-clock between the user typing a PIN and the key waiting to be touched. A large `keyMs` is someone not realising the key wants a touch, not a slow device, since each call is a fresh process paying the same fixed costs.
+- `elapsedMs` on the renderer's `credentials.get() succeeded` is the same window measured from the page's side, so a gap against `totalMs` is IPC or PIN-window overhead.
+- `aborted` on that line, plus a `Page aborted credentials.get()` line, say whether the page gave up before we answered. `called without an AbortSignal` means the page never offered a way to cancel, so its own timeout is the only limit.
+
+None of these carry credential material: no credential IDs, user handles, challenges, PINs or raw origins.
+
 ## Related
 
 - Browser override: `app/browser/tools/webauthnOverride.js`

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -95,7 +95,21 @@ async function handleWebauthnRequest(operation, event, options) {
     return { success: false, error: "SecurityError: origin not allowed" };
   }
 
-  log.info("[WEBAUTHN] Processing request", { op: operation, originClass: log.classifyOrigin(origin) });
+  // timeoutSec is the timeout the relying party asked for. It is the number that
+  // tells us whether a slow ceremony (PIN entry plus waiting for the touch) can
+  // realistically outlast what the page is prepared to wait for. See #2719.
+  log.info("[WEBAUTHN] Processing request", {
+    op: operation,
+    originClass: log.classifyOrigin(origin),
+    timeoutSec: options?.timeout ?? null,
+  });
+
+  // Phase timings, so a log shows how the wall-clock split between the user
+  // typing a PIN and the key waiting to be touched, rather than leaving it to be
+  // inferred from timestamps.
+  const startedAt = Date.now();
+  let pinMs = null;
+  let keyMs = null;
 
   try {
     // Determine if UV is required (PIN will be needed)
@@ -106,17 +120,32 @@ async function handleWebauthnRequest(operation, event, options) {
     let preCollectedPin = null;
     if (uvRequired) {
       log.info("[WEBAUTHN] userVerification=required, collecting PIN upfront");
+      const pinStartedAt = Date.now();
       preCollectedPin = await collectPin(event.sender);
+      pinMs = Date.now() - pinStartedAt;
       log.info("[WEBAUTHN] PIN collected, proceeding with fido2-tools");
     }
 
-    const result = operation === "create"
-      ? await fido2Backend.createCredential({ ...options, origin, preCollectedPin })
-      : await fido2Backend.getAssertion({ ...options, origin, preCollectedPin });
-    log.info("[WEBAUTHN] Succeeded", { op: operation });
-    return { success: true, data: result };
+    const keyStartedAt = Date.now();
+    try {
+      const result = operation === "create"
+        ? await fido2Backend.createCredential({ ...options, origin, preCollectedPin })
+        : await fido2Backend.getAssertion({ ...options, origin, preCollectedPin });
+      keyMs = Date.now() - keyStartedAt;
+      log.info("[WEBAUTHN] Succeeded", { op: operation, totalMs: Date.now() - startedAt, pinMs, keyMs });
+      return { success: true, data: result };
+    } catch (err) {
+      keyMs = Date.now() - keyStartedAt;
+      throw err;
+    }
   } catch (err) {
-    log.error("[WEBAUTHN] Failed", { op: operation, errClass: log.classifyError(err) });
+    log.error("[WEBAUTHN] Failed", {
+      op: operation,
+      errClass: log.classifyError(err),
+      totalMs: Date.now() - startedAt,
+      pinMs,
+      keyMs,
+    });
     return { success: false, error: err.message };
   }
 }

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -108,8 +108,10 @@ async function handleWebauthnRequest(operation, event, options) {
   // typing a PIN and the key waiting to be touched, rather than leaving it to be
   // inferred from timestamps.
   const startedAt = Date.now();
+  // Named touchMs, not keyMs: the log sanitizer redacts any field whose name
+  // contains "key", which would blank the one number this logging exists for.
   let pinMs = null;
-  let keyMs = null;
+  let touchMs = null;
 
   try {
     // Determine if UV is required (PIN will be needed)
@@ -126,16 +128,16 @@ async function handleWebauthnRequest(operation, event, options) {
       log.info("[WEBAUTHN] PIN collected, proceeding with fido2-tools");
     }
 
-    const keyStartedAt = Date.now();
+    const touchStartedAt = Date.now();
     try {
       const result = operation === "create"
         ? await fido2Backend.createCredential({ ...options, origin, preCollectedPin })
         : await fido2Backend.getAssertion({ ...options, origin, preCollectedPin });
-      keyMs = Date.now() - keyStartedAt;
-      log.info("[WEBAUTHN] Succeeded", { op: operation, totalMs: Date.now() - startedAt, pinMs, keyMs });
+      touchMs = Date.now() - touchStartedAt;
+      log.info("[WEBAUTHN] Succeeded", { op: operation, totalMs: Date.now() - startedAt, pinMs, touchMs });
       return { success: true, data: result };
     } catch (err) {
-      keyMs = Date.now() - keyStartedAt;
+      touchMs = Date.now() - touchStartedAt;
       throw err;
     }
   } catch (err) {
@@ -144,7 +146,7 @@ async function handleWebauthnRequest(operation, event, options) {
       errClass: log.classifyError(err),
       totalMs: Date.now() - startedAt,
       pinMs,
-      keyMs,
+      touchMs,
     });
     return { success: false, error: err.message };
   }


### PR DESCRIPTION
Adds diagnostic logging to the WebAuthn path so #2719 can be diagnosed from a reporter's log. Observability only, no behaviour change.

#2719 fails on the first sign-in attempt and passes on an automatic retry, with both ceremonies logging `Succeeded` and differing only in duration (9.5s vs 1.6s). The logs cannot currently show whether the login page gave up waiting, which is what separates a slow touch from an unrelated failure.

New fields: `timeoutSec` on `Processing request` (what the relying party asked for, the number that says whether a slow ceremony can outlast the page's patience), `pinMs` and `keyMs` on `Succeeded` (splits PIN entry from waiting for the touch), and on the renderer side `elapsedMs`, `aborted`, and a line when the page aborts `credentials.get()` or never supplies an `AbortSignal`. No credential material is logged.

Wiring the abort signal through to actually cancel the call is a behaviour change and belongs with the touch-prompt work in #2779, not here.

Refs: #2719
