### PR TITLE
fix(webauthn): sign the iframe's own origin for relayed ceremonies (#2828)

### DIFF
--- a/app/browser/tools/webauthnOverride.js
+++ b/app/browser/tools/webauthnOverride.js
@@ -142,7 +142,11 @@ function init(config, ipcRenderer) {
     }
     console.info("[WEBAUTHN] Relaying subframe request", { channel });
     try {
-      const result = await ipcRenderer.invoke(channel, data);
+      // event.origin is set by the browser, not by the frame, so it is the one
+      // trustworthy record of which origin the ceremony belongs to. The main
+      // process signs it instead of our own (outer) origin, and re-checks it
+      // against the allowlist. See #2719.
+      const result = await ipcRenderer.invoke(channel, { ...data, frameOrigin: event.origin });
       if (result.success) {
         event.source.postMessage({ type: "webauthn-response", id, result: result.data }, event.origin);
       } else {

--- a/app/browser/tools/webauthnOverride.js
+++ b/app/browser/tools/webauthnOverride.js
@@ -145,7 +145,7 @@ function init(config, ipcRenderer) {
       // event.origin is set by the browser, not by the frame, so it is the one
       // trustworthy record of which origin the ceremony belongs to. The main
       // process signs it instead of our own (outer) origin, and re-checks it
-      // against the allowlist. See #2719.
+      // against the allowlist. See #2828.
       const result = await ipcRenderer.invoke(channel, { ...data, frameOrigin: event.origin });
       if (result.success) {
         event.source.postMessage({ type: "webauthn-response", id, result: result.data }, event.origin);

--- a/app/webauthn/fido2Backend.js
+++ b/app/webauthn/fido2Backend.js
@@ -182,11 +182,12 @@ function coseAlgToFido2Type(alg) {
  * @param {string} type - "webauthn.create" or "webauthn.get"
  * @param {string} challenge - base64url-encoded challenge
  * @param {string} origin - Request origin
+ * @param {string|null} [topOrigin] - Top-level origin for an iframe ceremony
  * @returns {{ clientDataJSON: Buffer, clientDataHash: Buffer }}
  */
-function prepareClientData(type, challenge, origin) {
+function prepareClientData(type, challenge, origin, topOrigin = null) {
   const challengeBytes = base64urlDecode(challenge);
-  const clientDataJSON = generateClientDataJSON(type, challengeBytes, origin);
+  const clientDataJSON = generateClientDataJSON(type, challengeBytes, origin, topOrigin);
   const clientDataHash = createHash("sha256").update(clientDataJSON).digest();
   return { clientDataJSON, clientDataHash };
 }
@@ -255,7 +256,7 @@ async function createCredential(options) {
     attestation: options.attestation || "none",
   });
 
-  const { clientDataJSON, clientDataHash } = prepareClientData("webauthn.create", options.challenge, options.origin);
+  const { clientDataJSON, clientDataHash } = prepareClientData("webauthn.create", options.challenge, options.origin, options.topOrigin);
 
   // fido2-tools expect standard base64, not hex (validated by rlavriv).
   const inputLines = [
@@ -338,7 +339,7 @@ async function getAssertion(options) {
     credCount: options.allowCredentials?.length || 0,
   });
 
-  const { clientDataJSON, clientDataHash } = prepareClientData("webauthn.get", options.challenge, options.origin);
+  const { clientDataJSON, clientDataHash } = prepareClientData("webauthn.get", options.challenge, options.origin, options.topOrigin);
 
   // fido2-tools expect standard base64, not hex (same as createCredential).
   const inputLines = [clientDataHash.toString("base64"), sanitizeForFido2(options.rpId)];

--- a/app/webauthn/helpers.js
+++ b/app/webauthn/helpers.js
@@ -40,15 +40,21 @@ function base64urlDecode(str) {
  *
  * @param {string} type - "webauthn.create" or "webauthn.get"
  * @param {Buffer} challengeBytes - Raw challenge bytes
- * @param {string} origin - Origin string (e.g. "https://login.microsoftonline.com")
+ * @param {string} origin - Origin of the frame that called navigator.credentials
+ * @param {string|null} [topOrigin] - Origin of the top-level document, when the
+ *   ceremony ran in a frame. Only differs from `origin` for an iframe ceremony,
+ *   which is what makes it cross-origin.
  * @returns {Buffer}
  */
-function generateClientDataJSON(type, challengeBytes, origin) {
+function generateClientDataJSON(type, challengeBytes, origin, topOrigin = null) {
+  const crossOrigin = Boolean(topOrigin) && topOrigin !== origin;
   const clientData = JSON.stringify({
     type,
     challenge: base64urlEncode(challengeBytes),
     origin,
-    crossOrigin: false,
+    crossOrigin,
+    // topOrigin is defined only for a cross-origin ceremony (WebAuthn L3).
+    ...(crossOrigin ? { topOrigin } : {}),
   });
   return Buffer.from(clientData, "utf-8");
 }

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -78,15 +78,24 @@ async function collectPin(sender) {
  * @param {object} options
  */
 async function handleWebauthnRequest(operation, event, options) {
-  let origin;
+  let senderOrigin;
   try {
-    origin = event.senderFrame?.origin || new URL(event.sender.getURL()).origin;
+    senderOrigin = event.senderFrame?.origin || new URL(event.sender.getURL()).origin;
   } catch {
     log.warn("[WEBAUTHN] Blocked request", { op: operation, reason: "no-origin" });
     return { success: false, error: "SecurityError: could not determine origin" };
   }
 
-  if (!isAllowedOrigin(origin)) {
+  // A ceremony started inside a login iframe is relayed through the main frame's
+  // preload, so the IPC sender is the outer frame. The key has to sign the origin
+  // of the frame that actually called navigator.credentials, or the relying party
+  // discards an assertion we consider successful (#2719). `frameOrigin` is the
+  // browser's own MessageEvent.origin for that frame, and is held to the same
+  // allowlist as the sender before anything signs it.
+  const origin = options?.frameOrigin || senderOrigin;
+  const relayed = origin !== senderOrigin;
+
+  if (!isAllowedOrigin(senderOrigin) || !isAllowedOrigin(origin)) {
     log.warn("[WEBAUTHN] Blocked request", {
       op: operation,
       reason: "origin-not-allowed",
@@ -101,6 +110,7 @@ async function handleWebauthnRequest(operation, event, options) {
   log.info("[WEBAUTHN] Processing request", {
     op: operation,
     originClass: log.classifyOrigin(origin),
+    relayed,
     timeoutSec: options?.timeout ?? null,
   });
 
@@ -131,8 +141,8 @@ async function handleWebauthnRequest(operation, event, options) {
     const touchStartedAt = Date.now();
     try {
       const result = operation === "create"
-        ? await fido2Backend.createCredential({ ...options, origin, preCollectedPin })
-        : await fido2Backend.getAssertion({ ...options, origin, preCollectedPin });
+        ? await fido2Backend.createCredential({ ...options, origin, topOrigin: senderOrigin, preCollectedPin })
+        : await fido2Backend.getAssertion({ ...options, origin, topOrigin: senderOrigin, preCollectedPin });
       touchMs = Date.now() - touchStartedAt;
       log.info("[WEBAUTHN] Succeeded", { op: operation, totalMs: Date.now() - startedAt, pinMs, touchMs });
       return { success: true, data: result };
@@ -252,7 +262,9 @@ function injectIntoFrame(wf) {
           response: { attestationObject: b64urlToBuf(r.attestationObject), clientDataJSON: b64urlToBuf(r.clientDataJson),
             getAuthenticatorData: () => b64urlToBuf(r.authenticatorData), getTransports: () => r.transports || ["usb"],
             getPublicKey: () => null, getPublicKeyAlgorithm: () => r.publicKeyAlgorithm || -7 },
-          getClientExtensionResults: () => ({}) };
+          getClientExtensionResults: () => ({}),
+          toJSON: () => ({ id: r.credentialId, rawId: r.rawId, type: r.type,
+            response: { attestationObject: r.attestationObject, clientDataJSON: r.clientDataJson } }) };
       };
 
       navigator.credentials.get = async function(opts) {
@@ -261,10 +273,16 @@ function injectIntoFrame(wf) {
         console.info("[WEBAUTHN:frame] Intercepting credentials.get()");
         const r = await ipcInvoke("webauthn:get", serGet(opts.publicKey));
         const raw = b64urlToBuf(r.rawId);
+        const authData = b64urlToBuf(r.authenticatorData);
         return { id: r.credentialId, rawId: raw, type: r.type, authenticatorAttachment: "cross-platform",
-          response: { authenticatorData: b64urlToBuf(r.authenticatorData), clientDataJSON: b64urlToBuf(r.clientDataJson),
-            signature: b64urlToBuf(r.signature), userHandle: r.userHandle ? b64urlToBuf(r.userHandle) : null },
-          getClientExtensionResults: () => ({}) };
+          response: { authenticatorData: authData, clientDataJSON: b64urlToBuf(r.clientDataJson),
+            signature: b64urlToBuf(r.signature), userHandle: r.userHandle ? b64urlToBuf(r.userHandle) : null,
+            getAuthenticatorData: () => authData },
+          getClientExtensionResults: () => ({}),
+          toJSON: () => ({ id: r.credentialId, rawId: r.rawId, type: r.type,
+            authenticatorAttachment: "cross-platform", clientExtensionResults: {},
+            response: { authenticatorData: r.authenticatorData, clientDataJSON: r.clientDataJson,
+              signature: r.signature, userHandle: r.userHandle || null } }) };
       };
 
       console.info("[WEBAUTHN:frame] navigator.credentials patched in subframe");

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -89,7 +89,7 @@ async function handleWebauthnRequest(operation, event, options) {
   // A ceremony started inside a login iframe is relayed through the main frame's
   // preload, so the IPC sender is the outer frame. The key has to sign the origin
   // of the frame that actually called navigator.credentials, or the relying party
-  // discards an assertion we consider successful (#2719). `frameOrigin` is the
+  // discards an assertion we consider successful (#2828). `frameOrigin` is the
   // browser's own MessageEvent.origin for that frame, and is held to the same
   // allowlist as the sender before anything signs it.
   const origin = options?.frameOrigin || senderOrigin;

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -167,6 +167,42 @@ describe('WebAuthn helpers - generateClientDataJSON', () => {
 		const json = generateClientDataJSON('webauthn.get', Buffer.from('x'), 'https://example.com');
 		assert.ok(Buffer.isBuffer(json));
 	});
+
+	// A ceremony relayed out of a login iframe signs the iframe's origin, with
+	// the top-level document recorded separately (#2719).
+	it('marks a ceremony cross-origin and records topOrigin when the frame differs', () => {
+		const json = generateClientDataJSON(
+			'webauthn.get',
+			Buffer.from('c'),
+			'https://login.live.com',
+			'https://login.microsoft.com'
+		);
+		const parsed = JSON.parse(json.toString('utf-8'));
+
+		assert.strictEqual(parsed.origin, 'https://login.live.com');
+		assert.strictEqual(parsed.crossOrigin, true);
+		assert.strictEqual(parsed.topOrigin, 'https://login.microsoft.com');
+	});
+
+	it('omits topOrigin and stays same-origin for a main-frame ceremony', () => {
+		const sameOrigin = generateClientDataJSON(
+			'webauthn.get',
+			Buffer.from('c'),
+			'https://login.microsoft.com',
+			'https://login.microsoft.com'
+		);
+		const parsed = JSON.parse(sameOrigin.toString('utf-8'));
+
+		assert.strictEqual(parsed.crossOrigin, false);
+		assert.ok(!('topOrigin' in parsed));
+		// Byte-identical to the pre-change call, so main-frame logins are untouched.
+		const withoutTopOrigin = generateClientDataJSON(
+			'webauthn.get',
+			Buffer.from('c'),
+			'https://login.microsoft.com'
+		);
+		assert.deepStrictEqual(sameOrigin, withoutTopOrigin);
+	});
 });
 
 describe('WebAuthn helpers - sanitizeForFido2', () => {

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -198,7 +198,12 @@ describe('WebAuthn helpers - generateClientDataJSON', () => {
 
 		assert.strictEqual(parsed.crossOrigin, false);
 		assert.ok(!('topOrigin' in parsed));
-		// Byte-identical to the pre-change call, so main-frame logins are untouched.
+		// Pinned to the exact pre-#2829 byte layout, so main-frame logins are
+		// untouched by construction, not by both calls drifting together.
+		assert.strictEqual(
+			sameOrigin.toString('utf-8'),
+			'{"type":"webauthn.get","challenge":"Yw","origin":"https://login.microsoft.com","crossOrigin":false}'
+		);
 		const withoutTopOrigin = generateClientDataJSON(
 			'webauthn.get',
 			Buffer.from('c'),

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -172,7 +172,7 @@ describe('WebAuthn helpers - generateClientDataJSON', () => {
 	});
 
 	// A ceremony relayed out of a login iframe signs the iframe's origin, with
-	// the top-level document recorded separately (#2719).
+	// the top-level document recorded separately (#2828).
 	it('marks a ceremony cross-origin and records topOrigin when the frame differs', () => {
 		const json = generateClientDataJSON(
 			'webauthn.get',

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -2,6 +2,9 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
 const { encode: cborEncode, decode: cborDecode } = require('cbor-x');
 const { base64urlEncode, base64urlDecode, generateClientDataJSON, sanitizeForFido2 } = require('../../app/webauthn/helpers');
 
@@ -518,5 +521,31 @@ describe('WebAuthn fido2Backend - stdin line construction', () => {
 		}
 
 		assert.strictEqual(allLines[2], '1234');
+	});
+});
+
+// The subframe override is a template string run through executeJavaScript, so
+// a syntax error in it fails silently at runtime and surfaces only as logins
+// not working inside the login iframe. Nothing else parses it.
+describe('WebAuthn subframe injection - injected script', () => {
+	const injected = (() => {
+		const src = readFileSync(path.join(__dirname, '..', '..', 'app', 'webauthn', 'index.js'), 'utf8');
+		const start = src.indexOf('wf.executeJavaScript(String.raw`');
+		assert.notStrictEqual(start, -1, 'injected block not found');
+		const open = src.indexOf('`', start);
+		const close = src.indexOf('`)', open + 1);
+		assert.notStrictEqual(close, -1, 'closing backtick not found');
+		return src.slice(open + 1, close);
+	})();
+
+	it('parses as valid JavaScript', () => {
+		assert.doesNotThrow(() => new vm.Script(injected, { filename: 'injected-subframe.js' }));
+	});
+
+	// The relayed credential has to carry the same members as the main-frame
+	// reconstruction or the page serialises a different body (#2828).
+	it('gives the relayed credential toJSON and getAuthenticatorData', () => {
+		assert.ok(injected.includes('toJSON'));
+		assert.ok(injected.includes('getAuthenticatorData'));
 	});
 });


### PR DESCRIPTION
A WebAuthn ceremony started inside a Microsoft login iframe is relayed through the main frame's preload, so the IPC sender was the outer document and the key signed the wrong origin, which makes the relying party discard an assertion our logs record as successful. The relay now forwards the browser-provided `MessageEvent.origin` (re-checked against the allowlist before signing), records the top-level document as `topOrigin`, and the relayed credential gains the `toJSON` and `getAuthenticatorData` the main-frame path already had.

Main-frame ceremonies produce byte-identical `clientDataJSON`, which a test pins.

closes #2828
