### PR TITLE
fix(network): bound the connectivity sweep so a hung probe cannot stall startup

### DIFF
--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -270,7 +270,8 @@ const RETRY_SLEEP_MS = 500;
 
 // Bound a connectivity probe so it always settles. run(finish) performs the
 // probe and calls the idempotent finish(true|false) when it resolves; finish
-// also clears the timeout. If the probe has not settled within PROBE_TIMEOUT_MS,
+// also clears the timeout. If the probe has not settled within timeoutMs
+// (PROBE_TIMEOUT_MS unless isOnline() has less budget than that left),
 // the optional cleanup returned by run() runs (e.g. abort an in-flight request)
 // and the probe resolves false. A synchronous throw from run() (net.request on a
 // malformed URL, a net-stack init failure) is treated as offline, so the probe

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -152,8 +152,8 @@ class ConnectionManager {
         // Perform an actual HTTPS request, similar to loading the Teams app.
         method: "https",
         tries: 10,
-        networkTest: async () => {
-          return await isOnlineHttps(this.config.url);
+        networkTest: async (timeoutMs) => {
+          return await isOnlineHttps(this.config.url, timeoutMs);
         },
       },
       {
@@ -161,9 +161,9 @@ class ConnectionManager {
         // mandatory but not reachable yet.
         method: "dns",
         tries: 5,
-        networkTest: async () => {
+        networkTest: async (timeoutMs) => {
           const testDomain = new URL(this.config.url).hostname;
-          return await isOnlineDns(testDomain);
+          return await isOnlineDns(testDomain, timeoutMs);
         },
       },
       {
@@ -191,17 +191,24 @@ class ConnectionManager {
     const deadline = Date.now() + ONLINE_CHECK_BUDGET_MS;
     for (const onlineCheckMethod of onlineCheckMethods) {
       for (let i = 1; i <= onlineCheckMethod.tries; i++) {
-        const online = await onlineCheckMethod.networkTest();
-        if (online) {
-          return true;
-        }
-        if (Date.now() >= deadline) {
+        // Checking the budget before each probe rather than after it also
+        // catches a deadline that passed during the retry sleep, and clamping
+        // the probe to what is left stops a single hung probe from running past
+        // the budget by up to PROBE_TIMEOUT_MS.
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
           console.warn(
             `[CONNECTION] Connectivity check exceeded ${ONLINE_CHECK_BUDGET_MS}ms, assuming online`,
           );
           return true;
         }
-        await sleep(500);
+        const online = await onlineCheckMethod.networkTest(
+          Math.min(PROBE_TIMEOUT_MS, remainingMs),
+        );
+        if (online) {
+          return true;
+        }
+        await sleep(RETRY_SLEEP_MS);
       }
     }
     return false;
@@ -254,7 +261,12 @@ const PROBE_TIMEOUT_MS = 5000;
 // hung-socket case from #2611. Nothing is lost by stopping early: the escape
 // gate at the end of the table assumes online regardless, so the sweep loads the
 // page and did-fail-load schedules a retry if the network really is still down.
+// isOnline() checks this before each probe and clamps the probe to whatever is
+// left, so the sweep settles within the budget plus at most one retry sleep.
 const ONLINE_CHECK_BUDGET_MS = 20000;
+
+// Pause between tries, giving a recovering network time to come back.
+const RETRY_SLEEP_MS = 500;
 
 // Bound a connectivity probe so it always settles. run(finish) performs the
 // probe and calls the idempotent finish(true|false) when it resolves; finish
@@ -264,7 +276,7 @@ const ONLINE_CHECK_BUDGET_MS = 20000;
 // malformed URL, a net-stack init failure) is treated as offline, so the probe
 // always resolves a boolean and isOnline() falls through rather than rejecting
 // and wedging refresh().
-function probeWithTimeout(run) {
+function probeWithTimeout(run, timeoutMs = PROBE_TIMEOUT_MS) {
   return new Promise((resolve) => {
     let settled = false;
     let timer;
@@ -282,7 +294,7 @@ function probeWithTimeout(run) {
         /* nothing to clean up, or request already settled */
       }
       finish(false);
-    }, PROBE_TIMEOUT_MS);
+    }, timeoutMs);
     try {
       cleanup = run(finish);
     } catch {
@@ -291,7 +303,7 @@ function probeWithTimeout(run) {
   });
 }
 
-function isOnlineHttps(testUrl) {
+function isOnlineHttps(testUrl, timeoutMs) {
   return probeWithTimeout((finish) => {
     const req = net.request({ url: testUrl, method: "HEAD" });
     req.on("response", () => finish(true));
@@ -299,16 +311,16 @@ function isOnlineHttps(testUrl) {
     req.end();
     // On timeout, abort the in-flight request before resolving false.
     return () => req.abort();
-  });
+  }, timeoutMs);
 }
 
-function isOnlineDns(testDomain) {
+function isOnlineDns(testDomain, timeoutMs) {
   return probeWithTimeout((finish) => {
     net
       .resolveHost(testDomain)
       .then(() => finish(true))
       .catch(() => finish(false));
-  });
+  }, timeoutMs);
 }
 
 module.exports = ConnectionManager;

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -188,10 +188,17 @@ class ConnectionManager {
       },
     ];
 
+    const deadline = Date.now() + ONLINE_CHECK_BUDGET_MS;
     for (const onlineCheckMethod of onlineCheckMethods) {
       for (let i = 1; i <= onlineCheckMethod.tries; i++) {
         const online = await onlineCheckMethod.networkTest();
         if (online) {
+          return true;
+        }
+        if (Date.now() >= deadline) {
+          console.warn(
+            `[CONNECTION] Connectivity check exceeded ${ONLINE_CHECK_BUDGET_MS}ms, assuming online`,
+          );
           return true;
         }
         await sleep(500);
@@ -237,6 +244,17 @@ function sleep(timeout) {
 // always settles; a timed-out probe resolves false and isOnline() falls through
 // to the next method (and the retry loop gives a recovering network time).
 const PROBE_TIMEOUT_MS = 5000;
+
+// PROBE_TIMEOUT_MS bounds one probe; this bounds the whole sweep. The tries in
+// the isOnline() table add up to 20 probes, so when every probe hangs to its
+// timeout the user watches "Waiting for network..." for about 85 seconds before
+// the escape gate gives up and assumes online. Probes that fail fast (no route,
+// connection refused) only cost the 500ms retry sleep, totalling ~10s, so a
+// 20 second budget leaves the ordinary offline path untouched and only clips the
+// hung-socket case from #2611. Nothing is lost by stopping early: the escape
+// gate at the end of the table assumes online regardless, so the sweep loads the
+// page and did-fail-load schedules a retry if the network really is still down.
+const ONLINE_CHECK_BUDGET_MS = 20000;
 
 // Bound a connectivity probe so it always settles. run(finish) performs the
 // probe and calls the idempotent finish(true|false) when it resolves; finish

--- a/tests/unit/connectionManagerOnlineCheck.test.js
+++ b/tests/unit/connectionManagerOnlineCheck.test.js
@@ -110,8 +110,10 @@ describe('ConnectionManager connectivity sweep', () => {
 			const elapsed = settledAt - startedAt;
 
 			assert.strictEqual(online, true, 'escape gate still assumes online');
+			// The 20s budget plus the trailing retry sleep. Probes are clamped to
+			// the remaining budget, so a hung one cannot push past this.
 			assert.ok(
-				elapsed < 30000,
+				elapsed <= 20500,
 				`sweep should settle inside the budget, took ${elapsed}ms`,
 			);
 		} finally {

--- a/tests/unit/connectionManagerOnlineCheck.test.js
+++ b/tests/unit/connectionManagerOnlineCheck.test.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const { describe, it, before, after, beforeEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+// The connectivity sweep is bounded by two different limits: PROBE_TIMEOUT_MS
+// caps one probe, and ONLINE_CHECK_BUDGET_MS caps the whole table of them. The
+// budget is the one that matters after a suspend/resume, where probes hang
+// instead of failing fast (#2611): without it the twenty tries in the table add
+// up to roughly 85 seconds of "Waiting for network..." before the escape gate
+// assumes online. These tests drive the sweep on mocked timers so the real
+// durations can be asserted without waiting for them.
+const electronPath = require.resolve('electron');
+
+let requestsCreated;
+let resolveHostCalls;
+let nativeIsOnlineCalls;
+
+function installElectronMock() {
+	requestsCreated = 0;
+	resolveHostCalls = 0;
+	nativeIsOnlineCalls = 0;
+
+	require.cache[electronPath] = {
+		id: electronPath,
+		filename: electronPath,
+		loaded: true,
+		exports: {
+			ipcMain: { on() {}, removeListener() {} },
+			powerMonitor: { on() {}, removeListener() {} },
+			net: {
+				// A hung probe: the request is created and ended, but neither
+				// 'response' nor 'error' ever fires, so only PROBE_TIMEOUT_MS
+				// settles it. This is the stale-socket case from #2611.
+				request() {
+					requestsCreated++;
+					return { on() {}, end() {}, abort() {} };
+				},
+				resolveHost() {
+					resolveHostCalls++;
+					return new Promise(() => {});
+				},
+				isOnline() {
+					nativeIsOnlineCalls++;
+					return false;
+				},
+			},
+		},
+	};
+}
+
+// Enough mocked time for the unbounded sweep (~85s) to finish as well as the
+// bounded one, so removing the budget makes these tests fail on the assertion
+// rather than hang waiting for a promise that never settles.
+const CLOCK_RUN_MS = 120000;
+
+// Advance mocked time in small steps, yielding to the real macrotask queue
+// between them so the awaits inside isOnline() can progress.
+async function runClock(totalMs, stepMs = 100) {
+	for (let elapsed = 0; elapsed < totalMs; elapsed += stepMs) {
+		await new Promise((r) => setImmediate(r));
+		mock.timers.tick(stepMs);
+	}
+	await new Promise((r) => setImmediate(r));
+}
+
+function newManager() {
+	const ConnectionManager = require('../../app/connectionManager');
+	const manager = new ConnectionManager();
+	// start() would register listeners and kick off a refresh; the sweep only
+	// needs a config, so shadow the prototype getter instead.
+	Object.defineProperty(manager, 'config', {
+		value: { url: 'https://teams.microsoft.com' },
+	});
+	return manager;
+}
+
+describe('ConnectionManager connectivity sweep', () => {
+	before(() => {
+		installElectronMock();
+	});
+
+	after(() => {
+		delete require.cache[electronPath];
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	beforeEach(() => {
+		installElectronMock();
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	it('gives up within the budget when every probe hangs', async () => {
+		mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+		try {
+			const manager = newManager();
+			const startedAt = Date.now();
+			// Stamp the mocked clock when the sweep settles: the driver below
+			// keeps ticking afterwards, so reading Date.now() at the end would
+			// only report how far the clock was advanced.
+			let settledAt = null;
+			const sweep = manager.isOnline().then((value) => {
+				settledAt ??= Date.now();
+				return value;
+			});
+
+			await runClock(CLOCK_RUN_MS);
+
+			const online = await sweep;
+			const elapsed = settledAt - startedAt;
+
+			assert.strictEqual(online, true, 'escape gate still assumes online');
+			assert.ok(
+				elapsed < 30000,
+				`sweep should settle inside the budget, took ${elapsed}ms`,
+			);
+		} finally {
+			mock.timers.reset();
+		}
+	});
+
+	it('stops probing once the budget is spent instead of running every method', async () => {
+		mock.timers.enable({ apis: ['setTimeout', 'Date'] });
+		try {
+			const manager = newManager();
+			const sweep = manager.isOnline();
+			await runClock(CLOCK_RUN_MS);
+			await sweep;
+
+			// Each hung HTTPS probe costs PROBE_TIMEOUT_MS plus the retry sleep,
+			// so the budget is spent long before the ten configured tries.
+			assert.ok(
+				requestsCreated < 10,
+				`expected the HTTPS tries to be cut short, saw ${requestsCreated}`,
+			);
+			assert.strictEqual(
+				resolveHostCalls + nativeIsOnlineCalls,
+				0,
+				'later methods should not run once the budget is spent',
+			);
+		} finally {
+			mock.timers.reset();
+		}
+	});
+
+	it('returns as soon as a probe succeeds', async () => {
+		installElectronMock();
+		delete require.cache[require.resolve('../../app/connectionManager')];
+		require.cache[electronPath].exports.net.request = () => {
+			requestsCreated++;
+			const handlers = {};
+			return {
+				on(event, handler) {
+					handlers[event] = handler;
+				},
+				end() {
+					handlers.response?.();
+				},
+				abort() {},
+			};
+		};
+
+		const manager = newManager();
+		assert.strictEqual(await manager.isOnline(), true);
+		assert.strictEqual(requestsCreated, 1, 'a healthy network needs one probe');
+	});
+});


### PR DESCRIPTION
`isOnline()` sweeps four check methods with twenty tries between them. `PROBE_TIMEOUT_MS` bounds one probe at 5s, but nothing bounded the sweep, so when every probe hangs rather than failing fast the user sits on "Waiting for network..." for 85 seconds. That is the suspend/resume stale-socket case from #2611: the fix there stopped the check wedging forever, but left the worst case at 85s.

This caps the sweep at 20 seconds. A genuinely unreachable network fails each probe immediately and only pays the retry sleep, so the full table still runs in about 10s and is unaffected; the budget only clips the hung-probe case.

The returned value cannot change. The last entry in the table is an escape gate that returns `true` unconditionally, so `isOnline()` already always resolved true and the trailing `return false` is unreachable. Stopping early returns the same true, sooner, and `did-fail-load` still schedules a retry if the load then fails.

The new test drives the sweep on mocked timers. With the budget removed it reports the sweep taking exactly 85000ms, which is where that number comes from.

closes #2817

Refs: #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
