### PR TITLE
ci(flatpak): smoke build on release tags, document the beta remote

### DIFF
--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -1,0 +1,149 @@
+name: Flatpak Smoke Build
+
+# Builds the Flathub manifest against a freshly released .deb so packaging
+# breakage surfaces here rather than in flathubbot's version-bump PR against
+# the packaging repo. x86_64 only: this is a smoke signal, not a release build.
+#
+# The manifest is fetched from the packaging repo rather than vendored, so this
+# always tests what Flathub will actually build. The remote sources are swapped
+# for the downloaded files, which both pins the build to this exact release and
+# avoids having to recompute sha256 values here.
+#
+# All release-controlled values reach the shell through env: and are quoted at
+# use, never interpolated into a run: body.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (defaults to the latest release)"
+        required: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PACKAGING_REPO: flathub/com.github.IsmaelMartinez.teams_for_linux
+  APP_ID: com.github.IsmaelMartinez.teams_for_linux
+
+jobs:
+  flatpak_smoke:
+    name: flatpak-builder (x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Resolve the release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
+          if [ -z "$TAG" ]; then
+            TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not resolve a release tag to build"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Building manifest against ${TAG}"
+
+      - name: Install flatpak tooling
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # python3-yaml is not guaranteed on the runner image and the manifest
+          # rewrite below depends on it, so install it here rather than assume.
+          sudo apt-get install -y --no-install-recommends \
+            flatpak flatpak-builder python3-yaml
+          flatpak remote-add --if-not-exists --user \
+            flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Fetch the manifest from the packaging repo
+        run: |
+          set -euo pipefail
+          curl -fsSL -o manifest.yml \
+            "https://raw.githubusercontent.com/${PACKAGING_REPO}/master/${APP_ID}.yml"
+          echo "::group::manifest as published"
+          cat manifest.yml
+          echo "::endgroup::"
+
+      - name: Download the released deb and metainfo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern '*_amd64.deb' --output teams-for-linux.deb --clobber
+          curl -fsSL -o metainfo.xml \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${TAG}/${APP_ID}.appdata.xml"
+          ls -l teams-for-linux.deb metainfo.xml
+
+      - name: Point the manifest at the downloaded files
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import yaml
+
+          APP_ID = "com.github.IsmaelMartinez.teams_for_linux"
+
+          with open("manifest.yml") as fh:
+              manifest = yaml.safe_load(fh)
+
+          module = manifest["modules"][0]
+
+          # Keep the inline wrapper script verbatim; it is part of what we are
+          # smoke testing. Everything else is a remote download we replace with
+          # the local copies fetched from this release.
+          scripts = [s for s in module["sources"] if s.get("type") == "script"]
+
+          module["sources"] = [
+              {
+                  "type": "file",
+                  "path": "teams-for-linux.deb",
+                  "dest-filename": "teams-for-linux.deb",
+              },
+              {
+                  "type": "file",
+                  "path": "metainfo.xml",
+                  "dest-filename": f"{APP_ID}.metainfo.xml",
+              },
+              *scripts,
+          ]
+
+          with open("manifest.yml", "w") as fh:
+              yaml.safe_dump(manifest, fh, sort_keys=False)
+          PY
+          echo "::group::manifest as built"
+          cat manifest.yml
+          echo "::endgroup::"
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          flatpak-builder --user --force-clean --disable-rofiles-fuse \
+            --install-deps-from=flathub \
+            --arch=x86_64 \
+            build-dir manifest.yml
+
+      - name: Report what was built
+        run: |
+          set -euo pipefail
+          echo "::group::installed tree"
+          find build-dir/files -maxdepth 2 -mindepth 1 | sort
+          echo "::endgroup::"
+          test -x build-dir/files/bin/teams-for-linux
+          test -f "build-dir/files/share/metainfo/${APP_ID}.metainfo.xml"
+          test -f build-dir/files/share/applications/teams-for-linux.desktop
+          echo "Smoke build produced the wrapper, metainfo and desktop entry."

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -49,14 +49,31 @@ jobs:
           set -euo pipefail
           TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
           if [ -z "$TAG" ]; then
-            TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+            # `gh release view` with no tag resolves via releases/latest, which
+            # skips pre-releases. Pre-releases are exactly what a manual run
+            # wants to smoke, so take the newest release of any kind instead.
+            TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 \
+              --json tagName --jq '.[0].tagName')
           fi
           if [ -z "$TAG" ]; then
             echo "::error::Could not resolve a release tag to build"
             exit 1
           fi
+
+          # Flathub builds pre-releases from the packaging repo's `beta` branch
+          # and stable from `master`, so smoke the branch that will actually be
+          # used for this release.
+          PRERELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json isPrerelease --jq .isPrerelease)
+          if [ "$PRERELEASE" = "true" ]; then
+            BRANCH=beta
+          else
+            BRANCH=master
+          fi
+
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Building manifest against ${TAG}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Building the ${BRANCH} manifest against ${TAG}"
 
       - name: Install flatpak tooling
         run: |
@@ -70,10 +87,19 @@ jobs:
             flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
       - name: Fetch the manifest from the packaging repo
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
         run: |
           set -euo pipefail
-          curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL -o manifest.yml \
-            "https://raw.githubusercontent.com/${PACKAGING_REPO}/master/${APP_ID}.yml"
+          # The beta branch may not exist yet on the packaging repo, in which
+          # case Flathub builds that release from master anyway, so fall back
+          # rather than failing the smoke run.
+          if ! curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL -o manifest.yml \
+            "https://raw.githubusercontent.com/${PACKAGING_REPO}/${BRANCH}/${APP_ID}.yml"; then
+            echo "::warning::No ${BRANCH} manifest on ${PACKAGING_REPO}, falling back to master"
+            curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL -o manifest.yml \
+              "https://raw.githubusercontent.com/${PACKAGING_REPO}/master/${APP_ID}.yml"
+          fi
           echo "::group::manifest as published"
           cat manifest.yml
           echo "::endgroup::"
@@ -148,5 +174,8 @@ jobs:
           echo "::endgroup::"
           test -x build-dir/files/bin/teams-for-linux
           test -f "build-dir/files/share/metainfo/${APP_ID}.metainfo.xml"
-          test -f build-dir/files/share/applications/teams-for-linux.desktop
+          # rename-desktop-file is a toplevel manifest property, so the cleanup
+          # phase renames teams-for-linux.desktop to one based on the app id.
+          # Asserting the pre-rename name here would fail on every good build.
+          test -f "build-dir/files/share/applications/${APP_ID}.desktop"
           echo "Smoke build produced the wrapper, metainfo and desktop entry."

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -94,9 +94,12 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
+          import os
           import yaml
 
-          APP_ID = "com.github.IsmaelMartinez.teams_for_linux"
+          # Read from the workflow env rather than restating the id, so this
+          # cannot drift from the value the rest of the workflow uses.
+          APP_ID = os.environ["APP_ID"]
 
           with open("manifest.yml") as fh:
               manifest = yaml.safe_load(fh)

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Fetch the manifest from the packaging repo
         run: |
           set -euo pipefail
-          curl -fsSL -o manifest.yml \
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL -o manifest.yml \
             "https://raw.githubusercontent.com/${PACKAGING_REPO}/master/${APP_ID}.yml"
           echo "::group::manifest as published"
           cat manifest.yml
@@ -86,7 +86,7 @@ jobs:
           set -euo pipefail
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern '*_amd64.deb' --output teams-for-linux.deb --clobber
-          curl -fsSL -o metainfo.xml \
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL -o metainfo.xml \
             "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${TAG}/${APP_ID}.appdata.xml"
           ls -l teams-for-linux.deb metainfo.xml
 

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -51,9 +51,12 @@ jobs:
           if [ -z "$TAG" ]; then
             # `gh release view` with no tag resolves via releases/latest, which
             # skips pre-releases. Pre-releases are exactly what a manual run
-            # wants to smoke, so take the newest release of any kind instead.
+            # wants to smoke, so take the newest published release instead.
+            # --exclude-drafts matters: merging the release PR leaves a draft
+            # sitting there until it is published by hand, and a draft has no
+            # git tag, so picking one would 404 on the metainfo fetch.
             TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 \
-              --json tagName --jq '.[0].tagName')
+              --exclude-drafts --json tagName --jq '.[0].tagName')
           fi
           if [ -z "$TAG" ]; then
             echo "::error::Could not resolve a release tag to build"

--- a/docs-site/docs/development/manual-release-process.md
+++ b/docs-site/docs/development/manual-release-process.md
@@ -98,16 +98,42 @@ When the Release PR merges to main:
 
 Then:
 1. Promote GitHub draft → full release
-   - This triggers Flatpak
    - This triggers the **Snap Release** workflow, which builds and publishes the release version to the **candidate** channel
-2. Test the Snap candidate version
-3. Manually promote Snap candidate → stable: `snapcraft release teams-for-linux <revision> stable`
+   - This triggers the **Flatpak Smoke Build**, which builds the Flathub manifest against the released deb
+2. Bump the [Flathub beta branch](#flathub-beta-branch) so Flatpak users can test the pre-release
+3. Test the Snap candidate version
+4. Manually promote Snap candidate → stable: `snapcraft release teams-for-linux <revision> stable`
+5. Clear the pre-release flag once the release has soaked: `gh release edit vX.Y.Z --prerelease=false`
+
+:::warning Flathub does not move until the pre-release flag is cleared
+The Flathub manifest tracks `releases/latest`, and that endpoint skips pre-releases. So a release left flagged as a pre-release never reaches Flatpak users, no matter how long it sits. Step 5 is what moves both the `latest` pointer and Flathub stable, and it is easy to forget because nothing fails or warns when it is skipped.
+:::
 
 :::info Snap Channels
 - **edge** — Every push to main. Versioned with commit SHA suffix (e.g., `2.7.5-edge.g1a2b3c4`)
 - **candidate** — Automatically published when a GitHub Release is published. Uses the clean release version (e.g., `2.7.5`)
 - **stable** — Manual promotion from candidate after testing
 :::
+
+### Flathub beta branch
+
+The Flathub packaging repo has a `beta` branch that Flathub builds into the `flathub-beta` remote, which is how Flatpak users test a pre-release before it reaches stable. Bumping it is manual: Flathub's hosted update checker only runs against a repo's default branch (`master`), so flathubbot never touches `beta`. The `x-checker-data` queries on that branch describe what it should track, but nothing executes them.
+
+Collect the three checksums, two of which the release already publishes:
+
+```bash
+TAG=v2.16.0
+gh release view "$TAG" --repo IsmaelMartinez/teams-for-linux --json assets \
+  --jq '.assets[] | select(.name | test("_(amd64|arm64)\\.deb$")) | "\(.name) \(.digest)"'
+curl -sL "https://raw.githubusercontent.com/IsmaelMartinez/teams-for-linux/$TAG/com.github.IsmaelMartinez.teams_for_linux.appdata.xml" \
+  | sha256sum
+```
+
+The deb digests come back prefixed with `sha256:`, which the manifest does not want, so paste only the hex part.
+
+Then on the packaging repo's `beta` branch, point the two deb sources and the metainfo source at `$TAG`, paste the matching `sha256` values, and push with `git push upstream beta`. That push is what triggers the Flathub buildbot, so it publishes to `flathub-beta` on its own from there.
+
+Keep `beta` otherwise in sync with `master`, since the only intended difference is the version it points at plus any packaging change deliberately under test.
 
 ## Changelog Categories
 

--- a/docs-site/docs/development/manual-release-process.md
+++ b/docs-site/docs/development/manual-release-process.md
@@ -131,7 +131,7 @@ curl -sL "https://raw.githubusercontent.com/IsmaelMartinez/teams-for-linux/$TAG/
 
 The deb digests come back prefixed with `sha256:`, which the manifest does not want, so paste only the hex part.
 
-Then on the packaging repo's `beta` branch, point the two deb sources and the metainfo source at `$TAG`, paste the matching `sha256` values, and push with `git push upstream beta`. That push is what triggers the Flathub buildbot, so it publishes to `flathub-beta` on its own from there.
+Then on the packaging repo's `beta` branch, point the two deb sources and the metainfo source at `$TAG` and paste the matching `sha256` values. Push that branch to the Flathub repo itself, not to a fork, since the buildbot only watches `flathub/com.github.IsmaelMartinez.teams_for_linux`. In the maintainer's checkout that remote is named `upstream` (`origin` being the fork), so the push is `git push upstream beta`; check `git remote -v` if you are unsure which name points where. That push is what triggers the buildbot, so it publishes to `flathub-beta` on its own from there.
 
 Keep `beta` otherwise in sync with `master`, since the only intended difference is the version it points at plus any packaging change deliberately under test.
 

--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -129,17 +129,22 @@ Pre-releases are published to the Flathub beta remote before they reach the stab
 
 ```bash
 flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-flatpak install flathub-beta com.github.IsmaelMartinez.teams_for_linux
+flatpak install flathub-beta com.github.IsmaelMartinez.teams_for_linux//beta
 ```
 
-The beta and stable builds share an application ID, so install one or the other rather than both. To go back to stable:
+The beta build is a separate branch of the same application ID, so it installs alongside the stable one rather than replacing it. That matters when you launch it: the desktop launcher and a bare `flatpak run com.github.IsmaelMartinez.teams_for_linux` both keep starting the stable build, so run the beta explicitly, otherwise you will think you are testing the pre-release when you are not.
 
 ```bash
-flatpak uninstall com.github.IsmaelMartinez.teams_for_linux
-flatpak install flathub com.github.IsmaelMartinez.teams_for_linux
+flatpak run com.github.IsmaelMartinez.teams_for_linux//beta
 ```
 
-If the install fails with the app not being found on `flathub-beta`, there is no beta build published at the moment. The beta remote only carries a build while a pre-release is being tested, so fall back to the stable Flathub install above and try again after the next release.
+To go back to stable, remove the beta branch:
+
+```bash
+flatpak uninstall com.github.IsmaelMartinez.teams_for_linux//beta
+```
+
+If the install fails with the app not being found on `flathub-beta`, there is no beta build published at the moment. The beta remote only carries a build while a pre-release is being tested, so use the stable Flathub install above and try again after the next release.
 
 :::note
 The beta remote carries pre-release builds and packaging changes that are still being validated, so expect the occasional rough edge. If you hit one, please [open an issue](https://github.com/IsmaelMartinez/teams-for-linux/issues) and mention that you are on the beta remote.

--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -139,6 +139,8 @@ flatpak uninstall com.github.IsmaelMartinez.teams_for_linux
 flatpak install flathub com.github.IsmaelMartinez.teams_for_linux
 ```
 
+If the install fails with the app not being found on `flathub-beta`, there is no beta build published at the moment. The beta remote only carries a build while a pre-release is being tested, so fall back to the stable Flathub install above and try again after the next release.
+
 :::note
 The beta remote carries pre-release builds and packaging changes that are still being validated, so expect the occasional rough edge. If you hit one, please [open an issue](https://github.com/IsmaelMartinez/teams-for-linux/issues) and mention that you are on the beta remote.
 :::

--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -123,6 +123,26 @@ flatpak install flathub com.github.IsmaelMartinez.teams_for_linux
 
 <a href='https://flathub.org/apps/details/com.github.IsmaelMartinez.teams_for_linux'><img width='170' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
+#### Flathub Beta Channel (Pre-releases)
+
+Pre-releases are published to the Flathub beta remote before they reach the stable Flathub build. Following the beta remote is the most useful thing a Flatpak user can do for this project, because sandbox and permission changes can be built by the Flathub buildbot but cannot be tested by the maintainer, who has no Linux desktop available.
+
+```bash
+flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+flatpak install flathub-beta com.github.IsmaelMartinez.teams_for_linux
+```
+
+The beta and stable builds share an application ID, so install one or the other rather than both. To go back to stable:
+
+```bash
+flatpak uninstall com.github.IsmaelMartinez.teams_for_linux
+flatpak install flathub com.github.IsmaelMartinez.teams_for_linux
+```
+
+:::note
+The beta remote carries pre-release builds and packaging changes that are still being validated, so expect the occasional rough edge. If you hit one, please [open an issue](https://github.com/IsmaelMartinez/teams-for-linux/issues) and mention that you are on the beta remote.
+:::
+
 ## Manual Installation
 
 ### Download from GitHub Releases


### PR DESCRIPTION
Adds the flatpak-builder smoke build on release tags (#2835) and documents the Flathub beta remote so Flatpak users can opt in to pre-releases (#2833). The matching `beta` branch on the packaging repo is prepared separately and needs pushing to Flathub before the docs here are true.

The smoke build fetches the manifest from the packaging repo rather than vendoring it, so it always tests what Flathub will actually build.

Refs #2835
Refs #2833
