### PR TITLE
fix(deps): bump nanoid in docs-site lockfile to clear advisory #211

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -15764,9 +15764,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Refreshes docs-site/package-lock.json via `npm update --package-lock-only nanoid` to resolve nanoid@3.3.18; no manifest change. This clears Dependabot alert #211 (nanoid); alerts #210 and #209 (image-size) are left open because no patched image-size version exists upstream yet.