### PR TITLE
fix(paste): restore File.path on pasted files so Teams uploads accept them

### DIFF
--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -5,6 +5,13 @@ const { ipcRenderer } = require("electron");
 // Restore it via webUtils.getPathForFile before Teams's drop handler reads it,
 // scoped to Teams hosts so the SSO/auth pages this window also loads can't read
 // local paths off dropped files.
+//
+// The same stripping hits pasted files: when a user copies an image file
+// in their file manager and pastes into the compose box, Chromium surfaces it
+// as a File on the paste event's clipboardData, and Teams uploads by path — so
+// the paste fails the same way drag-drop used to. Restore the path on a
+// capture-phase paste listener too. Raw image-bit paste (screenshots) arrives
+// as a Blob with no path and is unaffected.
 try {
   const { webUtils } = require("electron");
   const TEAMS_HOSTS = ["teams.cloud.microsoft", "teams.microsoft.com", "teams.live.com"];
@@ -19,34 +26,49 @@ try {
           !hostname.slice(0, -(domain.length + 1)).includes(".")),
     );
   };
+  // Restore the non-standard `File.path` on every File in a FileList, in place.
+  // No-op for blob-backed files (screenshots) since webUtils only resolves a
+  // path for files that originated from the OS file list; those are left as-is.
+  const restoreFilePaths = (files) => {
+    if (!files?.length) {
+      return;
+    }
+    for (const file of files) {
+      if (file.path) {
+        continue;
+      }
+      try {
+        const path = webUtils.getPathForFile(file);
+        if (path) {
+          Object.defineProperty(file, "path", {
+            value: path,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
+        }
+      } catch {
+        // leave the file untouched if the path can't be resolved
+      }
+    }
+  };
   globalThis.addEventListener(
     "drop",
     (event) => {
       if (!isTeamsHost(globalThis.location.hostname)) {
         return;
       }
-      const files = event.dataTransfer?.files;
-      if (!files?.length) {
+      restoreFilePaths(event.dataTransfer?.files);
+    },
+    true,
+  );
+  globalThis.addEventListener(
+    "paste",
+    (event) => {
+      if (!isTeamsHost(globalThis.location.hostname)) {
         return;
       }
-      for (const file of files) {
-        if (file.path) {
-          continue;
-        }
-        try {
-          const path = webUtils.getPathForFile(file);
-          if (path) {
-            Object.defineProperty(file, "path", {
-              value: path,
-              writable: true,
-              enumerable: true,
-              configurable: true,
-            });
-          }
-        } catch {
-          // leave the file untouched if the path can't be resolved
-        }
-      }
+      restoreFilePaths(event.clipboardData?.files);
     },
     true,
   );


### PR DESCRIPTION
## Summary

Pasting an image file copied from a file manager into the Teams compose box fails (Teams reports *"File is missing data"* or silently does nothing) — the same symptom drag-drop had before #2679.

PR #2679 / issue #2677 fixed this for **drag-drop** by restoring the non-standard `File.path` (which Electron removed) via `webUtils.getPathForFile(file)` in a capture-phase `drop` listener in `app/browser/preload.js`. That handler only covers `drop` events. Pasting a copied *file* hits the identical failure because Teams uploads by native path and the paste-derived `File` has no path.

## Change

Extends the existing handler to also run on a capture-phase `paste` event, restoring `File.path` on `event.clipboardData.files` for Teams hosts. The path-resolution logic is shared with the drop path via a `restoreFilePaths(files)` helper (no behaviour change to the drop path — it's refactored to call the same helper).

Scoped to the same Teams-host allowlist already used by the drop handler, so SSO/auth pages loaded in the same window can't read local paths off pasted files.

## What is and isn't affected

- **Paste a copied image file** (from file manager) → now gets `File.path` restored; should upload like a drag-drop.
- **Paste a screenshot** (raw image bits) → unaffected. It arrives as a Blob with no path; `webUtils.getPathForFile` is a no-op for it (wrapped in try/catch).
- **Drag-drop** → unchanged behaviour (refactored to shared helper).

## Caveat

`webUtils.getPathForFile()` is documented for drop-derived `File` objects; whether it resolves a path for paste-derived `File` objects may depend on platform/clipboard format. The fix is low-risk: the existing `try/catch` leaves the file untouched if a path can't be resolved, so non-file paste paths are unaffected. I could not exercise this end-to-end locally (no `node_modules` in this checkout); CI lint will run, and real-world confirmation requires pasting a copied image file in a running app.

## Testing

There is no e2e test for this in the PR — simulating a clipboard file paste with a real on-disk path in Playwright is non-trivial and `webUtils.getPathForFile` behaviour for paste-derived files is uncertain. Happy to add one if the maintainer has a preferred approach. `node --check` passes on the edited file.

Related: #2677, #2679.