### PR TITLE
fix(tray): clear dock/tray badge when the main window regains focus

### DIFF
--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -14,6 +14,37 @@ class TrayIconRenderer {
       "unread-count",
       this.updateActivityCount.bind(this),
     );
+
+    // Main process requests a forced badge reset when the window regains focus
+    // (config.clearBadgeOnFocus). Routed through the renderer so it takes part in
+    // the update sequence: bumping the sequence discards any non-zero render that
+    // is still awaiting the canvas, which would otherwise land after the clear and
+    // re-stick the badge.
+    this.ipcRenderer.on("clear-badge-on-focus", () => this.clearBadge());
+  }
+
+  // Force the badge (and tray overlay) back to 0. Distinct from updateActivityCount
+  // because this is a UI reset, not an unread-count change: it must always run even
+  // if the last requested count was already 0, and it must invalidate in-flight
+  // renders from a prior non-zero count.
+  clearBadge() {
+    this.#lastRequestedCount = 0;
+    const sequence = ++this.#updateSequence;
+    console.debug("[TRAY_DIAG] clearBadge on focus", { sequence });
+
+    this.ipcRenderer.send("tray-update", {
+      icon: null,
+      flash: false,
+      count: 0,
+    });
+
+    if (!this.config.disableBadgeCount) {
+      this.ipcRenderer
+        .invoke("set-badge-count", 0)
+        .catch((err) =>
+          console.error("[TRAY_DIAG] Failed to clear badge count:", err.message)
+        );
+    }
   }
 
   async updateActivityCount(event) {

--- a/app/config/options.js
+++ b/app/config/options.js
@@ -413,6 +413,17 @@ module.exports = {
         type: "boolean",
         applyMode: "live",
       },
+      clearBadgeOnFocus: {
+        default: true,
+        describe:
+          "Reset the tray/dock badge to 0 when the main window regains focus " +
+          "(after it has lost focus at least once). The badge otherwise mirrors " +
+          "the unread count in Teams' page title, which can lag or disagree with " +
+          "what you have actually read (Activity feed, muted channels, multi-device " +
+          "sync). Clear-on-focus matches the dock-indicator behaviour of Slack/Discord.",
+        type: "boolean",
+        applyMode: "live",
+      },
       disableGlobalShortcuts: {
         default: [],
         describe:

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -40,6 +40,10 @@ let profilesManagerRef = null;
 let aboutBlankRequestCount = 0;
 let config;
 let window = null;
+// Tracks whether the main window has lost focus at least once since launch, so
+// the clear-badge-on-focus reset (config.clearBadgeOnFocus) only fires on a real
+// return-to-app, not on the initial window show.
+let mainWindowHasBlurred = false;
 let appConfig = null;
 let customBackgroundService = null;
 let streamSelector;
@@ -1288,6 +1292,24 @@ function addEventHandlers() {
   });
 
   window.on("page-title-updated", onPageTitleUpdated);
+  // Reset the tray/dock badge when the user returns to the app. Teams' page-title
+  // unread count (the source of the badge) can lag or disagree with what the user
+  // has actually read; clearing on focus matches the dock-indicator behaviour of
+  // Slack/Discord. Skip the launch focus by requiring a prior blur. The renderer
+  // participates in the update sequence so an in-flight non-zero render cannot
+  // re-stick the badge afterwards.
+  window.on("blur", () => {
+    mainWindowHasBlurred = true;
+  });
+  window.on("focus", () => {
+    if (
+      mainWindowHasBlurred &&
+      config?.clearBadgeOnFocus &&
+      !config?.disableBadgeCount
+    ) {
+      window.webContents.send("clear-badge-on-focus");
+    }
+  });
   window.webContents.setWindowOpenHandler(onNewWindow);
   window.webContents.session.webRequest.onBeforeRequest(
     { urls: ["https://*/*"] },

--- a/app/security/ipcValidator.js
+++ b/app/security/ipcValidator.js
@@ -48,6 +48,10 @@ const allowedChannels = new Set([
   'set-badge-count',
   'tray-update',
   'dock-icon-update',
+  // main → renderer only (webContents.send); not gated by this validator,
+  // listed here so the allowlist stays authoritative per CLAUDE.md. Sent when the
+  // main window regains focus (config.clearBadgeOnFocus) to reset the badge.
+  'clear-badge-on-focus',
 
   // Call management (sorted alphabetically)
   'call-connected',


### PR DESCRIPTION
## Problem

The dock/tray badge can stay stuck at a stale unread count even after the user has read everything — a recurrence of the symptom reported in #2620.

The badge mirrors the unread count in Teams' page title:

```
Teams document.title "(6) …"
  → mutationTitle.js ^\((\d+)\) → 6
  → trayIconRenderer → set-badge-count IPC
  → app.setBadgeCount(6)  (Linux dock + tray overlay)
```

PR #2643 (shipped in v2.12.0) fixed the renderer-side race that left the badge stuck after reading. That fix is correct and deployed. But the **title count itself** can still lag or disagree with what the user has actually read:

- Teams counts Activity-feed items, @mentions, and muted/hidden-channel messages the user may not consider "unread".
- Multi-device sync can leave the desktop web client's title count stale after reading on mobile.

So the wrapper faithfully mirrors a count Teams hasn't dropped, and the badge stays at e.g. 6 after the user cleared everything. The wrapper is "correct" relative to the title, but the title is wrong from the user's point of view.

## Fix

Reset the badge to 0 when the main window **regains focus** after having lost it at least once — the conventional dock-indicator behaviour of Slack/Discord: switch away and come back, the indicator clears; a new message re-arms it via the title as before.

New config option `clearBadgeOnFocus` (default `true`, `applyMode: "live"`).

### Why the clear is routed through the renderer

The clear is sent to `trayIconRenderer.clearBadge()` via a new main→renderer `clear-badge-on-focus` channel rather than calling `app.setBadgeCount(0)` directly from the main process. This makes the clear participate in the renderer's update sequence (#2643): bumping `#updateSequence` discards any non-zero render still awaiting the canvas, which would otherwise land after the clear and re-stick the badge.

### Launch focus

The first focus is skipped by requiring a prior `blur` (`mainWindowHasBlurred`), so the unread count is still shown on a fresh launch. The clear is also gated by the existing `disableBadgeCount` flag.

## Changes

- `app/config/options.js` — new `clearBadgeOnFocus` option (default `true`).
- `app/mainAppWindow/index.js` — `blur`/`focus` listeners on the main window; sends `clear-badge-on-focus` to the renderer.
- `app/browser/tools/trayIconRenderer.js` — `clearBadge()` method (sequence-bumped reset) + `clear-badge-on-focus` listener.
- `app/security/ipcValidator.js` — `clear-badge-on-focus` added to the allowlist (main→renderer, listed for an authoritative allowlist per CLAUDE.md).

## Testing

- `npm run lint` ✅
- No new `ipcMain.handle`/`on` registrations, so `ipc-api-generated.md` is unchanged.

Manual verification still wanted: confirm that on focus-after-blur the dock badge and tray overlay reset to 0, that new incoming messages re-arm the count, and that the count is preserved on launch.

Relates to #2620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)