### PR TITLE
refactor(config): aggregate deprecation warnings into one message

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -1,6 +1,6 @@
 # Config Module
 
-Handles loading configuration from `config.json` and parsing command-line arguments using `yargs`. `validator.js` warns about unknown keys, type mismatches, and invalid values at startup — see [Startup Validation](../../docs-site/docs/configuration.md#startup-validation).
+Handles loading configuration from `config.json` and parsing command-line arguments using `yargs`. `validator.js` warns about unknown keys, type mismatches, and invalid values at startup — see [Startup Validation](../../docs-site/docs/configuration.md#startup-validation). `deprecation.js` builds the startup warning for deprecated options as a single aggregated message, because `app/index.js` opens a blocking modal for every entry in `config.warnings`.
 
 ## Usage
 

--- a/app/config/deprecation.js
+++ b/app/config/deprecation.js
@@ -8,6 +8,12 @@
 //
 // PII safety (see CLAUDE.md): the message contains option NAMES and the
 // author-written deprecation text only, never config values.
+//
+// Known limitation: only the config file is inspected. A deprecated option
+// passed as a CLI flag or environment variable (yargs runs with .env(true))
+// produces no warning, so those users would be silently ignored once a
+// renamed option stops being read. Widening this needs the parsed argv and
+// the env prefix, not just the config file.
 
 /**
  * @param {Record<string, string|boolean>} deprecatedOptions yargs

--- a/app/config/deprecation.js
+++ b/app/config/deprecation.js
@@ -1,0 +1,41 @@
+// Builds the startup warning for deprecated config options. Pure data module,
+// no Electron imports, mirroring app/config/validator.js.
+//
+// One aggregated message, never one per option: showConfigurationDialogs in
+// app/index.js opens a blocking modal for every entry in config.warnings, so
+// a config using several deprecated options would stack modals at startup.
+// This matters as ADR-025 renames land, since each rename deprecates a key.
+//
+// PII safety (see CLAUDE.md): the message contains option NAMES and the
+// author-written deprecation text only, never config values.
+
+/**
+ * @param {Record<string, string|boolean>} deprecatedOptions yargs
+ *   getDeprecatedOptions() output: option name to message, or `true` when the
+ *   option declared `deprecated: true` with no text.
+ * @param {Record<string, unknown>} configFile the merged config file contents.
+ * @returns {string|null} a single warning, or null when nothing is deprecated.
+ */
+function buildDeprecationWarning(deprecatedOptions, configFile) {
+  const used = Object.keys(deprecatedOptions || {}).filter(
+    (option) => configFile && option in configFile
+  );
+
+  if (used.length === 0) return null;
+
+  const lines = used.map((option) => {
+    const detail = deprecatedOptions[option];
+    return typeof detail === "string" && detail.length > 0
+      ? `  - ${option}: ${detail}`
+      : `  - ${option}`;
+  });
+
+  const subject =
+    used.length === 1
+      ? "1 configuration option is"
+      : `${used.length} configuration options are`;
+
+  return `${subject} deprecated and will be removed in a future release:\n${lines.join("\n")}`;
+}
+
+module.exports = { buildDeprecationWarning };

--- a/app/config/deprecation.js
+++ b/app/config/deprecation.js
@@ -23,8 +23,10 @@
  * @returns {string|null} a single warning, or null when nothing is deprecated.
  */
 function buildDeprecationWarning(deprecatedOptions, configFile) {
+  // Object.hasOwn, matching validator.js, so an inherited key (a config file
+  // literally naming "__proto__" or "constructor") cannot trigger a warning.
   const used = Object.keys(deprecatedOptions || {}).filter(
-    (option) => configFile && option in configFile
+    (option) => configFile && Object.hasOwn(configFile, option)
   );
 
   if (used.length === 0) return null;

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -111,7 +111,10 @@ function checkUsedDeprecatedValues(yargsInstance, configObject, config) {
 
   console.warn(message);
   // Single entry on purpose; see app/config/deprecation.js for why.
-  config["warnings"] = [...(config["warnings"] || []), message];
+  // `warnings` is not a declared option, so a config file containing that key
+  // lands here verbatim; only extend it when it is already a list.
+  const existing = Array.isArray(config["warnings"]) ? config["warnings"] : [];
+  config["warnings"] = [...existing, message];
 }
 
 function argv(configPath, appVersion) {
@@ -131,9 +134,6 @@ function argv(configPath, appVersion) {
     config["error"] = configObject.configError;
   }
 
-  // Pass yargs instance to access getDeprecatedOptions() in v18
-  checkUsedDeprecatedValues(yargsInstance, configObject, config);
-
   if (configObject.isConfigFile && config.watchConfigFile) {
     fs.watch(getConfigFilePath(configPath), (event, filename) => {
       console.info(
@@ -150,6 +150,11 @@ function argv(configPath, appVersion) {
   config.disableGpuExplicitlySet = wasSetInCli || wasSetInFile;
 
   logger.init(config.logConfig);
+
+  // Runs after logger.init so the warning reaches the log file and not just
+  // stdout; users attaching a log to a bug report need to see it.
+  // Pass yargs instance to access getDeprecatedOptions() in v18
+  checkUsedDeprecatedValues(yargsInstance, configObject, config);
 
   // Warn-only schema validation of the merged (system + user) config file
   // contents (issue #2597). Runs after logger.init so warnings reach the log.

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -5,6 +5,7 @@ const { ipcMain } = require("electron");
 const logger = require("./logger");
 const configOptions = require("./options");
 const { validateConfigFile } = require("./validator");
+const { buildDeprecationWarning } = require("./deprecation");
 
 function getConfigFilePath(configPath) {
   return path.join(configPath, "config.json");
@@ -102,23 +103,15 @@ function extractYargConfig(configObject, appVersion) {
 
 function checkUsedDeprecatedValues(yargsInstance, configObject, config) {
   // yargs v18: getDeprecatedOptions() must be called on the instance
-  const deprecatedOptions = yargsInstance.getDeprecatedOptions();
-  const warnings = [];
+  const message = buildDeprecationWarning(
+    yargsInstance.getDeprecatedOptions(),
+    configObject.configFile
+  );
+  if (!message) return;
 
-  for (const option in deprecatedOptions) {
-    if (option in configObject.configFile) {
-      const deprecatedWarningMessage = `Option \`${option}\` is deprecated and will be removed in future version. \n ${deprecatedOptions[option]}.`;
-      console.warn(deprecatedWarningMessage);
-      warnings.push(deprecatedWarningMessage);
-    } else {
-      console.debug(`all good with ${option} you aren't using them`);
-    }
-  }
-
-  // Accumulate all warnings instead of overwriting
-  if (warnings.length > 0) {
-    config["warnings"] = warnings;
-  }
+  console.warn(message);
+  // Single entry on purpose; see app/config/deprecation.js for why.
+  config["warnings"] = [...(config["warnings"] || []), message];
 }
 
 function argv(configPath, appVersion) {

--- a/tests/unit/configDeprecationWarning.test.js
+++ b/tests/unit/configDeprecationWarning.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { buildDeprecationWarning } = require('../../app/config/deprecation');
+
+describe('buildDeprecationWarning - nothing to report', () => {
+	it('returns null when no deprecated option appears in the config file', () => {
+		const warning = buildDeprecationWarning(
+			{ proxyServer: 'use network.proxyServer' },
+			{ appTitle: 'Teams' }
+		);
+		assert.strictEqual(warning, null);
+	});
+
+	it('returns null when no option is declared deprecated', () => {
+		assert.strictEqual(buildDeprecationWarning({}, { proxyServer: 'http://x' }), null);
+	});
+
+	it('returns null for missing or empty inputs', () => {
+		assert.strictEqual(buildDeprecationWarning(undefined, undefined), null);
+		assert.strictEqual(buildDeprecationWarning({ webDebug: true }, null), null);
+	});
+});
+
+describe('buildDeprecationWarning - aggregation', () => {
+	// The headline contract: one string covering every deprecated option in use,
+	// because app/index.js opens a blocking modal per entry in config.warnings.
+	it('reports every deprecated option in use in a single message', () => {
+		const warning = buildDeprecationWarning(
+			{
+				proxyServer: 'use network.proxyServer',
+				clearStorageData: 'use storage.clearData',
+				webDebug: 'use development.webDebug',
+			},
+			{ proxyServer: 'http://localhost:3128', clearStorageData: {}, webDebug: true }
+		);
+
+		assert.strictEqual(typeof warning, 'string');
+		assert.match(warning, /^3 configuration options are deprecated/);
+		assert.match(warning, /^ {2}- proxyServer: use network\.proxyServer$/m);
+		assert.match(warning, /^ {2}- clearStorageData: use storage\.clearData$/m);
+		assert.match(warning, /^ {2}- webDebug: use development\.webDebug$/m);
+	});
+
+	it('uses singular wording for exactly one deprecated option', () => {
+		const warning = buildDeprecationWarning(
+			{ proxyServer: 'use network.proxyServer' },
+			{ proxyServer: 'http://x' }
+		);
+		assert.match(warning, /^1 configuration option is deprecated/);
+	});
+
+	it('omits the detail when an option declares `deprecated: true` with no text', () => {
+		const warning = buildDeprecationWarning({ webDebug: true }, { webDebug: true });
+		assert.match(warning, /^ {2}- webDebug$/m);
+	});
+
+	it('ignores deprecated options the user has not set', () => {
+		const warning = buildDeprecationWarning(
+			{ proxyServer: 'use network.proxyServer', webDebug: 'use development.webDebug' },
+			{ webDebug: true }
+		);
+		assert.match(warning, /^1 configuration option is deprecated/);
+		assert.doesNotMatch(warning, /proxyServer/);
+	});
+
+	it('reports a deprecated option even when its value is falsy', () => {
+		const warning = buildDeprecationWarning({ webDebug: true }, { webDebug: false });
+		assert.match(warning, /^1 configuration option is deprecated/);
+	});
+
+	// PII safety (CLAUDE.md): names and the author-written text only, no values.
+	it('never includes the configured value', () => {
+		const warning = buildDeprecationWarning(
+			{ proxyServer: 'use network.proxyServer' },
+			{ proxyServer: 'http://user:secret@proxy.internal:3128' }
+		);
+		assert.doesNotMatch(warning, /secret/);
+		assert.doesNotMatch(warning, /proxy\.internal/);
+	});
+});

--- a/tests/unit/configDeprecationWarning.test.js
+++ b/tests/unit/configDeprecationWarning.test.js
@@ -21,6 +21,11 @@ describe('buildDeprecationWarning - nothing to report', () => {
 		assert.strictEqual(buildDeprecationWarning(undefined, undefined), null);
 		assert.strictEqual(buildDeprecationWarning({ webDebug: true }, null), null);
 	});
+
+	it('ignores inherited keys so a polluted prototype cannot trigger a warning', () => {
+		const polluted = Object.create({ webDebug: true });
+		assert.strictEqual(buildDeprecationWarning({ webDebug: true }, polluted), null);
+	});
 });
 
 describe('buildDeprecationWarning - aggregation', () => {


### PR DESCRIPTION
`config.warnings` gets one entry per deprecated option and `showConfigurationDialogs` opens a blocking modal per entry, so several deprecated keys meant several sequential modals at startup. Message building moves to a pure `app/config/deprecation.js` (mirroring `validator.js`) and returns a single aggregated message.

Groundwork for the ADR-025 renames (#2842); no user-visible change yet since no option declares `deprecated`.

Refs #2842