### PR TITLE
fix(logging): remove #2587 debug instrumentation that shipped in 2.15.0

### DIFF
--- a/app/browser/preload.js
+++ b/app/browser/preload.js
@@ -273,10 +273,6 @@ function playNotificationSound(notifSound) {
 }
 
 function createWebNotification(classicNotification, title, options) {
-  // DEBUG-ONLY: Remove before merge (#2587): log notification content to learn
-  // whether meeting-start arrives via the notification path instead of a DOM
-  // toast. Title/body can contain names; branch build only.
-  console.info('[MeetingStart][DEBUG] web notification:', String(title ?? '').slice(0, 200), '|', String(options?.body ?? '').slice(0, 200));
   const notifSound = {
     type: options.type,
     audio: "default",
@@ -299,8 +295,6 @@ function createWebNotification(classicNotification, title, options) {
 }
 
 function createElectronNotification(options) {
-  // DEBUG-ONLY: Remove before merge (#2587): see createWebNotification note.
-  console.info('[MeetingStart][DEBUG] electron notification:', String(options?.title ?? '').slice(0, 200), '|', String(options?.body ?? '').slice(0, 200));
   const notificationId = crypto.randomUUID();
   const stub = createNotificationStub();
   let closed = false;

--- a/app/browser/tools/activityHub.js
+++ b/app/browser/tools/activityHub.js
@@ -221,16 +221,6 @@ function handleCallEventEntityCommand(entityCommand) {
   console.debug('[MeetingStart] toast entityCommand scenario:',
     entityCommand.entityOptions?.crossClientScenarioName,
     { isIncomingCall: !!entityCommand.entityOptions?.isIncomingCall });
-  // DEBUG-ONLY: Remove before merge (#2587): full entityOptions dump for live
-  // validation of the React-store detection path. May contain names; branch
-  // build only.
-  try {
-    console.info('[MeetingStart][DEBUG] entityOptions:',
-      JSON.stringify(entityCommand.entityOptions ?? {}).slice(0, 600));
-  } catch {
-    console.info('[MeetingStart][DEBUG] entityOptions not serializable, keys:',
-      Object.keys(entityCommand.entityOptions ?? {}).join(','));
-  }
   const meetingStartId = getMeetingStartId(entityCommand.entityOptions);
   if (meetingStartId) {
     onMeetingStarted(meetingStartId);

--- a/app/browser/tools/meetingStartDetector.js
+++ b/app/browser/tools/meetingStartDetector.js
@@ -69,30 +69,6 @@ const activityHub = require('./activityHub');
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
-// DEBUG-ONLY: Remove before merge (#2587 live-validation instrumentation).
-// Broad sampler regex: logs any added element whose text looks meeting
-// adjacent, regardless of toast markers, so a live scheduled-meeting start
-// tells us what the real toast DOM (or lack of one) looks like. Sampled text
-// can contain names; acceptable on this branch build only.
-const DEBUG_SAMPLER_REGEX = /meeting|meet now|started|webinar/i;
-const DEBUG_SAMPLER_MAX_PER_MIN = 30;
-
-// DEBUG-ONLY: Remove before merge (#2587): compact element descriptor for logs.
-function debugDescribe(el) {
-	const attrs = [];
-	for (const name of ['role', 'aria-live', 'data-tid', 'data-tester-id', 'id']) {
-		const value = el.getAttribute?.(name);
-		if (value) {
-			attrs.push(`${name}=${value}`);
-		}
-	}
-	const cls = typeof el.className === 'string' ? el.className.slice(0, 80) : '';
-	const tag = el.tagName?.toLowerCase() || '?';
-	const attrPart = attrs.length ? ' ' + attrs.join(' ') : '';
-	const clsPart = cls ? ` class="${cls}"` : '';
-	return `<${tag}${attrPart}${clsPart}>`;
-}
-
 /**
  * Non-cryptographic string hash (djb2). Used so matched toast text (which
  * contains a person's name) is not retained verbatim for deduplication.
@@ -114,32 +90,17 @@ class MeetingStartDetector {
 	#observer = null;
 	#matchedElements = new WeakSet();
 	#recentSignatures = new Map();
-	// DEBUG-ONLY: Remove before merge (#2587): instrumentation state.
-	#debugStats = { mutations: 0, addedNodes: 0, markersScanned: 0, sampled: 0, droppedSamples: 0 };
-	#debugSampleWindowStart = 0;
-	#debugSampleCount = 0;
-	#debugHeartbeat = null;
 
 	init(config, ipcRenderer) {
 		this.#ipcRenderer = ipcRenderer;
 
 		const detectionConfig = config.mqtt?.meetingStartDetection;
-		// DEBUG-ONLY: Remove before merge (#2587): surface the exact config the
-		// detector resolved, so "nothing happened" reports show whether it even armed.
-		console.info('[MeetingStart][DEBUG] init', {
-			mqttEnabled: !!config.mqtt?.enabled,
-			detectionEnabled: !!detectionConfig?.enabled,
-			configuredPatternCount: Array.isArray(detectionConfig?.patterns) ? detectionConfig.patterns.length : 0,
-			readyState: document.readyState,
-		});
 		if (!config.mqtt?.enabled || !detectionConfig?.enabled) {
 			console.debug('[MeetingStartDetector] Disabled');
 			return;
 		}
 
 		this.#patterns = this.compilePatterns(detectionConfig.patterns);
-		// DEBUG-ONLY: Remove before merge (#2587): pattern sources are config, not PII.
-		console.info('[MeetingStart][DEBUG] compiled patterns:', this.#patterns.map((p) => p.source));
 		if (this.#patterns.length === 0) {
 			console.warn('[MeetingStartDetector] No valid patterns configured, detection disabled');
 			return;
@@ -173,8 +134,6 @@ class MeetingStartDetector {
 		}
 		// PII: the id is a call/toast GUID, not a person; still not logged.
 		console.info('[MeetingStartDetector] Meeting start detected via command stream');
-		// DEBUG-ONLY: Remove before merge (#2587).
-		console.info('[MeetingStart][DEBUG] sending meeting-started IPC (react path)');
 		this.#ipcRenderer.send('meeting-started');
 	}
 
@@ -237,13 +196,6 @@ class MeetingStartDetector {
 			scopedToContainer: !!container,
 			patternCount: this.#patterns.length,
 		});
-
-		// DEBUG-ONLY: Remove before merge (#2587): heartbeat proves the observer
-		// is alive and shows how much DOM traffic it sees while we wait for a
-		// live meeting start.
-		this.#debugHeartbeat = setInterval(() => {
-			console.info('[MeetingStart][DEBUG] heartbeat', { ...this.#debugStats });
-		}, 30000);
 	}
 
 	#findToastContainer() {
@@ -251,70 +203,30 @@ class MeetingStartDetector {
 			try {
 				const element = document.querySelector(selector);
 				if (element) {
-					// DEBUG-ONLY: Remove before merge (#2587).
-					console.info('[MeetingStart][DEBUG] toast container matched selector:', selector);
 					return element;
 				}
 			} catch {
 				// invalid/unsupported selector — try the next one
 			}
 		}
-		// DEBUG-ONLY: Remove before merge (#2587).
-		console.info('[MeetingStart][DEBUG] no toast container selector matched, observing document.body');
 		return null;
 	}
 
 	#onMutations(mutations) {
-		// DEBUG-ONLY: Remove before merge (#2587).
-		this.#debugStats.mutations += mutations.length;
 		for (const mutation of mutations) {
 			for (const node of mutation.addedNodes) {
-				// DEBUG-ONLY: Remove before merge (#2587).
-				this.#debugStats.addedNodes++;
 				if (node.nodeType === ELEMENT_NODE) {
-					// DEBUG-ONLY: Remove before merge (#2587).
-					this.#debugSample(node);
 					this.#checkMarkers(this.#collectMarkerElements(node));
 				} else if (node.nodeType === TEXT_NODE && mutation.target?.closest) {
 					// Toast text can be filled in after the element is inserted;
 					// re-check the enclosing marker when its text arrives.
 					const host = mutation.target.closest(TOAST_MARKER_SELECTOR);
 					if (host) {
-						// DEBUG-ONLY: Remove before merge (#2587).
-						console.info('[MeetingStart][DEBUG] text-node mutation re-check on', debugDescribe(host));
 						this.#checkMarkers([host]);
 					}
 				}
 			}
 		}
-	}
-
-	/**
-	 * DEBUG-ONLY: Remove before merge (#2587). Logs any added element whose
-	 * text looks meeting-adjacent, whether or not it carries toast markers, so
-	 * we learn what the real meeting-start surface looks like. Rate-limited.
-	 */
-	#debugSample(node) {
-		const text = (node.textContent || '').slice(0, MAX_TEXT_LENGTH);
-		if (text.length === 0 || !DEBUG_SAMPLER_REGEX.test(text)) {
-			return;
-		}
-		const now = Date.now();
-		if (now - this.#debugSampleWindowStart > 60000) {
-			if (this.#debugStats.droppedSamples > 0) {
-				console.info('[MeetingStart][DEBUG] sampler dropped', this.#debugStats.droppedSamples, 'elements in the last window');
-			}
-			this.#debugSampleWindowStart = now;
-			this.#debugSampleCount = 0;
-			this.#debugStats.droppedSamples = 0;
-		}
-		if (this.#debugSampleCount >= DEBUG_SAMPLER_MAX_PER_MIN) {
-			this.#debugStats.droppedSamples++;
-			return;
-		}
-		this.#debugSampleCount++;
-		this.#debugStats.sampled++;
-		console.info('[MeetingStart][DEBUG] sampled', debugDescribe(node), 'text:', text.slice(0, 200));
 	}
 
 	#collectMarkerElements(node) {
@@ -335,10 +247,6 @@ class MeetingStartDetector {
 			}
 
 			const text = element.textContent || '';
-			// DEBUG-ONLY: Remove before merge (#2587): marker surfaces are rare,
-			// log each scan so we can see toast text against the patterns.
-			this.#debugStats.markersScanned++;
-			console.info('[MeetingStart][DEBUG] marker scanned', debugDescribe(element), 'matched:', this.matchesPatterns(text), 'text:', text.slice(0, 200));
 			if (!this.matchesPatterns(text)) {
 				continue;
 			}
@@ -351,8 +259,6 @@ class MeetingStartDetector {
 
 			// PII: never include the matched text — it carries a person's name.
 			console.info('[MeetingStartDetector] Meeting-start toast detected');
-			// DEBUG-ONLY: Remove before merge (#2587).
-			console.info('[MeetingStart][DEBUG] sending meeting-started IPC to main process');
 			this.#ipcRenderer.send('meeting-started');
 		}
 	}
@@ -387,11 +293,6 @@ class MeetingStartDetector {
 		if (this.#observer) {
 			this.#observer.disconnect();
 			this.#observer = null;
-		}
-		// DEBUG-ONLY: Remove before merge (#2587).
-		if (this.#debugHeartbeat) {
-			clearInterval(this.#debugHeartbeat);
-			this.#debugHeartbeat = null;
 		}
 		this.#recentSignatures.clear();
 		console.debug('[MeetingStartDetector] Stopped');

--- a/tests/unit/debugOnlyMarkers.test.js
+++ b/tests/unit/debugOnlyMarkers.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { readdirSync, readFileSync, statSync } = require('node:fs');
+const path = require('node:path');
+
+// CLAUDE.md requires temporary debug instrumentation to be marked
+// "DEBUG-ONLY: Remove before merge" and stripped before it reaches main. That
+// convention only works if something enforces it: the #2587 meeting-start
+// sampler carried the marker and still shipped in v2.15.0, logging toast text
+// that contains colleagues' names. This guard fails the build instead.
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+const MARKER = 'DEBUG-ONLY';
+
+function collectSourceFiles(dir) {
+	const found = [];
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			found.push(...collectSourceFiles(full));
+		} else if (/\.(js|mjs|html)$/.test(entry)) {
+			found.push(full);
+		}
+	}
+	return found;
+}
+
+describe('debug-only instrumentation', () => {
+	it('is not present anywhere under app/', () => {
+		const offenders = [];
+		for (const file of collectSourceFiles(APP_DIR)) {
+			const lines = readFileSync(file, 'utf8').split('\n');
+			lines.forEach((line, index) => {
+				if (line.includes(MARKER)) {
+					offenders.push(`${path.relative(APP_DIR, file)}:${index + 1}`);
+				}
+			});
+		}
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			`Debug-only instrumentation must be removed before merge. Found at:\n  ${offenders.join('\n  ')}`
+		);
+	});
+});


### PR DESCRIPTION
The #2587 live-validation instrumentation was merged with its `DEBUG-ONLY: Remove before merge` markers still in place and shipped in v2.15.0. It logs other people's names and message content at info level, into the log files users routinely attach to issues here.

The widest leak is not in the detector. `createWebNotification` and `createElectronNotification` each logged the notification's title and body, 200 characters apiece. `web` is the default `notificationMethod` and neither function is gated on any config, so every 2.15.0 user receiving a Teams notification wrote the sender and the message text to their log. The detector's own two text-logging sites were gated behind `mqtt.enabled` plus `mqtt.meetingStartDetection.enabled`, both off by default, so those affected opted-in users only.

Detection behaviour is unchanged. No gate, pattern, dedup or IPC path is touched, only logging. `meetingStartDetector.js` loses 99 lines and its header comment promising the matched toast text "is never logged" is true again.

The new `tests/unit/debugOnlyMarkers.test.js` fails if the marker appears anywhere under `app/`. Worth having: I stripped the detector by hand first, wrote the guard second, and only then found the three notification and `activityHub` sites. Nothing was enforcing the convention.

Lint clean, 387 unit tests pass, 15 e2e pass.

Refs: #2587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
