### PR TITLE
ci(docs): bound the docs build with timeout-minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,16 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    # Without this the runner default is 6 HOURS, and this workflow holds the
+    # "pages" concurrency group with cancel-in-progress: false — so one hung
+    # build blocks every docs deploy behind it for most of a working day. The
+    # site builds in ~1-2 minutes; 10 is generous. This matters more than a
+    # routine timeout because the docs build sizes local images via an
+    # unmaintained dependency with two open infinite-loop advisories
+    # (image-size <= 2.0.2, GHSA-5p2g-fcmc-qvqq / GHSA-w3rx-r6r6-pgpr) that will
+    # never be fixed — upstream is archived — so "hangs forever" is a known
+    # reachable state, not a hypothetical one.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -73,6 +83,9 @@ jobs:
 
     # Specify runner + deployment step
     runs-on: ubuntu-latest
+    # Holds the pages concurrency group like the others; the deploy itself is a
+    # single API-backed step, so this is a backstop rather than a real bound.
+    timeout-minutes: 10
     # Only deploy on main branch pushes
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
@@ -83,6 +96,10 @@ jobs:
   test-build:
     name: Test Build (PR/Branch)
     runs-on: ubuntu-latest
+    # Same reasoning as `build`, and this job is the one a fork PR can reach.
+    # It also backgrounds `npm run serve` and waits on a fixed sleep, which is a
+    # second way to hang independent of the build itself.
+    timeout-minutes: 10
     permissions:
       contents: read
     # Only run for PRs and non-main branch pushes


### PR DESCRIPTION
`docs.yml` had no timeout on any job, so the 6-hour runner default applied — and the workflow holds the `pages` concurrency group with `cancel-in-progress: false`, so one hung build blocks every docs deploy behind it for most of a working day.

Not hypothetical: the build sizes local images via `image-size`, which has two open infinite-loop advisories with no fix coming (upstream archived), and `test-build` is fork-reachable.