### PR TITLE
perf: bound timestamp polling, cache tray base icon, parallelise cache scans

### DIFF
--- a/app/browser/tools/timestampCopyOverride.js
+++ b/app/browser/tools/timestampCopyOverride.js
@@ -1,10 +1,19 @@
 const ReactHandler = require("./reactHandler");
 
+// Bounded retry: stop polling instead of polling forever when Teams never
+// exposes the core settings API. 120 consecutive misses (~2 minutes at the
+// 1s poll) covers a cold Teams SPA boot on slow hardware.
+const MAX_APPLY_ATTEMPTS = 120;
+
 class TimestampCopyOverride {
     overrideInterval = null;
+    #applyAttempts = 0;
 
     init(config) {
+        // Idempotent: a second init must not orphan the running timer
+        if (this.overrideInterval) return;
         this.config = config;
+        this.#applyAttempts = 0;
         this.overrideInterval = setInterval(() => this.applyOverride(), 1000);
     }
 
@@ -16,8 +25,36 @@ class TimestampCopyOverride {
     }
 
     applyOverride() {
+        try {
+            if (this.#tryApplyOverride()) {
+                // The cap counts consecutive failures, not lifetime ones
+                this.#applyAttempts = 0;
+            } else {
+                this.#chargeAttempt();
+            }
+        } catch (error) {
+            // A throwing settings API (e.g. get('compose') returning
+            // undefined) is charged against the same attempt budget so it
+            // cannot keep throwing out of the interval callback forever.
+            console.debug('[TIMESTAMP_COPY] Apply attempt failed:', error.message);
+            this.#chargeAttempt();
+        }
+    }
+
+    #chargeAttempt() {
+        this.#applyAttempts += 1;
+        if (this.#applyAttempts >= MAX_APPLY_ATTEMPTS) {
+            console.warn(`[TIMESTAMP_COPY] Teams core settings never appeared after ${MAX_APPLY_ATTEMPTS} attempts; disableTimestampOnCopy will not apply this session, reload the window to retry.`);
+            this.stop();
+        }
+    }
+
+    // Returns true once the override work ran against a live settings API.
+    #tryApplyOverride() {
         const coreServices = ReactHandler._getTeams2CoreServices();
-        if (!coreServices?.coreSettings) return;
+        if (!coreServices?.coreSettings) {
+            return false;
+        }
 
         const coreSettings = coreServices.coreSettings;
 
@@ -76,6 +113,8 @@ class TimestampCopyOverride {
                 return composeSubject._originalNext.call(this, value);
             };
         }
+
+        return true;
     }
 }
 

--- a/app/browser/tools/timestampCopyOverride.js
+++ b/app/browser/tools/timestampCopyOverride.js
@@ -35,7 +35,7 @@ class TimestampCopyOverride {
             // A throwing settings API (e.g. get('compose') returning
             // undefined) is charged against the same attempt budget so it
             // cannot keep throwing out of the interval callback forever.
-            console.debug('[TIMESTAMP_COPY] Apply attempt failed:', error.message);
+            console.debug('[TIMESTAMP_COPY] Apply attempt failed:', error?.message ?? String(error));
         }
 
         this.#applyAttempts += 1;

--- a/app/browser/tools/timestampCopyOverride.js
+++ b/app/browser/tools/timestampCopyOverride.js
@@ -29,19 +29,15 @@ class TimestampCopyOverride {
             if (this.#tryApplyOverride()) {
                 // The cap counts consecutive failures, not lifetime ones
                 this.#applyAttempts = 0;
-            } else {
-                this.#chargeAttempt();
+                return;
             }
         } catch (error) {
             // A throwing settings API (e.g. get('compose') returning
             // undefined) is charged against the same attempt budget so it
             // cannot keep throwing out of the interval callback forever.
             console.debug('[TIMESTAMP_COPY] Apply attempt failed:', error.message);
-            this.#chargeAttempt();
         }
-    }
 
-    #chargeAttempt() {
         this.#applyAttempts += 1;
         if (this.#applyAttempts >= MAX_APPLY_ATTEMPTS) {
             console.warn(`[TIMESTAMP_COPY] Teams core settings never appeared after ${MAX_APPLY_ATTEMPTS} attempts; disableTimestampOnCopy will not apply this session, reload the window to retry.`);

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -86,13 +86,6 @@ class TrayIconRenderer {
     }
   }
 
-  // The data URL never changes for a given base icon, so compute it once
-  // instead of re-encoding the icon on every render.
-  #getBaseIconDataUrl() {
-    this.#baseIconDataUrl ??= this.baseIcon.toDataURL("image/png");
-    return this.#baseIconDataUrl;
-  }
-
   render(newActivityCount) {
     return new Promise((resolve) => {
       const canvas = document.createElement("canvas");
@@ -100,7 +93,10 @@ class TrayIconRenderer {
       canvas.width = 140;
       const image = new Image();
       
-      const baseIconData = this.#getBaseIconDataUrl();
+      // The data URL never changes for a given base icon, so encode it once
+      // instead of re-encoding on every render.
+      this.#baseIconDataUrl ??= this.baseIcon.toDataURL("image/png");
+      const baseIconData = this.#baseIconDataUrl;
       
       image.onerror = () => {
         console.error("Failed to load base icon for tray rendering");

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -3,12 +3,16 @@ const TrayIconChooser = require("./trayIconChooser");
 class TrayIconRenderer {
   #lastRequestedCount;
   #updateSequence = 0;
+  #baseIconDataUrl = null;
 
   init(config, ipcRenderer) {
     this.ipcRenderer = ipcRenderer;
     this.config = config;
     const iconChooser = new TrayIconChooser(config);
     this.baseIcon = nativeImage.createFromPath(iconChooser.getFile());
+    // Defensive cache reset only; re-running init() is not otherwise safe
+    // (it would double-register the unread-count listener)
+    this.#baseIconDataUrl = null;
     this.iconSize = this.baseIcon.getSize();
     globalThis.addEventListener(
       "unread-count",
@@ -82,15 +86,21 @@ class TrayIconRenderer {
     }
   }
 
+  // The data URL never changes for a given base icon, so compute it once
+  // instead of re-encoding the icon on every render.
+  #getBaseIconDataUrl() {
+    this.#baseIconDataUrl ??= this.baseIcon.toDataURL("image/png");
+    return this.#baseIconDataUrl;
+  }
+
   render(newActivityCount) {
-    const IMAGE_PNG = "image/png";
     return new Promise((resolve) => {
       const canvas = document.createElement("canvas");
       canvas.height = 140;
       canvas.width = 140;
       const image = new Image();
       
-      const baseIconData = this.baseIcon.toDataURL(IMAGE_PNG);
+      const baseIconData = this.#getBaseIconDataUrl();
       
       image.onerror = () => {
         console.error("Failed to load base icon for tray rendering");

--- a/app/cacheManager/index.js
+++ b/app/cacheManager/index.js
@@ -219,8 +219,9 @@ class CacheManager {
       await fsp.rmdir(filePath);
     } catch (error) {
       // A directory left non-empty (entries failed to delete or reappeared)
-      // is routine; anything else counts toward the aggregate failure log.
-      if (error.code !== 'ENOTEMPTY') {
+      // and rmdir refusing a symlinked directory path (ENOTDIR) are routine;
+      // anything else counts toward the aggregate failure log.
+      if (error.code !== 'ENOTEMPTY' && error.code !== 'ENOTDIR') {
         throw error;
       }
     }

--- a/app/cacheManager/index.js
+++ b/app/cacheManager/index.js
@@ -14,6 +14,11 @@ const electron = require("electron");
  * tokens and prevent 24-hour forced re-authentication cycles.
  */
 
+// Directory scans and cleans process entries in fixed-size chunks, bounding
+// in-flight fs operations to roughly chunk size times tree depth instead of
+// fanning out over the whole tree at once (libuv threadpool starvation).
+const SCAN_CHUNK_SIZE = 32;
+
 class CacheManager {
   constructor(config) {
     this.config = config;
@@ -163,30 +168,25 @@ class CacheManager {
 
   async cleanDirectory(dirPath) {
     try {
-      const files = await fsp.readdir(dirPath);
+      const entries = await fsp.readdir(dirPath, { withFileTypes: true });
 
-      for (const file of files) {
-        const filePath = path.join(dirPath, file);
-        const stat = await fsp.stat(filePath);
-
-        if (stat.isDirectory()) {
-          await this.cleanDirectory(filePath);
-          // Try to remove empty directory
-          try {
-            await fsp.rmdir(filePath);
-          } catch (error) {
-            if (error.code === 'ENOTEMPTY') {
-              console.debug("Directory not empty, skipping rmdir:", filePath);
-            } else {
-              console.warn("Failed to remove directory:", {
-                path: filePath,
-                error: error.message,
-              });
-            }
+      const failureCodes = [];
+      await this.#mapInChunks(entries, async (entry) => {
+        try {
+          await this.#cleanEntry(path.join(dirPath, entry.name), entry);
+        } catch (error) {
+          // ENOENT means the entry vanished mid-clean; routine cache churn
+          if (error.code !== 'ENOENT') {
+            failureCodes.push(error.code || 'UNKNOWN');
           }
-        } else {
-          await fsp.unlink(filePath);
         }
+      });
+
+      if (failureCodes.length > 0) {
+        console.warn(`Failed to clean ${failureCodes.length} of ${entries.length} entries:`, {
+          path: dirPath,
+          errorCodes: [...new Set(failureCodes)],
+        });
       }
 
       console.debug("Cleaned directory:", dirPath);
@@ -198,6 +198,48 @@ class CacheManager {
     }
   }
 
+  /**
+   * Delete a single directory entry. Dirents report symlinks as
+   * isSymbolicLink() without following them; fsp.stat (which follows links)
+   * preserves the previous behaviour of traversing symlinked directories.
+   */
+  async #cleanEntry(filePath, entry) {
+    let isDirectory = entry.isDirectory();
+    if (entry.isSymbolicLink()) {
+      isDirectory = (await fsp.stat(filePath)).isDirectory();
+    }
+
+    if (!isDirectory) {
+      await fsp.unlink(filePath);
+      return;
+    }
+
+    await this.cleanDirectory(filePath);
+    try {
+      await fsp.rmdir(filePath);
+    } catch (error) {
+      // A directory left non-empty (entries failed to delete or reappeared)
+      // is routine; anything else counts toward the aggregate failure log.
+      if (error.code !== 'ENOTEMPTY') {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Run worker over items in fixed-size chunks: chunks run sequentially and
+   * items within a chunk run concurrently via Promise.allSettled, so the
+   * returned promise settles only after every worker has finished.
+   */
+  async #mapInChunks(items, worker) {
+    const results = [];
+    for (let index = 0; index < items.length; index += SCAN_CHUNK_SIZE) {
+      const chunk = items.slice(index, index + SCAN_CHUNK_SIZE);
+      results.push(...(await Promise.allSettled(chunk.map(worker))));
+    }
+    return results;
+  }
+
   async getDirSize(dirPath) {
     let totalSize = 0;
     try {
@@ -207,18 +249,13 @@ class CacheManager {
       }
 
       if (stat.isDirectory()) {
-        const files = await fsp.readdir(dirPath);
-
-        for (const file of files) {
-          const filePath = path.join(dirPath, file);
-          try {
-            totalSize += await this.getDirSize(filePath);
-          } catch (error) {
-            // Skip files that can't be accessed (e.g., permission errors, broken symlinks)
-            console.debug("Skipping inaccessible file:", {
-              path: filePath,
-              error: error.message,
-            });
+        const entries = await fsp.readdir(dirPath, { withFileTypes: true });
+        const results = await this.#mapInChunks(entries, (entry) =>
+          this.#entrySize(path.join(dirPath, entry.name), entry)
+        );
+        for (const result of results) {
+          if (result.status === 'fulfilled') {
+            totalSize += result.value;
           }
         }
       }
@@ -234,6 +271,34 @@ class CacheManager {
     }
 
     return totalSize;
+  }
+
+  /**
+   * Size contribution of one directory entry. Directories and symlinks
+   * recurse through getDirSize, whose top-level fsp.stat follows links,
+   * matching the previous stat-per-entry behaviour (broken links resolve
+   * to 0). ENOENT is silent: entries evicted mid-scan are routine churn.
+   */
+  async #entrySize(entryPath, entry) {
+    if (entry.isDirectory() || entry.isSymbolicLink()) {
+      return this.getDirSize(entryPath);
+    }
+
+    if (!entry.isFile()) {
+      return 0; // sockets, FIFOs, etc. contributed no size before either
+    }
+
+    try {
+      return (await fsp.stat(entryPath)).size;
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.debug("Skipping inaccessible file:", {
+          path: entryPath,
+          error: error.message,
+        });
+      }
+      return 0;
+    }
   }
 
   async getCacheStats() {

--- a/app/cacheManager/index.js
+++ b/app/cacheManager/index.js
@@ -262,12 +262,11 @@ class CacheManager {
     } catch (error) {
       if (error.code === 'ENOENT') {
         return 0; // Path does not exist, size is 0
-      } else {
-        console.debug("Error accessing path:", {
-          path: dirPath,
-          error: error.message,
-        });
       }
+      console.debug("Error accessing path:", {
+        path: dirPath,
+        error: error.message,
+      });
     }
 
     return totalSize;

--- a/app/cacheManager/index.js
+++ b/app/cacheManager/index.js
@@ -14,9 +14,14 @@ const electron = require("electron");
  * tokens and prevent 24-hour forced re-authentication cycles.
  */
 
-// Directory scans and cleans process entries in fixed-size chunks, bounding
-// in-flight fs operations to roughly chunk size times tree depth instead of
-// fanning out over the whole tree at once (libuv threadpool starvation).
+// Directory scans and cleans process entries in fixed-size chunks rather than
+// fanning out over a whole directory at once (libuv threadpool starvation).
+// The chunk bounds concurrency per directory, not across the recursion: each
+// subdirectory worker opens its own chunk, so the worst case is exponential in
+// tree depth. Chromium cache trees are wide and shallow (the volume is files at
+// the leaves, which is exactly what chunking parallelises), so in practice
+// in-flight operations stay near the chunk size. Revisit with a shared
+// semaphore if this ever runs over a deep tree.
 const SCAN_CHUNK_SIZE = 32;
 
 class CacheManager {

--- a/tests/unit/cacheManager.test.js
+++ b/tests/unit/cacheManager.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const electronPath = require.resolve('electron');
+const cacheManagerPath = require.resolve('../../app/cacheManager');
+
+let tempRoot;
+let CacheManager;
+
+function installElectronMock(userDataPath) {
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: {
+      app: {
+        getPath: () => userDataPath,
+      },
+    },
+  };
+
+  delete require.cache[cacheManagerPath];
+  CacheManager = require('../../app/cacheManager');
+}
+
+function cleanupElectronMock() {
+  delete require.cache[electronPath];
+  delete require.cache[cacheManagerPath];
+  CacheManager = undefined;
+}
+
+function makeManager() {
+  return new CacheManager({ partition: 'persist:teams-4-linux' });
+}
+
+describe('CacheManager directory scanning', () => {
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cache-manager-test-'));
+    installElectronMock(tempRoot);
+  });
+
+  afterEach(() => {
+    cleanupElectronMock();
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  describe('getDirSize', () => {
+    it('sums file sizes recursively, following symlinks', async () => {
+      const dir = path.join(tempRoot, 'scan');
+      fs.mkdirSync(path.join(dir, 'sub'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'aaaaa'); // 5 bytes
+      fs.writeFileSync(path.join(dir, 'sub', 'b.txt'), 'bbbbbbbbbb'); // 10 bytes
+
+      // Symlink to a file outside the scanned directory counts the target size
+      const outsideFile = path.join(tempRoot, 'outside.txt');
+      fs.writeFileSync(outsideFile, 'ccccccc'); // 7 bytes
+      fs.symlinkSync(outsideFile, path.join(dir, 'link-to-file'));
+
+      const size = await makeManager().getDirSize(dir);
+      assert.strictEqual(size, 22);
+    });
+
+    it('counts broken symlinks as zero without failing the scan', async () => {
+      const dir = path.join(tempRoot, 'scan-broken');
+      fs.mkdirSync(dir);
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'aaa'); // 3 bytes
+      fs.symlinkSync(path.join(tempRoot, 'does-not-exist'), path.join(dir, 'broken'));
+
+      const size = await makeManager().getDirSize(dir);
+      assert.strictEqual(size, 3);
+    });
+
+    it('returns 0 for a missing path', async () => {
+      const size = await makeManager().getDirSize(path.join(tempRoot, 'missing'));
+      assert.strictEqual(size, 0);
+    });
+
+    it('returns the file size when given a file path', async () => {
+      const filePath = path.join(tempRoot, 'single.txt');
+      fs.writeFileSync(filePath, 'dddd'); // 4 bytes
+
+      const size = await makeManager().getDirSize(filePath);
+      assert.strictEqual(size, 4);
+    });
+  });
+
+  describe('cleanDirectory', () => {
+    it('removes files and empty subdirectories but keeps the root', async () => {
+      const dir = path.join(tempRoot, 'clean');
+      fs.mkdirSync(path.join(dir, 'sub', 'nested'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'aaa');
+      fs.writeFileSync(path.join(dir, 'sub', 'b.txt'), 'bbb');
+      fs.writeFileSync(path.join(dir, 'sub', 'nested', 'c.txt'), 'ccc');
+
+      await makeManager().cleanDirectory(dir);
+
+      assert.ok(fs.existsSync(dir), 'root directory should remain');
+      assert.deepStrictEqual(fs.readdirSync(dir), [], 'root should be emptied');
+    });
+
+    it('unlinks a symlink to a file without deleting the target', async () => {
+      const dir = path.join(tempRoot, 'clean-link');
+      fs.mkdirSync(dir);
+      const outsideFile = path.join(tempRoot, 'keep.txt');
+      fs.writeFileSync(outsideFile, 'keep');
+      fs.symlinkSync(outsideFile, path.join(dir, 'link-to-file'));
+
+      await makeManager().cleanDirectory(dir);
+
+      assert.deepStrictEqual(fs.readdirSync(dir), []);
+      assert.ok(fs.existsSync(outsideFile), 'symlink target should survive');
+    });
+
+    // Characterisation test: pins the pre-existing stat-following behaviour,
+    // not a desired specification.
+    it('empties a symlinked directory target, matching stat-following behaviour', async () => {
+      const dir = path.join(tempRoot, 'clean-dirlink');
+      fs.mkdirSync(dir);
+      const outsideDir = path.join(tempRoot, 'outside-dir');
+      fs.mkdirSync(outsideDir);
+      fs.writeFileSync(path.join(outsideDir, 'c.txt'), 'ccc');
+      fs.symlinkSync(outsideDir, path.join(dir, 'link-to-dir'));
+
+      await makeManager().cleanDirectory(dir);
+
+      // fsp.stat follows the link, so the target directory gets emptied;
+      // rmdir on the symlink itself fails (ENOTDIR), so the link remains.
+      assert.ok(fs.existsSync(outsideDir), 'target directory should remain');
+      assert.deepStrictEqual(fs.readdirSync(outsideDir), [], 'target should be emptied');
+      assert.deepStrictEqual(fs.readdirSync(dir), ['link-to-dir']);
+    });
+
+    it('continues cleaning siblings when one entry cannot be removed', async () => {
+      const dir = path.join(tempRoot, 'clean-locked');
+      const lockedDir = path.join(dir, 'locked');
+      fs.mkdirSync(lockedDir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'aaa');
+      fs.writeFileSync(path.join(dir, 'b.txt'), 'bbb');
+      fs.writeFileSync(path.join(lockedDir, 'c.txt'), 'ccc');
+      // Read-only directory: unlinking its contents fails with EACCES
+      fs.chmodSync(lockedDir, 0o555);
+
+      try {
+        await makeManager().cleanDirectory(dir);
+
+        // The awaited promise settling means all fs work finished; siblings
+        // must be gone even though the locked entry failed.
+        assert.ok(!fs.existsSync(path.join(dir, 'a.txt')), 'sibling a.txt should be removed');
+        assert.ok(!fs.existsSync(path.join(dir, 'b.txt')), 'sibling b.txt should be removed');
+        assert.ok(fs.existsSync(path.join(lockedDir, 'c.txt')), 'locked entry contents remain');
+      } finally {
+        // Restore before the suite afterEach removes tempRoot
+        fs.chmodSync(lockedDir, 0o755);
+      }
+    });
+
+    it('skips a broken symlink and still cleans its siblings', async () => {
+      const dir = path.join(tempRoot, 'clean-broken');
+      fs.mkdirSync(dir);
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'aaa');
+      fs.symlinkSync(path.join(tempRoot, 'does-not-exist'), path.join(dir, 'broken'));
+
+      await makeManager().cleanDirectory(dir);
+
+      // The dangling link's stat resolves ENOENT, which is suppressed as
+      // routine mid-clean eviction, so the link itself is skipped.
+      assert.ok(!fs.existsSync(path.join(dir, 'a.txt')), 'sibling should be removed');
+      assert.deepStrictEqual(fs.readdirSync(dir), ['broken']);
+    });
+  });
+});

--- a/tests/unit/timestampCopyOverride.test.js
+++ b/tests/unit/timestampCopyOverride.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const reactHandlerPath = require.resolve('../../app/browser/tools/reactHandler');
+const toolPath = require.resolve('../../app/browser/tools/timestampCopyOverride');
+
+// Mirrors MAX_APPLY_ATTEMPTS in the module under test
+const MAX_APPLY_ATTEMPTS = 120;
+
+let coreServices;
+let warnMessages;
+let originalWarn;
+let originalDebug;
+let tool;
+
+function installReactHandlerStub() {
+  require.cache[reactHandlerPath] = {
+    id: reactHandlerPath,
+    filename: reactHandlerPath,
+    loaded: true,
+    exports: {
+      _getTeams2CoreServices: () => coreServices,
+    },
+  };
+}
+
+function loadTool() {
+  delete require.cache[toolPath];
+  return require(toolPath);
+}
+
+function makeCoreSettings(composeSettings) {
+  return {
+    get: () => ({ ...composeSettings }),
+    getLatestSettingsForCategory: () => ({ ...composeSettings }),
+    categoryBehaviorSubjectMap: new Map(),
+  };
+}
+
+describe('timestampCopyOverride', () => {
+  beforeEach(() => {
+    coreServices = null;
+    warnMessages = [];
+    originalWarn = console.warn;
+    originalDebug = console.debug;
+    console.warn = (...args) => warnMessages.push(args.join(' '));
+    console.debug = () => {};
+    installReactHandlerStub();
+  });
+
+  afterEach(() => {
+    tool?.stop();
+    tool = undefined;
+    console.warn = originalWarn;
+    console.debug = originalDebug;
+    delete require.cache[reactHandlerPath];
+    delete require.cache[toolPath];
+  });
+
+  it('warns exactly once and clears the interval at the attempt cap', () => {
+    tool = loadTool();
+    tool.init({ disableTimestampOnCopy: true });
+
+    for (let i = 0; i < MAX_APPLY_ATTEMPTS; i++) {
+      tool.applyOverride();
+    }
+
+    assert.strictEqual(warnMessages.length, 1, 'give-up warn must fire exactly once');
+    assert.match(warnMessages[0], /disableTimestampOnCopy/);
+    assert.strictEqual(tool.overrideInterval, null, 'interval must be cleared at the cap');
+  });
+
+  it('resets the attempt counter after a successful pass', () => {
+    tool = loadTool();
+    tool.config = { disableTimestampOnCopy: true };
+
+    for (let i = 0; i < MAX_APPLY_ATTEMPTS - 1; i++) {
+      tool.applyOverride();
+    }
+    assert.strictEqual(warnMessages.length, 0);
+
+    // A successful pass resets the budget (setting differs from config so
+    // the override installs without stopping the poll)
+    coreServices = {
+      coreSettings: makeCoreSettings({ disableTimestampOnCopy: false }),
+    };
+    tool.applyOverride();
+    assert.strictEqual(warnMessages.length, 0);
+
+    // A full fresh run of consecutive misses is needed to hit the cap
+    coreServices = null;
+    for (let i = 0; i < MAX_APPLY_ATTEMPTS - 1; i++) {
+      tool.applyOverride();
+    }
+    assert.strictEqual(warnMessages.length, 0, 'cap must count consecutive misses only');
+    tool.applyOverride();
+    assert.strictEqual(warnMessages.length, 1);
+  });
+
+  it('charges a throwing settings API against the budget instead of escaping', () => {
+    tool = loadTool();
+    tool.config = { disableTimestampOnCopy: true };
+    coreServices = {
+      coreSettings: {
+        get: () => {
+          throw new Error('boom');
+        },
+      },
+    };
+
+    for (let i = 0; i < MAX_APPLY_ATTEMPTS; i++) {
+      assert.doesNotThrow(() => tool.applyOverride());
+    }
+
+    assert.strictEqual(warnMessages.length, 1, 'throws must consume the same budget');
+  });
+});

--- a/tests/unit/trayIconRenderer.test.js
+++ b/tests/unit/trayIconRenderer.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const electronPath = require.resolve('electron');
+const rendererPath = require.resolve('../../app/browser/tools/trayIconRenderer');
+
+describe('trayIconRenderer base icon cache', () => {
+  beforeEach(() => {
+    require.cache[electronPath] = {
+      id: electronPath,
+      filename: electronPath,
+      loaded: true,
+      exports: { nativeImage: {} },
+    };
+    delete require.cache[rendererPath];
+    // render() touches DOM globals; minimal stubs suffice because the
+    // returned promise is simply left pending (image.onload never fires).
+    globalThis.document = { createElement: () => ({}) };
+    globalThis.Image = class {};
+  });
+
+  afterEach(() => {
+    delete require.cache[electronPath];
+    delete require.cache[rendererPath];
+    delete globalThis.document;
+    delete globalThis.Image;
+  });
+
+  it('encodes the base icon to a data URL only once across renders', () => {
+    const renderer = require(rendererPath);
+    let toDataURLCalls = 0;
+    renderer.baseIcon = {
+      toDataURL: () => {
+        toDataURLCalls += 1;
+        return 'data:image/png;base64,TEST';
+      },
+    };
+    renderer.config = {};
+
+    renderer.render(1);
+    renderer.render(2);
+
+    assert.strictEqual(toDataURLCalls, 1);
+  });
+});


### PR DESCRIPTION
Three cheap wins from the system performance research audit, hardened by a three-reviewer panel: the timestamp override poll now has a 120-attempt consecutive-miss budget instead of running unbounded, the tray base-icon dataURL is cached, and cacheManager directory scans run in chunked parallel batches. cleanDirectory now skips bad entries instead of aborting a whole directory and aggregates errors into one log line.

Refs ADR-026 (performance audit outcomes, in review on a parallel branch).
