### PR TITLE
fix(ui): point dialog placeholders at teams.cloud.microsoft

### DIFF
--- a/app/joinMeetingDialog/joinMeeting.html
+++ b/app/joinMeetingDialog/joinMeeting.html
@@ -11,7 +11,7 @@
     <div class="container">
         <h2>Join Meeting</h2>
         <p>Paste a Teams meeting URL:</p>
-        <input type="text" id="url-input" aria-label="Teams meeting URL" placeholder="https://teams.microsoft.com/l/meetup-join/..." autofocus>
+        <input type="text" id="url-input" aria-label="Teams meeting URL" placeholder="https://teams.cloud.microsoft/l/meetup-join/..." autofocus>
         <div class="error" id="error-message"></div>
         <div class="buttons">
             <button id="cancel-btn" class="secondary">Cancel</button>

--- a/app/profileDialogs/addProfile/addProfile.html
+++ b/app/profileDialogs/addProfile/addProfile.html
@@ -16,7 +16,7 @@
     <input type="text" id="name-input" maxlength="64" autofocus required>
 
     <label for="url-input">Custom Teams URL <span class="hint">(optional)</span></label>
-    <input type="text" id="url-input" maxlength="2048" placeholder="https://teams.microsoft.com">
+    <input type="text" id="url-input" maxlength="2048" placeholder="https://teams.cloud.microsoft">
 
     <div class="row">
       <div class="row-item">


### PR DESCRIPTION
The Add Profile and Join Meeting dialogs still suggested the old `teams.microsoft.com` host. A profile URL typed from that placeholder is persisted verbatim and wins over our default, pinning that profile to the old host.

Surfaced while triaging #2796.