### PR TITLE
feat(linux): background portal integration for Flatpak (#2815)

### DIFF
--- a/app/backgroundPortal/README.md
+++ b/app/backgroundPortal/README.md
@@ -1,0 +1,26 @@
+# Background Portal
+
+Bare-minimum integration with `org.freedesktop.portal.Background`
+(issue [#2815](https://github.com/IsmaelMartinez/teams-for-linux/issues/2815)).
+
+On startup, when running inside a Flatpak sandbox (`FLATPAK_ID` set), the
+module calls `RequestBackground` with a static reason and, when the portal is
+version 2 or newer and the request is granted, `SetStatus` with a short
+status line. Everything is fire-and-forget over the session D-Bus using
+`@homebridge/dbus-native`; failures degrade to log lines.
+
+What this does and does not change:
+
+- GNOME's Background Apps menu (GNOME 44+) already lists windowless Flatpak
+  apps automatically; this module is not what makes the app appear there.
+- `RequestBackground` records the background permission, which stops the
+  recurring "running in the background" prompt. If a user picked Forbid, the
+  portal SIGKILLs the app whenever it runs windowless; that is portal policy,
+  not something the app controls.
+- `SetStatus` adds the "Running in background" line under the entry.
+- Native, deb, AppImage and snap installs are unaffected: the portal's
+  background monitor only tracks Flatpak instances and `SetStatus` rejects
+  host callers.
+
+Diagnostic log lines (no PII): portal version, `RequestBackground`
+response code (0 granted, 1 dismissed, 2 error), and status-set confirmation.

--- a/app/backgroundPortal/index.js
+++ b/app/backgroundPortal/index.js
@@ -146,7 +146,7 @@ function requestBackground(sessionBus, callback) {
     }
     // Response signature is (ua{sv}); body[0] is 0 granted, 1 dismissed,
     // 2 error.
-    const code = Array.isArray(msg.body) ? Number(msg.body[0]) : NaN;
+    const code = Array.isArray(msg.body) ? Number(msg.body[0]) : Number.NaN;
     finish(Number.isFinite(code) ? code : 2);
   };
 

--- a/app/backgroundPortal/index.js
+++ b/app/backgroundPortal/index.js
@@ -1,0 +1,210 @@
+/**
+ * xdg-desktop-portal Background integration (issue #2815).
+ *
+ * GNOME's "Background Apps" menu (GNOME 44+) lists windowless Flatpak apps
+ * automatically via the portal's background monitor, so the app does not need
+ * to register to appear there. What calling the portal adds:
+ *
+ *   - `RequestBackground` records the background permission in the portal's
+ *     permission store, which suppresses the recurring "running in the
+ *     background" Allow/Forbid prompt cycle. An app the user forbade gets
+ *     SIGKILLed by the portal whenever it runs windowless, so surfacing the
+ *     request once, with a reason, is strictly better than never asking.
+ *   - `SetStatus` (portal version 2+) puts a short status line under the
+ *     app's entry in the Background Apps menu.
+ *
+ * Both calls are only meaningful inside a Flatpak sandbox: the background
+ * monitor enumerates Flatpak instances exclusively, and `SetStatus` rejects
+ * host callers. Snap and native installs are unaffected, hence the
+ * `FLATPAK_ID` gate.
+ *
+ * Electron has no built-in support for this portal (electron#32388), so the
+ * calls go over D-Bus directly, same as `app/intune` and the download
+ * manager's emitters.
+ */
+
+const dbus = require("@homebridge/dbus-native");
+
+const PORTAL_SERVICE = "org.freedesktop.portal.Desktop";
+const PORTAL_PATH = "/org/freedesktop/portal/desktop";
+const BACKGROUND_INTERFACE = "org.freedesktop.portal.Background";
+const REQUEST_INTERFACE = "org.freedesktop.portal.Request";
+// Shown by the portal backend in the permission dialog / notification.
+const REQUEST_REASON =
+  "Show notifications and keep calls ringing while the window is closed";
+// Shown under the app entry in GNOME's Background Apps menu. Portal limit is
+// 96 characters, single line.
+const STATUS_MESSAGE = "Running in background";
+// The response may sit behind a user-facing permission dialog, so the wait is
+// generous. After the timeout we only stop listening; nothing is aborted.
+const RESPONSE_TIMEOUT_MS = 30000;
+
+/**
+ * Request the background permission and, when granted on a v2+ portal, set
+ * the background status message. Fire-and-forget: every failure degrades to
+ * a warn/debug log, never to a startup error.
+ *
+ * @returns {boolean} whether the integration was attempted
+ */
+function init() {
+  if (process.platform !== "linux" || !process.env.FLATPAK_ID) {
+    return false;
+  }
+
+  let sessionBus;
+  try {
+    sessionBus = dbus.sessionBus();
+  } catch (error) {
+    console.warn("[BackgroundPortal] dbus sessionBus unavailable", {
+      message: error.message,
+    });
+    return false;
+  }
+
+  getPortalVersion(sessionBus, (version) => {
+    console.debug(`[BackgroundPortal] Portal version ${version}`);
+    requestBackground(sessionBus, (responseCode) => {
+      console.info(
+        `[BackgroundPortal] RequestBackground response=${responseCode}`
+      );
+      if (responseCode === 0 && version >= 2) {
+        setStatus(sessionBus);
+      }
+    });
+  });
+  return true;
+}
+
+/**
+ * Read the Background interface version property. Reports 1 when the probe
+ * fails, which keeps behaviour on the v1 path (no SetStatus).
+ */
+function getPortalVersion(sessionBus, callback) {
+  sessionBus.invoke(
+    {
+      destination: PORTAL_SERVICE,
+      path: PORTAL_PATH,
+      interface: "org.freedesktop.DBus.Properties",
+      member: "Get",
+      signature: "ss",
+      body: [BACKGROUND_INTERFACE, "version"],
+    },
+    (error, result) => {
+      if (error) {
+        console.warn("[BackgroundPortal] Version probe failed", {
+          message: String(error),
+        });
+        callback(1);
+        return;
+      }
+      // dbus-native marshals a variant as [signatureTree, [value]].
+      const raw = Array.isArray(result) ? result[1]?.[0] : result;
+      const version = Number(raw);
+      callback(Number.isFinite(version) ? version : 1);
+    }
+  );
+}
+
+/**
+ * Call RequestBackground and wait for the portal's asynchronous Response
+ * signal. The signal arrives on a Request object path ending in our
+ * handle_token, which is how the reply is matched without computing the
+ * sender-scoped path (that would race the method return anyway).
+ */
+function requestBackground(sessionBus, callback) {
+  const token = `tfl${Date.now().toString(36)}`;
+  let done = false;
+
+  const finish = (responseCode) => {
+    if (done) return;
+    done = true;
+    clearTimeout(timer);
+    sessionBus.connection.removeListener("message", onMessage);
+    if (responseCode !== null) {
+      callback(responseCode);
+    }
+  };
+
+  const onMessage = (msg) => {
+    if (msg?.interface !== REQUEST_INTERFACE || msg?.member !== "Response") {
+      return;
+    }
+    if (typeof msg.path !== "string" || !msg.path.endsWith(`/${token}`)) {
+      return;
+    }
+    // Response signature is (ua{sv}); body[0] is 0 granted, 1 dismissed,
+    // 2 error.
+    const code = Array.isArray(msg.body) ? Number(msg.body[0]) : NaN;
+    finish(Number.isFinite(code) ? code : 2);
+  };
+
+  const timer = setTimeout(() => {
+    console.debug("[BackgroundPortal] No Response signal before timeout");
+    finish(null);
+  }, RESPONSE_TIMEOUT_MS);
+  timer.unref?.();
+
+  sessionBus.connection.on("message", onMessage);
+  sessionBus.addMatch(
+    `type='signal',interface='${REQUEST_INTERFACE}',member='Response'`,
+    (matchError) => {
+      if (matchError) {
+        console.warn("[BackgroundPortal] addMatch failed", {
+          message: String(matchError),
+        });
+        finish(null);
+        return;
+      }
+      sessionBus.invoke(
+        {
+          destination: PORTAL_SERVICE,
+          path: PORTAL_PATH,
+          interface: BACKGROUND_INTERFACE,
+          member: "RequestBackground",
+          signature: "sa{sv}",
+          body: [
+            // Empty parent window: the request is not anchored to a window,
+            // which the portal accepts.
+            "",
+            [
+              ["handle_token", ["s", token]],
+              ["reason", ["s", REQUEST_REASON]],
+            ],
+          ],
+        },
+        (error) => {
+          if (error) {
+            console.warn("[BackgroundPortal] RequestBackground failed", {
+              message: String(error),
+            });
+            finish(null);
+          }
+        }
+      );
+    }
+  );
+}
+
+function setStatus(sessionBus) {
+  sessionBus.invoke(
+    {
+      destination: PORTAL_SERVICE,
+      path: PORTAL_PATH,
+      interface: BACKGROUND_INTERFACE,
+      member: "SetStatus",
+      signature: "a{sv}",
+      body: [[["message", ["s", STATUS_MESSAGE]]]],
+    },
+    (error) => {
+      if (error) {
+        console.warn("[BackgroundPortal] SetStatus failed", {
+          message: String(error),
+        });
+        return;
+      }
+      console.debug("[BackgroundPortal] Status message set");
+    }
+  );
+}
+
+module.exports = { init };

--- a/app/backgroundPortal/index.js
+++ b/app/backgroundPortal/index.js
@@ -23,8 +23,6 @@
  * manager's emitters.
  */
 
-const dbus = require("@homebridge/dbus-native");
-
 const PORTAL_SERVICE = "org.freedesktop.portal.Desktop";
 const PORTAL_PATH = "/org/freedesktop/portal/desktop";
 const BACKGROUND_INTERFACE = "org.freedesktop.portal.Background";
@@ -48,6 +46,18 @@ const RESPONSE_TIMEOUT_MS = 30000;
  */
 function init() {
   if (process.platform !== "linux" || !process.env.FLATPAK_ID) {
+    return false;
+  }
+
+  // Lazy require after the gate, same as the download-manager emitters, so
+  // non-Linux startups never load the D-Bus stack.
+  let dbus;
+  try {
+    dbus = require("@homebridge/dbus-native");
+  } catch (error) {
+    console.warn("[BackgroundPortal] dbus module unavailable", {
+      message: error.message,
+    });
     return false;
   }
 
@@ -113,6 +123,7 @@ function getPortalVersion(sessionBus, callback) {
  */
 function requestBackground(sessionBus, callback) {
   const token = `tfl${Date.now().toString(36)}`;
+  const matchRule = `type='signal',interface='${REQUEST_INTERFACE}',member='Response'`;
   let done = false;
 
   const finish = (responseCode) => {
@@ -120,6 +131,7 @@ function requestBackground(sessionBus, callback) {
     done = true;
     clearTimeout(timer);
     sessionBus.connection.removeListener("message", onMessage);
+    sessionBus.removeMatch?.(matchRule, () => {});
     if (responseCode !== null) {
       callback(responseCode);
     }
@@ -146,7 +158,7 @@ function requestBackground(sessionBus, callback) {
 
   sessionBus.connection.on("message", onMessage);
   sessionBus.addMatch(
-    `type='signal',interface='${REQUEST_INTERFACE}',member='Response'`,
+    matchRule,
     (matchError) => {
       if (matchError) {
         console.warn("[BackgroundPortal] addMatch failed", {

--- a/app/index.js
+++ b/app/index.js
@@ -118,6 +118,7 @@ const player = createPlayer();
 
 const certificateModule = require("./certificate");
 const clientCertificate = require("./clientCertificate");
+const backgroundPortal = require("./backgroundPortal");
 const CacheManager = require("./cacheManager");
 const gotTheLock = app.requestSingleInstanceLock();
 const mainAppWindow = require("./mainAppWindow");
@@ -721,6 +722,10 @@ async function handleAppReady() {
     certificateModule.installCertificateVerifyProc(config, app, session.defaultSession);
 
     await mainAppWindow.onAppReady(appConfig, customBackground, screenSharingService, profilesManager);
+
+    // Flatpak only: record the background permission with the desktop portal
+    // and set the Background Apps status line (issue #2815). No-op elsewhere.
+    backgroundPortal.init();
 
     // Wire per-profile WebContentsView lifecycle once the main window
     // exists. Bootstrap Profile 0 from the legacy partition so a

--- a/tests/unit/backgroundPortal.test.js
+++ b/tests/unit/backgroundPortal.test.js
@@ -1,0 +1,29 @@
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const backgroundPortal = require('../../app/backgroundPortal');
+
+// The granted path needs a real session bus and a Flatpak sandbox, so unit
+// coverage stops at the gate: outside Flatpak the module must decline to do
+// anything, on every platform.
+describe('backgroundPortal', () => {
+	const originalFlatpakId = process.env.FLATPAK_ID;
+
+	afterEach(() => {
+		if (originalFlatpakId === undefined) {
+			delete process.env.FLATPAK_ID;
+		} else {
+			process.env.FLATPAK_ID = originalFlatpakId;
+		}
+	});
+
+	it('does not initialise without FLATPAK_ID', () => {
+		delete process.env.FLATPAK_ID;
+		assert.strictEqual(backgroundPortal.init(), false);
+	});
+
+	it('does not initialise outside linux even with FLATPAK_ID set', { skip: process.platform === 'linux' }, () => {
+		process.env.FLATPAK_ID = 'com.github.IsmaelMartinez.teams_for_linux';
+		assert.strictEqual(backgroundPortal.init(), false);
+	});
+});

--- a/tests/unit/backgroundPortal.test.js
+++ b/tests/unit/backgroundPortal.test.js
@@ -1,15 +1,84 @@
-const { describe, it, afterEach } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
 
-const backgroundPortal = require('../../app/backgroundPortal');
+const MODULE_PATH = require.resolve('../../app/backgroundPortal');
+const DBUS_PATH = require.resolve('@homebridge/dbus-native');
 
-// The granted path needs a real session bus and a Flatpak sandbox, so unit
-// coverage stops at the gate: outside Flatpak the module must decline to do
-// anything, on every platform.
+// The dbus module is required lazily inside init(), so planting a fake in
+// require.cache before calling init() is enough to intercept the whole
+// portal conversation.
+function makeFakeBus({ portalVersion, responseCode }) {
+	const connection = new EventEmitter();
+	const calls = [];
+	return {
+		connection,
+		calls,
+		addMatch(rule, callback) {
+			calls.push({ member: 'addMatch', rule });
+			callback(null);
+		},
+		removeMatch(rule, callback) {
+			calls.push({ member: 'removeMatch', rule });
+			callback?.(null);
+		},
+		invoke(message, callback) {
+			calls.push(message);
+			if (message.member === 'Get') {
+				// dbus-native marshals the variant as [signatureTree, [value]].
+				callback(null, [[{ type: 'u' }], [portalVersion]]);
+				return;
+			}
+			if (message.member === 'RequestBackground') {
+				callback(null);
+				const token = message.body[1].find(([key]) => key === 'handle_token')[1][1];
+				setImmediate(() => {
+					connection.emit('message', {
+						interface: 'org.freedesktop.portal.Request',
+						member: 'Response',
+						path: `/org/freedesktop/portal/desktop/request/1_23/${token}`,
+						body: [responseCode, []],
+					});
+				});
+				return;
+			}
+			callback(null);
+		},
+	};
+}
+
+function loadWithFakeBus(fakeBus) {
+	require.cache[DBUS_PATH] = {
+		id: DBUS_PATH,
+		filename: DBUS_PATH,
+		loaded: true,
+		exports: { sessionBus: () => fakeBus },
+	};
+	delete require.cache[MODULE_PATH];
+	return require(MODULE_PATH);
+}
+
+async function waitFor(predicate) {
+	for (let i = 0; i < 50; i++) {
+		if (predicate()) return;
+		await new Promise((resolve) => setImmediate(resolve));
+	}
+	throw new Error('condition not reached');
+}
+
 describe('backgroundPortal', () => {
 	const originalFlatpakId = process.env.FLATPAK_ID;
+	const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+	beforeEach(() => {
+		delete require.cache[MODULE_PATH];
+		delete require.cache[DBUS_PATH];
+	});
 
 	afterEach(() => {
+		delete require.cache[MODULE_PATH];
+		delete require.cache[DBUS_PATH];
+		Object.defineProperty(process, 'platform', originalPlatform);
 		if (originalFlatpakId === undefined) {
 			delete process.env.FLATPAK_ID;
 		} else {
@@ -17,13 +86,54 @@ describe('backgroundPortal', () => {
 		}
 	});
 
+	function pretendFlatpakOnLinux() {
+		Object.defineProperty(process, 'platform', {
+			value: 'linux',
+			configurable: true,
+		});
+		process.env.FLATPAK_ID = 'com.github.IsmaelMartinez.teams_for_linux';
+	}
+
 	it('does not initialise without FLATPAK_ID', () => {
 		delete process.env.FLATPAK_ID;
-		assert.strictEqual(backgroundPortal.init(), false);
+		assert.strictEqual(require(MODULE_PATH).init(), false);
 	});
 
 	it('does not initialise outside linux even with FLATPAK_ID set', { skip: process.platform === 'linux' }, () => {
 		process.env.FLATPAK_ID = 'com.github.IsmaelMartinez.teams_for_linux';
-		assert.strictEqual(backgroundPortal.init(), false);
+		assert.strictEqual(require(MODULE_PATH).init(), false);
+	});
+
+	it('requests background and sets status when granted on a v2 portal', async () => {
+		pretendFlatpakOnLinux();
+		const bus = makeFakeBus({ portalVersion: 2, responseCode: 0 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'SetStatus'));
+
+		const request = bus.calls.find((c) => c.member === 'RequestBackground');
+		assert.strictEqual(request.signature, 'sa{sv}');
+		assert.ok(request.body[1].some(([key]) => key === 'reason'));
+		assert.ok(bus.calls.some((c) => c.member === 'removeMatch'));
+	});
+
+	it('skips SetStatus on a v1 portal even when granted', async () => {
+		pretendFlatpakOnLinux();
+		const bus = makeFakeBus({ portalVersion: 1, responseCode: 0 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+		assert.ok(!bus.calls.some((c) => c.member === 'SetStatus'));
+	});
+
+	it('does not set status when the request is dismissed', async () => {
+		pretendFlatpakOnLinux();
+		const bus = makeFakeBus({ portalVersion: 2, responseCode: 1 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+		assert.ok(!bus.calls.some((c) => c.member === 'SetStatus'));
 	});
 });

--- a/tests/unit/backgroundPortal.test.js
+++ b/tests/unit/backgroundPortal.test.js
@@ -113,7 +113,9 @@ describe('backgroundPortal', () => {
 
 		const request = bus.calls.find((c) => c.member === 'RequestBackground');
 		assert.strictEqual(request.signature, 'sa{sv}');
-		assert.ok(request.body[1].some(([key]) => key === 'reason'));
+		const options = request.body[1];
+		assert.ok(Array.isArray(options));
+		assert.ok(options.some(([key]) => key === 'reason'));
 		assert.ok(bus.calls.some((c) => c.member === 'removeMatch'));
 	});
 


### PR DESCRIPTION
Adds a Flatpak-only `app/backgroundPortal` module that calls `org.freedesktop.portal.Background` `RequestBackground` on startup (records the background permission, so GNOME stops cycling the Allow/Forbid prompt) and `SetStatus` on v2+ portals, which puts a status line under the app in GNOME's Background Apps menu. Gated on `FLATPAK_ID`, fire-and-forget over the session bus, and the log carries the portal version and response code so reports can tell us what the portal answered.

closes #2815
