### PR TITLE
fix(sonar): exclude declarative config schema from duplication checks

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,26 @@
 # SonarCloud Automatic Analysis configuration.
 # Spikes are throwaway investigation code, never shipped; keep them out of analysis.
 sonar.exclusions=testing/spikes/**
+
+# Copy-paste detection exclusions.
+#
+# Both files are declarative data tables rather than logic: one entry per config
+# key, one per language code. SonarJS normalises string literals before matching,
+# so every schema leaf
+#
+#   "key": { type: "...", describe: "..." },
+#
+# tokenises identically whatever its key, type or description text. Any run of
+# consecutive leaves therefore matches any other run in the file, which is why
+# options.js carries 47 duplicated lines (the media block against the auth block)
+# with nothing actually duplicated. The schema cannot be deduplicated away:
+# config validation and the generated docs both need one leaf per key.
+#
+# The practical cost is that every new config option pushes part of that
+# pre-existing match into the new-code window and fails the duplication gate on
+# an unrelated PR (#2761 added five auth.webLogin keys and inherited 25 lines).
+#
+# app/spellCheckProvider/codes.js was already excluded via the SonarCloud project
+# settings UI for the same reason; it is restated here so this file is the single
+# source of truth and a file-level value cannot silently drop it.
+sonar.cpd.exclusions=app/config/options.js,app/spellCheckProvider/codes.js


### PR DESCRIPTION
Excludes `app/config/options.js` from SonarCloud copy-paste detection. SonarJS normalises string literals, so every `"key": { type, describe }` schema leaf tokenises identically and the `media` fields run matches the `auth` fields run: 47 duplicated lines on main with nothing actually duplicated, and every new config option pushes part of that into the new-code window and fails the gate on an unrelated PR (#2761 inherited 25 lines).

Reviewer caveat: this suppresses a quality signal rather than fixing code, which is the right call for a declarative schema that needs one leaf per key for validation and doc generation, and matches the existing exclusion of `app/spellCheckProvider/codes.js` (previously set in the project settings UI, now restated in the file so the repo is the single source of truth).

Verification once merged: `app/config/options.js` should drop from 47 `duplicated_lines` to 0.
