### PR TITLE
feat(auth): pre-fill Microsoft web sign-in credentials (#2761)

### DIFF
--- a/docs-site/docs/development/module-index.md
+++ b/docs-site/docs/development/module-index.md
@@ -59,6 +59,7 @@ OS-level integrations and platform-specific functionality.
 |--------|------|---------|---------------|
 | **Idle Monitor** | `app/idle/` | System idle state monitoring & status correlation | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/idle/README.md) |
 | **Login** | `app/login/` | Authentication and login flow management | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/login/README.md) |
+| **SSO Password Pre-fill** | `app/ssoPasswordPrefill/` | Opt-in pre-fill of the Microsoft/federated **web** sign-in form: account, password from a command, optional auto-advance and MFA method ([#2794](https://github.com/IsmaelMartinez/teams-for-linux/issues/2794)). Distinct from `app/login/`, which drives the native HTTP Basic/NTLM dialog. | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/ssoPasswordPrefill/README.md) |
 | **Menus** | `app/menus/` | Application menu bar and context menus | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/menus/README.md) |
 | **Spell Check Provider** | `app/spellCheckProvider/` | Text spelling correction integration | [README](https://github.com/IsmaelMartinez/teams-for-linux/blob/main/app/spellCheckProvider/README.md) |
 

--- a/docs-site/docs/development/plan/roadmap.md
+++ b/docs-site/docs/development/plan/roadmap.md
@@ -42,6 +42,7 @@ Phase 2 work depending on a user trigger.
 
 - **Quick Chat Access** ([#2109](https://github.com/IsmaelMartinez/teams-for-linux/issues/2109), shipped v2.7.4): notification click-to-chat, recent contacts cache, favorites list if requested.
 - **Smartcard PIN Dialog** ([#2639](https://github.com/IsmaelMartinez/teams-for-linux/issues/2639), merged in [#2659](https://github.com/IsmaelMartinez/teams-for-linux/pull/2659), opt-in via `auth.clientCertificate.pinDialog.enabled`): WebAuthn PIN dialog migration onto the shared secure prompt, FIDO2 touch prompt ([#2631](https://github.com/IsmaelMartinez/teams-for-linux/issues/2631)) if requested.
+- **SSO Web Sign-in Pre-fill** ([#2794](https://github.com/IsmaelMartinez/teams-for-linux/issues/2794), merged in [#2761](https://github.com/IsmaelMartinez/teams-for-linux/pull/2761), opt-in via `auth.webLogin.*`): account and password pre-fill on the Microsoft/federated web login form, with optional auto-advance and MFA method selection. Broader host coverage and passkey-aware flows only if requested.
 - **Graph API Enhanced Features** ([research](../research/graph-api-integration-research.md)): calendar sync, mail preview notifications. Presence endpoint returns 403 because the Teams token lacks `Presence.Read` scope.
 
 ---


### PR DESCRIPTION
Adds the missing `app/ssoPasswordPrefill/` entry to the module index and records the feature on the roadmap.

The conventional-commit title is deliberate: #2761 landed with the squash title `Feat/sso web login password prefill`, which release-please could not parse, so the feature was dropped from the changelog entirely. Squashing this restores the entry. The diff itself is documentation only.

Refs #2794