### PR TITLE
fix(menus): limit hidden-menubar accelerators to profile switching (#2821)

### DIFF
--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -11,6 +11,7 @@ const fs = require("node:fs"),
   path = require("node:path");
 const { fileURLToPath } = require("node:url");
 const appMenu = require("./appMenu");
+const buildProfilesMenu = require("./profilesMenu");
 const Tray = require("./tray");
 const { SpellCheckProvider } = require("../spellCheckProvider");
 const DocumentationWindow = require("../documentationWindow");
@@ -159,23 +160,43 @@ class Menus {
     this.window.hide();
   }
 
+  // Attach the menu appropriate for the menubar/multi-account configuration.
+  // With `menubar: "hidden"` AND multi-account on, a menu stays ATTACHED with
+  // only the bar hidden — the menu is the registration site for the pinned-
+  // profile switch accelerators (Ctrl+Alt+1…5, see profilesMenu.js), and
+  // `removeMenu()` would kill them along with the bar. It holds ONLY the
+  // Profiles submenu though: attaching the full menu would also arm the rest
+  // of its accelerators (Ctrl+Q, Ctrl+R, …) where a hidden menubar previously
+  // had none (#2821). Falls back to `removeMenu()` if the Profiles menu
+  // cannot be built (no profilesManager).
+  #attachMenu(menu) {
+    if (
+      this.configGroup.startupConfig.menubar == "hidden" &&
+      this.#multiAccountOn()
+    ) {
+      const template = [buildProfilesMenu(this)].filter(Boolean);
+      if (template.length === 0) {
+        this.window.removeMenu();
+        return;
+      }
+      this.window.setMenu(Menu.buildFromTemplate(template));
+      return;
+    }
+    this.window.setMenu(Menu.buildFromTemplate([menu]));
+  }
+
   initialize() {
     const menu = appMenu(this);
 
-    // With `menubar: "hidden"` AND multi-account on, the menu stays ATTACHED
-    // and only the bar is hidden — the menu is the registration site for the
-    // pinned-profile switch accelerators (Ctrl+Alt+1…5, see profilesMenu.js),
-    // and `removeMenu()` would kill them along with the bar. This does mean
-    // the rest of the menu's accelerators (Ctrl+Q, Ctrl+R, …) go live for
-    // hidden-menubar users too, but only under the opt-in flag: with
-    // multi-account OFF the pre-feature `removeMenu()` behaviour is untouched.
+    // With multi-account OFF the pre-feature `removeMenu()` behaviour is
+    // untouched; otherwise #attachMenu picks the full or profiles-only menu.
     if (
       this.configGroup.startupConfig.menubar == "hidden" &&
       !this.#multiAccountOn()
     ) {
       this.window.removeMenu();
     } else {
-      this.window.setMenu(Menu.buildFromTemplate([menu]));
+      this.#attachMenu(menu);
       if (this.configGroup.startupConfig.menubar == "hidden") {
         this.window.setMenuBarVisibility(false);
       }
@@ -333,7 +354,7 @@ class Menus {
 
   updateMenu() {
     const menu = appMenu(this);
-    this.window.setMenu(Menu.buildFromTemplate([menu]));
+    this.#attachMenu(menu);
     // Re-assert the hidden bar: profile events rebuild the menu constantly
     // (add/update/switch/remove), and without this the rebuild would silently
     // restore a bar the user configured away. Gated on the flag so flag-off

--- a/tests/unit/ipcValidator.test.js
+++ b/tests/unit/ipcValidator.test.js
@@ -2,7 +2,30 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const { readdirSync, readFileSync, statSync } = require('node:fs');
+const path = require('node:path');
 const { validateIpcChannel, allowedChannels } = require('../../app/security/ipcValidator');
+
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+
+function collectSourceFiles(dir) {
+	const found = [];
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			found.push(...collectSourceFiles(full));
+		} else if (/\.js$/.test(entry)) {
+			found.push(full);
+		}
+	}
+	return found;
+}
+
+// Both regexes are linear-time: no nested quantifiers. Matching runs on
+// whole-file content, not per line — browserWindowManager.js registers
+// channels with the literal on the line after `ipcMain.handle(`.
+const IPC_REGISTRATION = /ipcMain\.(handle|on|once)\(/g;
+const IPC_CHANNEL_LITERAL = /ipcMain\.(handle|on|once)\(\s*["']([^"']+)["']/g;
 
 describe('IPC Validator - Channel validation', () => {
 	it('accepts all channels in the allowlist', () => {
@@ -102,50 +125,36 @@ describe('IPC Validator - Allowlist completeness', () => {
 		assert.ok(allowedChannels.size > 0, 'Allowlist should not be empty');
 	});
 
-	it('contains expected core channels', () => {
-		const expectedChannels = [
-			'get-config',
-			'get-app-version',
-			'user-status-changed',
-			'set-badge-count',
-			'navigate-back',
-			'navigate-forward',
-			'play-notification-sound',
-			'show-notification',
-			'select-source',
-			'submitForm',
-			'offline-retry',
-		];
-		for (const channel of expectedChannels) {
-			assert.ok(allowedChannels.has(channel), `Expected core channel '${channel}' in allowlist`);
+	// Every channel registered under app/ must be allowlisted or app/index.js's
+	// ipcMain wrap rejects it at runtime as `Unauthorized IPC channel`. A
+	// hardcoded expected list would only pin today's channels — a channel
+	// registered later and forgotten in both the allowlist and the list passes
+	// silently (the shape of the `manage-profile-pin` miss caught in review on
+	// PR #2787). Scanning the source instead makes a new channel fail CI by
+	// default (#2821).
+	it('allowlists every channel registered under app/', () => {
+		const offenders = [];
+		let registrationCount = 0;
+		let literalCount = 0;
+		for (const file of collectSourceFiles(APP_DIR)) {
+			const source = readFileSync(file, 'utf8');
+			registrationCount += (source.match(IPC_REGISTRATION) || []).length;
+			for (const match of source.matchAll(IPC_CHANNEL_LITERAL)) {
+				literalCount++;
+				if (!allowedChannels.has(match[2])) {
+					offenders.push(`${path.relative(APP_DIR, file)}:${match[2]}`);
+				}
+			}
 		}
-	});
-
-	// ADR-020 multi-account channels. Every renderer-reachable channel the
-	// feature registers must be allowlisted or app/index.js's ipcMain wrap
-	// rejects it at runtime — a missing entry here shipped once (the Manage
-	// dialog's pin channel was allowlisted only in a working tree, so a clean
-	// build rejected every pin; caught in review on PR #2787).
-	it('contains every multi-account profile channel', () => {
-		const expectedChannels = [
-			'profile-list',
-			'profile-get-active',
-			'profile-switch',
-			'profile-add',
-			'profile-update',
-			'profile-remove',
-			'add-profile-submit',
-			'add-profile-cancel',
-			'manage-profile-rename',
-			'manage-profile-pin',
-			'manage-profile-remove',
-			'manage-profile-close',
-			'profile-switcher-open-add',
-			'profile-switcher-open-manage',
-			'profile-switcher-set-expanded',
-		];
-		for (const channel of expectedChannels) {
-			assert.ok(allowedChannels.has(channel), `Expected multi-account channel '${channel}' in allowlist`);
-		}
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			`Every registered IPC channel must be in app/security/ipcValidator.js's allowlist. Missing:\n  ${offenders.join('\n  ')}`
+		);
+		assert.strictEqual(
+			registrationCount,
+			literalCount,
+			'An ipcMain.handle/on/once registration does not pass its channel as a string literal, so this scanner cannot verify it against the allowlist. A human must check the channel is allowlisted consciously (or make it a literal).'
+		);
 	});
 });


### PR DESCRIPTION
With menubar hidden and multi-account on, attach only the Profiles menu so the Ctrl+Alt+1..5 chords survive without arming the rest of the app menu's accelerators (Ctrl+Q etc.), and replace the hardcoded IPC allowlist tests with a source scan of ipcMain registrations under app/.

closes #2821