### PR TITLE
fix(logging): stop logging notification text and page DOM

### DIFF
--- a/app/browser/notifications/activityManager.js
+++ b/app/browser/notifications/activityManager.js
@@ -57,7 +57,6 @@ function setEventHandlers(self) {
   self.ipcRenderer.on("disable-wakelock", () => wakeLock.disable());
 
   self.ipcRenderer.on('incoming-call-action', (event, action) => {
-    console.debug("ActionHTML", document.body.innerHTML);
     const actionWrapper = document.querySelector('[data-testid="calling-actions"],[data-testid="msn-actions"]');
     if (actionWrapper) {
       const buttons = actionWrapper.querySelectorAll("button");

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -51,7 +51,7 @@ class NotificationService {
   async #showNotification(options) {
     const startTime = Date.now();
     console.debug("[NOTIFICATIONS] Native notification request received", {
-      title: options.title,
+      titleLength: options.title?.length || 0,
       bodyLength: options.body?.length || 0,
       hasIcon: !!options.icon,
       type: options.type,
@@ -65,8 +65,6 @@ class NotificationService {
       await this.#playNotificationSound({
         type: options.type,
         audio: "default",
-        title: options.title,
-        body: options.body,
       });
 
       const notificationConfig = {
@@ -111,7 +109,6 @@ class NotificationService {
 
       const totalTime = Date.now() - startTime;
       console.debug("[NOTIFICATIONS] Native notification displayed successfully", {
-        title: options.title,
         totalTimeMs: totalTime,
         urgency: this.#config.defaultNotificationUrgency,
         performanceNote: totalTime > 500 ? "Slow notification display detected" : "Normal notification speed"
@@ -120,7 +117,6 @@ class NotificationService {
     } catch (error) {
       console.error("[NOTIFICATIONS] Failed to show native notification", {
         error: error.message,
-        title: options.title,
         elapsedMs: Date.now() - startTime,
         suggestion: "Check if notification permissions are granted or icon data is valid"
       });
@@ -128,8 +124,10 @@ class NotificationService {
   }
 
   async #playNotificationSound(options) {
+    // options can carry the notification title and body (the web path forwards
+    // them over play-notification-sound), so log only the sound-relevant fields.
     console.debug(
-      `Notification => Type: ${options.type}, Audio: ${options.audio}, Title: ${options.title}, Body: ${options.body}`
+      `[NOTIFICATIONS] Sound requested => type: ${options.type}, audio: ${options.audio}`
     );
 
     // Player failed to load or notification sound disabled in config
@@ -160,7 +158,7 @@ class NotificationService {
       return;
     }
 
-    console.debug("No notification sound played", this.#soundPlayer, options);
+    console.debug(`[NOTIFICATIONS] No sound configured for type: ${options.type}`);
   }
 }
 

--- a/app/notifications/service.js
+++ b/app/notifications/service.js
@@ -45,7 +45,11 @@ class NotificationService {
   }
 
   async #handlePlayNotificationSound(_event, options) {
-    return this.#playNotificationSound(options);
+    // preload's playNotificationSound only rejects non-object values, so a
+    // renderer calling it with no argument reaches us as undefined. Every use
+    // below dereferences options, so normalise at the IPC boundary. A default
+    // parameter would not cover the null case, which preload also lets through.
+    return this.#playNotificationSound(options || {});
   }
 
   async #showNotification(options) {

--- a/tests/unit/debugOnlyMarkers.test.js
+++ b/tests/unit/debugOnlyMarkers.test.js
@@ -26,6 +26,14 @@ function collectSourceFiles(dir) {
 	return found;
 }
 
+// Logging a serialised DOM subtree is the highest-yield way to leak PII by
+// accident: one line dumps every name, message preview and meeting title on the
+// page. activityManager logged document.body.innerHTML on every incoming call
+// until this guard was added. Single-line check only, so a console call split
+// across lines still slips through; it catches the shape the mistake takes.
+const CONSOLE_CALL = /console\.(debug|info|warn|error|log)\(/;
+const SERIALISED_DOM = /(inner|outer)HTML/;
+
 describe('debug-only instrumentation', () => {
 	it('is not present anywhere under app/', () => {
 		const offenders = [];
@@ -41,6 +49,23 @@ describe('debug-only instrumentation', () => {
 			offenders,
 			[],
 			`Debug-only instrumentation must be removed before merge. Found at:\n  ${offenders.join('\n  ')}`
+		);
+	});
+
+	it('does not log serialised DOM anywhere under app/', () => {
+		const offenders = [];
+		for (const file of collectSourceFiles(APP_DIR)) {
+			const lines = readFileSync(file, 'utf8').split('\n');
+			lines.forEach((line, index) => {
+				if (CONSOLE_CALL.test(line) && SERIALISED_DOM.test(line)) {
+					offenders.push(`${path.relative(APP_DIR, file)}:${index + 1}`);
+				}
+			});
+		}
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			`Serialised DOM must not be logged, it carries message text and names. Found at:\n  ${offenders.join('\n  ')}`
 		);
 	});
 });


### PR DESCRIPTION
Follow-up to #2814, which swept the `DEBUG-ONLY` instrumentation. Two PII sites were never marked, so that sweep missed them.

`activityManager` logged `document.body.innerHTML` on every incoming-call action, dumping the whole Teams DOM: chat list, message previews, sender names, meeting titles. `NotificationService` logged the notification title at four sites and the full body at one, and its "no sound played" line dumped the raw options object carrying both.

Both are `console.debug` and the default console level is `info`, so nothing leaked by default. The exposure is the debug logs we ask reporters to attach to public issues, which is exactly when a notification bug is being diagnosed.

Also extends the `debugOnlyMarkers` guard to fail on any single-line `console` call containing `innerHTML`/`outerHTML`. Verified it flags `activityManager.js:60` when the removed line is put back.

Refs: #2814

🤖 Generated with [Claude Code](https://claude.com/claude-code)
