### PR TITLE
fix(notifications): load sender avatars for electron notifications

### DIFF
--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -145,20 +145,19 @@ class NotificationService {
     const session = win?.webContents?.session;
     if (!session?.fetch) return null;
 
-    return this.#loadRemoteIcon(session, url, pageUrl.origin);
+    return this.#loadRemoteIcon(session, url);
   }
 
-  async #loadRemoteIcon(session, url, origin) {
+  async #loadRemoteIcon(session, url) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), ICON_FETCH_TIMEOUT_MS);
     try {
       const response = await session.fetch(url.href, {
         credentials: "include",
+        redirect: "error",
         signal: controller.signal,
       });
       if (!response.ok) return null;
-      const responseUrl = this.#parseHttpsUrl(response.url);
-      if (!responseUrl || responseUrl.origin !== origin) return null;
 
       const declaredSize = Number(response.headers.get("content-length"));
       if (declaredSize > MAX_ICON_BYTES) return null;

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -2,7 +2,7 @@ const { Notification, nativeImage, ipcMain } = require("electron");
 const crypto = require("node:crypto");
 const path = require("node:path");
 
-const ICON_FETCH_TIMEOUT_MS = 3000;
+const ICON_FETCH_TIMEOUT_MS = 1000;
 const MAX_ICON_BYTES = 5 * 1024 * 1024;
 
 const USER_STATUS = {
@@ -68,7 +68,7 @@ class NotificationService {
     });
 
     try {
-      const iconPromise = this.#loadIcon(options.icon);
+      const iconPromise = this.#loadIcon(options.icon).catch(() => null);
 
       // Play notification sound if configured (await to catch any errors)
       await this.#playNotificationSound({
@@ -137,17 +137,18 @@ class NotificationService {
       return this.#nonEmptyImage(nativeImage.createFromDataURL(icon));
     }
 
-    const url = this.#parseHttpsUrl(icon);
-    if (!url) return null;
-
     const win = this.#mainWindow.getWindow();
+    const url = this.#parseHttpsUrl(icon);
+    const pageUrl = this.#parseHttpsUrl(win?.webContents?.getURL?.());
+    if (!url || !pageUrl || url.origin !== pageUrl.origin) return null;
+
     const session = win?.webContents?.session;
     if (!session?.fetch) return null;
 
-    return this.#loadRemoteIcon(session, url);
+    return this.#loadRemoteIcon(session, url, pageUrl.origin);
   }
 
-  async #loadRemoteIcon(session, url) {
+  async #loadRemoteIcon(session, url, origin) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), ICON_FETCH_TIMEOUT_MS);
     try {
@@ -156,7 +157,8 @@ class NotificationService {
         signal: controller.signal,
       });
       if (!response.ok) return null;
-      if (!this.#parseHttpsUrl(response.url)) return null;
+      const responseUrl = this.#parseHttpsUrl(response.url);
+      if (!responseUrl || responseUrl.origin !== origin) return null;
 
       const declaredSize = Number(response.headers.get("content-length"));
       if (declaredSize > MAX_ICON_BYTES) return null;

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -132,22 +132,20 @@ class NotificationService {
     if (typeof icon !== "string" || !icon) return null;
 
     if (icon.startsWith("data:")) {
-      const image = nativeImage.createFromDataURL(icon);
-      return image.isEmpty() ? null : image;
+      return this.#nonEmptyImage(nativeImage.createFromDataURL(icon));
     }
 
-    let url;
-    try {
-      url = new URL(icon);
-    } catch {
-      return null;
-    }
-    if (url.protocol !== "https:") return null;
+    const url = this.#parseHttpsUrl(icon);
+    if (!url) return null;
 
     const win = this.#mainWindow.getWindow();
     const session = win?.webContents?.session;
     if (!session?.fetch) return null;
 
+    return this.#loadRemoteIcon(session, url);
+  }
+
+  async #loadRemoteIcon(session, url) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), ICON_FETCH_TIMEOUT_MS);
     try {
@@ -156,42 +154,53 @@ class NotificationService {
         signal: controller.signal,
       });
       if (!response.ok) return null;
-
-      let responseUrl;
-      try {
-        responseUrl = new URL(response.url);
-      } catch {
-        return null;
-      }
-      if (responseUrl.protocol !== "https:") return null;
+      if (!this.#parseHttpsUrl(response.url)) return null;
 
       const declaredSize = Number(response.headers.get("content-length"));
       if (declaredSize > MAX_ICON_BYTES) return null;
 
-      const reader = response.body?.getReader();
-      if (!reader) return null;
+      const bytes = await this.#readIconBody(response.body);
+      if (!bytes) return null;
 
-      const chunks = [];
-      let size = 0;
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        size += value.byteLength;
-        if (size > MAX_ICON_BYTES) {
-          await reader.cancel();
-          return null;
-        }
-        chunks.push(Buffer.from(value));
-      }
-
-      const image = nativeImage.createFromBuffer(Buffer.concat(chunks, size));
-      return image.isEmpty() ? null : image;
+      return this.#nonEmptyImage(nativeImage.createFromBuffer(bytes));
     } catch {
       console.warn("[NOTIFICATIONS] Could not load remote notification icon");
       return null;
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  async #readIconBody(body) {
+    const reader = body?.getReader();
+    if (!reader) return null;
+
+    const chunks = [];
+    let size = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return Buffer.concat(chunks, size);
+
+      size += value.byteLength;
+      if (size > MAX_ICON_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(Buffer.from(value));
+    }
+  }
+
+  #parseHttpsUrl(value) {
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  #nonEmptyImage(image) {
+    return image.isEmpty() ? null : image;
   }
 
   async #playNotificationSound(options) {

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -68,12 +68,15 @@ class NotificationService {
     });
 
     try {
+      const iconPromise = this.#loadIcon(options.icon);
+
       // Play notification sound if configured (await to catch any errors)
       await this.#playNotificationSound({
         type: options.type,
         audio: "default",
       });
 
+      const icon = await iconPromise;
       const notificationConfig = {
         title: options.title,
         body: options.body,
@@ -81,7 +84,6 @@ class NotificationService {
         timeoutType: options.timeoutType === "never" ? "never" : "default",
       };
 
-      const icon = await this.#loadIcon(options.icon);
       if (icon) notificationConfig.icon = icon;
 
       const notification = new Notification(notificationConfig);

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -132,7 +132,8 @@ class NotificationService {
     if (typeof icon !== "string" || !icon) return null;
 
     if (icon.startsWith("data:")) {
-      return nativeImage.createFromDataURL(icon);
+      const image = nativeImage.createFromDataURL(icon);
+      return image.isEmpty() ? null : image;
     }
 
     let url;
@@ -156,6 +157,14 @@ class NotificationService {
       });
       if (!response.ok) return null;
 
+      let responseUrl;
+      try {
+        responseUrl = new URL(response.url);
+      } catch {
+        return null;
+      }
+      if (responseUrl.protocol !== "https:") return null;
+
       const declaredSize = Number(response.headers.get("content-length"));
       if (declaredSize > MAX_ICON_BYTES) return null;
 
@@ -175,7 +184,8 @@ class NotificationService {
         chunks.push(Buffer.from(value));
       }
 
-      return nativeImage.createFromBuffer(Buffer.concat(chunks, size));
+      const image = nativeImage.createFromBuffer(Buffer.concat(chunks, size));
+      return image.isEmpty() ? null : image;
     } catch {
       console.warn("[NOTIFICATIONS] Could not load remote notification icon");
       return null;

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -2,6 +2,9 @@ const { Notification, nativeImage, ipcMain } = require("electron");
 const crypto = require("node:crypto");
 const path = require("node:path");
 
+const ICON_FETCH_TIMEOUT_MS = 3000;
+const MAX_ICON_BYTES = 5 * 1024 * 1024;
+
 const USER_STATUS = {
   UNKNOWN: -1,
   AVAILABLE: 1,
@@ -78,10 +81,8 @@ class NotificationService {
         timeoutType: options.timeoutType === "never" ? "never" : "default",
       };
 
-      // Only add icon if provided to avoid errors with null/undefined
-      if (options.icon) {
-        notificationConfig.icon = nativeImage.createFromDataURL(options.icon);
-      }
+      const icon = await this.#loadIcon(options.icon);
+      if (icon) notificationConfig.icon = icon;
 
       const notification = new Notification(notificationConfig);
 
@@ -124,6 +125,62 @@ class NotificationService {
         elapsedMs: Date.now() - startTime,
         suggestion: "Check if notification permissions are granted or icon data is valid"
       });
+    }
+  }
+
+  async #loadIcon(icon) {
+    if (typeof icon !== "string" || !icon) return null;
+
+    if (icon.startsWith("data:")) {
+      return nativeImage.createFromDataURL(icon);
+    }
+
+    let url;
+    try {
+      url = new URL(icon);
+    } catch {
+      return null;
+    }
+    if (url.protocol !== "https:") return null;
+
+    const win = this.#mainWindow.getWindow();
+    const session = win?.webContents?.session;
+    if (!session?.fetch) return null;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ICON_FETCH_TIMEOUT_MS);
+    try {
+      const response = await session.fetch(url.href, {
+        credentials: "include",
+        signal: controller.signal,
+      });
+      if (!response.ok) return null;
+
+      const declaredSize = Number(response.headers.get("content-length"));
+      if (declaredSize > MAX_ICON_BYTES) return null;
+
+      const reader = response.body?.getReader();
+      if (!reader) return null;
+
+      const chunks = [];
+      let size = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > MAX_ICON_BYTES) {
+          await reader.cancel();
+          return null;
+        }
+        chunks.push(Buffer.from(value));
+      }
+
+      return nativeImage.createFromBuffer(Buffer.concat(chunks, size));
+    } catch {
+      console.warn("[NOTIFICATIONS] Could not load remote notification icon");
+      return null;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -431,7 +431,7 @@ Replace `<your-chrome-version>` with the Chrome version Teams for Linux reports.
     }
     ```
 
-   Known caveat: on the `electron` path, notifications currently render without the sender avatar. The `web` path gets Chromium to fetch the icon URL automatically; the `electron` path expects a data URL. This is tracked as a follow-up.
+   The `electron` path fetches sender avatars through the authenticated Teams session. If an avatar cannot be loaded, the notification still appears without it.
 
 **Related GitHub Issues:** [#2411](https://github.com/IsmaelMartinez/teams-for-linux/issues/2411)
 

--- a/tests/unit/notificationService.test.js
+++ b/tests/unit/notificationService.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+
+const electronPath = require.resolve('electron');
+const servicePath = require.resolve('../../app/notifications/service');
+
+let handlers;
+let notifications;
+let dataUrls;
+let imageBuffers;
+
+function installElectronMock() {
+	handlers = new Map();
+	notifications = [];
+	dataUrls = [];
+	imageBuffers = [];
+
+	class MockNotification extends EventEmitter {
+		constructor(options) {
+			super();
+			this.options = options;
+			this.shown = false;
+			notifications.push(this);
+		}
+
+		show() {
+			this.shown = true;
+		}
+	}
+
+	require.cache[electronPath] = {
+		id: electronPath,
+		filename: electronPath,
+		loaded: true,
+		exports: {
+			Notification: MockNotification,
+			ipcMain: {
+				handle: (channel, handler) => handlers.set(channel, handler),
+			},
+			nativeImage: {
+				createFromDataURL: (url) => {
+					dataUrls.push(url);
+					return { source: 'data-url' };
+				},
+				createFromBuffer: (buffer) => {
+					imageBuffers.push(buffer);
+					return { source: 'buffer' };
+				},
+			},
+		},
+	};
+
+	delete require.cache[servicePath];
+}
+
+function cleanupElectronMock() {
+	delete require.cache[electronPath];
+	delete require.cache[servicePath];
+}
+
+function responseWith(bytes) {
+	let sent = false;
+	return {
+		ok: true,
+		headers: { get: () => String(bytes.length) },
+		body: {
+			getReader: () => ({
+				read: async () => {
+					if (sent) return { done: true };
+					sent = true;
+					return { done: false, value: bytes };
+				},
+				cancel: async () => {},
+			}),
+		},
+	};
+}
+
+function makeService(fetch) {
+	const window = {
+		webContents: {
+			session: { fetch },
+			isDestroyed: () => false,
+			send: () => {},
+		},
+		isDestroyed: () => false,
+	};
+	const mainWindow = {
+		getWindow: () => window,
+		show: () => {},
+		restoreWindow: () => {},
+	};
+	const NotificationService = require(servicePath);
+	const service = new NotificationService(
+		null,
+		{ appPath: '/app', defaultNotificationUrgency: 'normal' },
+		mainWindow,
+		() => 1,
+	);
+	service.initialize();
+	return service;
+}
+
+async function show(options) {
+	await handlers.get('show-notification')({}, {
+		title: 'Title',
+		body: 'Body',
+		timeoutType: 'default',
+		...options,
+	});
+}
+
+describe('NotificationService icons', () => {
+	let originalConsoleDebug;
+	let originalConsoleWarn;
+
+	beforeEach(() => {
+		installElectronMock();
+		originalConsoleDebug = console.debug;
+		originalConsoleWarn = console.warn;
+		console.debug = () => {};
+		console.warn = () => {};
+	});
+
+	afterEach(() => {
+		console.debug = originalConsoleDebug;
+		console.warn = originalConsoleWarn;
+		cleanupElectronMock();
+	});
+
+	it('keeps data URL icons on the existing path', async () => {
+		let fetchCalls = 0;
+		makeService(async () => { fetchCalls += 1; });
+
+		await show({ icon: 'data:image/png;base64,aWNvbg==' });
+
+		assert.deepStrictEqual(dataUrls, ['data:image/png;base64,aWNvbg==']);
+		assert.strictEqual(fetchCalls, 0);
+		assert.deepStrictEqual(notifications[0].options.icon, { source: 'data-url' });
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('fetches remote icons through the authenticated window session', async () => {
+		const bytes = Uint8Array.from([1, 2, 3, 4]);
+		const calls = [];
+		makeService(async (...args) => {
+			calls.push(args);
+			return responseWith(bytes);
+		});
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0][0], 'https://teams.microsoft.com/avatar.png');
+		assert.strictEqual(calls[0][1].credentials, 'include');
+		assert.deepStrictEqual([...imageBuffers[0]], [...bytes]);
+		assert.deepStrictEqual(notifications[0].options.icon, { source: 'buffer' });
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('still shows the notification when a remote icon cannot be loaded', async () => {
+		makeService(async () => { throw new Error('network failure'); });
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('does not fetch non-HTTPS icon URLs', async () => {
+		let fetchCalls = 0;
+		makeService(async () => { fetchCalls += 1; });
+
+		await show({ icon: 'http://localhost/avatar.png' });
+
+		assert.strictEqual(fetchCalls, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+});

--- a/tests/unit/notificationService.test.js
+++ b/tests/unit/notificationService.test.js
@@ -164,6 +164,18 @@ describe('NotificationService icons', () => {
 		assert.strictEqual(calls.length, 1);
 		assert.strictEqual(calls[0][0], 'https://teams.microsoft.com/avatar.png');
 		assert.strictEqual(calls[0][1].credentials, 'include');
+		assert.strictEqual(calls[0][1].redirect, 'error');
+		assert.deepStrictEqual([...imageBuffers[0]], [...bytes]);
+		assert.strictEqual(notifications[0].options.icon.source, 'buffer');
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('accepts direct responses without a response URL', async () => {
+		const bytes = Uint8Array.from([1, 2, 3, 4]);
+		makeService(async () => responseWith(bytes, { url: '' }));
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
 		assert.deepStrictEqual([...imageBuffers[0]], [...bytes]);
 		assert.strictEqual(notifications[0].options.icon.source, 'buffer');
 		assert.strictEqual(notifications[0].shown, true);
@@ -200,24 +212,11 @@ describe('NotificationService icons', () => {
 		assert.strictEqual(notifications[0].shown, true);
 	});
 
-	it('rejects redirects from HTTPS to a non-HTTPS URL', async () => {
-		const bytes = Uint8Array.from([1, 2, 3, 4]);
-		makeService(async () => responseWith(bytes, {
-			url: 'http://teams.microsoft.com/avatar.png',
-		}));
-
-		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
-
-		assert.strictEqual(imageBuffers.length, 0);
-		assert.strictEqual('icon' in notifications[0].options, false);
-		assert.strictEqual(notifications[0].shown, true);
-	});
-
-	it('rejects redirects to a different HTTPS origin', async () => {
-		const bytes = Uint8Array.from([1, 2, 3, 4]);
-		makeService(async () => responseWith(bytes, {
-			url: 'https://example.com/avatar.png',
-		}));
+	it('still shows the notification when fetch rejects a redirect', async () => {
+		makeService(async (_url, options) => {
+			assert.strictEqual(options.redirect, 'error');
+			throw new TypeError('redirect rejected');
+		});
 
 		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
 

--- a/tests/unit/notificationService.test.js
+++ b/tests/unit/notificationService.test.js
@@ -89,6 +89,7 @@ function responseWith(bytes, options = {}) {
 function makeService(fetch) {
 	const window = {
 		webContents: {
+			getURL: () => 'https://teams.microsoft.com/',
 			session: { fetch },
 			isDestroyed: () => false,
 			send: () => {},
@@ -188,10 +189,34 @@ describe('NotificationService icons', () => {
 		assert.strictEqual(notifications[0].shown, true);
 	});
 
+	it('does not fetch icons from a different HTTPS origin', async () => {
+		let fetchCalls = 0;
+		makeService(async () => { fetchCalls += 1; });
+
+		await show({ icon: 'https://example.com/avatar.png' });
+
+		assert.strictEqual(fetchCalls, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
 	it('rejects redirects from HTTPS to a non-HTTPS URL', async () => {
 		const bytes = Uint8Array.from([1, 2, 3, 4]);
 		makeService(async () => responseWith(bytes, {
 			url: 'http://teams.microsoft.com/avatar.png',
+		}));
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual(imageBuffers.length, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('rejects redirects to a different HTTPS origin', async () => {
+		const bytes = Uint8Array.from([1, 2, 3, 4]);
+		makeService(async () => responseWith(bytes, {
+			url: 'https://example.com/avatar.png',
 		}));
 
 		await show({ icon: 'https://teams.microsoft.com/avatar.png' });

--- a/tests/unit/notificationService.test.js
+++ b/tests/unit/notificationService.test.js
@@ -11,12 +11,14 @@ let handlers;
 let notifications;
 let dataUrls;
 let imageBuffers;
+let bufferImageEmpty;
 
 function installElectronMock() {
 	handlers = new Map();
 	notifications = [];
 	dataUrls = [];
 	imageBuffers = [];
+	bufferImageEmpty = false;
 
 	class MockNotification extends EventEmitter {
 		constructor(options) {
@@ -43,11 +45,11 @@ function installElectronMock() {
 			nativeImage: {
 				createFromDataURL: (url) => {
 					dataUrls.push(url);
-					return { source: 'data-url' };
+					return { source: 'data-url', isEmpty: () => false };
 				},
 				createFromBuffer: (buffer) => {
 					imageBuffers.push(buffer);
-					return { source: 'buffer' };
+					return { source: 'buffer', isEmpty: () => bufferImageEmpty };
 				},
 			},
 		},
@@ -61,11 +63,16 @@ function cleanupElectronMock() {
 	delete require.cache[servicePath];
 }
 
-function responseWith(bytes) {
+function responseWith(bytes, options = {}) {
+	const {
+		url = 'https://teams.microsoft.com/avatar.png',
+		contentLength = bytes.length,
+	} = options;
 	let sent = false;
 	return {
 		ok: true,
-		headers: { get: () => String(bytes.length) },
+		url,
+		headers: { get: () => String(contentLength) },
 		body: {
 			getReader: () => ({
 				read: async () => {
@@ -139,7 +146,7 @@ describe('NotificationService icons', () => {
 
 		assert.deepStrictEqual(dataUrls, ['data:image/png;base64,aWNvbg==']);
 		assert.strictEqual(fetchCalls, 0);
-		assert.deepStrictEqual(notifications[0].options.icon, { source: 'data-url' });
+		assert.strictEqual(notifications[0].options.icon.source, 'data-url');
 		assert.strictEqual(notifications[0].shown, true);
 	});
 
@@ -157,7 +164,7 @@ describe('NotificationService icons', () => {
 		assert.strictEqual(calls[0][0], 'https://teams.microsoft.com/avatar.png');
 		assert.strictEqual(calls[0][1].credentials, 'include');
 		assert.deepStrictEqual([...imageBuffers[0]], [...bytes]);
-		assert.deepStrictEqual(notifications[0].options.icon, { source: 'buffer' });
+		assert.strictEqual(notifications[0].options.icon.source, 'buffer');
 		assert.strictEqual(notifications[0].shown, true);
 	});
 
@@ -177,6 +184,43 @@ describe('NotificationService icons', () => {
 		await show({ icon: 'http://localhost/avatar.png' });
 
 		assert.strictEqual(fetchCalls, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('rejects redirects from HTTPS to a non-HTTPS URL', async () => {
+		const bytes = Uint8Array.from([1, 2, 3, 4]);
+		makeService(async () => responseWith(bytes, {
+			url: 'http://teams.microsoft.com/avatar.png',
+		}));
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual(imageBuffers.length, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('omits remote icons larger than the size limit', async () => {
+		const bytes = Uint8Array.from([1, 2, 3, 4]);
+		makeService(async () => responseWith(bytes, {
+			contentLength: 5 * 1024 * 1024 + 1,
+		}));
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual(imageBuffers.length, 0);
+		assert.strictEqual('icon' in notifications[0].options, false);
+		assert.strictEqual(notifications[0].shown, true);
+	});
+
+	it('omits remote icons that Electron cannot decode', async () => {
+		bufferImageEmpty = true;
+		makeService(async () => responseWith(Uint8Array.from([1, 2, 3, 4])));
+
+		await show({ icon: 'https://teams.microsoft.com/avatar.png' });
+
+		assert.strictEqual(imageBuffers.length, 1);
 		assert.strictEqual('icon' in notifications[0].options, false);
 		assert.strictEqual(notifications[0].shown, true);
 	});


### PR DESCRIPTION
## Summary

The `electron` notification method prevents Teams's in-page toast lifecycle from prematurely closing system notifications, as documented in [#2411](https://github.com/IsmaelMartinez/teams-for-linux/issues/2411). After confirming that workaround, the reporter noted that Electron notifications no longer included the sender picture and that [it would be nice to get the icon back](https://github.com/IsmaelMartinez/teams-for-linux/issues/2411#issuecomment-4459560190).

The avatars were missing because Teams supplies the icon as a remote URL while `NotificationService` passed it directly to `nativeImage.createFromDataURL()`.

This change:

- Fetches remote notification icons through the active, authenticated Teams session.
- Preserves the existing path for data URL icons.
- Converts fetched image bytes into an Electron `nativeImage`.
- Restricts initial and redirected URLs to the active Teams HTTPS origin.
- Applies a one-second timeout and 5 MiB streaming size limit.
- Omits invalid or undecodable icons without suppressing the notification.

Closes #2812. Follow-up to #2411, specifically the missing-avatar report in [this comment](https://github.com/IsmaelMartinez/teams-for-linux/issues/2411#issuecomment-4459560190).

## Testing

- [x] `npm run lint`
- [x] `npm run test:unit` — 410 tests passed
- [x] `npm run test:e2e -- tests/e2e/notifications.spec.js` — 9 notification E2E tests passed
- [x] `npm run pack`
- [x] Ran the packaged application manually with an authenticated Teams profile on Hyprland using Varde as the notification daemon
- [x] Confirmed Electron notifications include the sender avatar
- [x] Confirmed notifications use the configured system timeout and are not closed by Teams's in-page toast
- [ ] Cross-distro packaging tests were not run

Focused unit coverage includes:

- Existing data URL icons
- Authenticated remote icon fetching
- Network failure fallback
- Non-HTTPS input rejection
- Cross-origin input rejection
- HTTPS-to-HTTP redirect rejection
- Cross-origin HTTPS redirect rejection
- Oversized response rejection
- Invalid `nativeImage` decoding fallback

## Documentation

- [x] Updated `docs-site/docs/troubleshooting.md`
- [x] No IPC channels were added or changed
- [x] No new configuration options were added
- [x] No new PII is written to logs

## Notes for reviewers

Remote icon failures degrade gracefully to an iconless notification. Notification delivery and lifecycle behavior are otherwise unchanged.
