### PR TITLE
fix(menus): honour clearStorageData when quitting with clear storage

### DIFF
--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -99,9 +99,14 @@ class Menus {
       // is always undefined and silently clears everything (#2860).
       const clearOptions = this.configGroup.startupConfig.clearStorageData;
       if (clearOptions) {
-        // The value is a clearStorageDataOptions object which can carry an
-        // origin, so log that it is configured rather than what it contains.
-        console.debug("Clearing storage data on quit using configured options");
+        // Log the storage names only. They are a fixed Electron enum, unlike
+        // the sibling `origin`, which is a URL. Naming them makes a typo
+        // visible, since Electron ignores an unknown storage silently and the
+        // clear would then quietly keep data the user expected to lose.
+        console.debug(
+          "Clearing storage data on quit using configured options",
+          { storages: clearOptions?.storages ?? "all" }
+        );
         await defSession.clearStorageData(clearOptions);
       } else {
         console.debug("Clearing all storage data on quit");

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -94,17 +94,17 @@ class Menus {
       const defSession = session.fromPartition(
         this.configGroup.startupConfig.partition
       );
-      if (this.configGroup.clearStorageData) {
-        console.debug(
-          "Clearing storage data on quit",
-          this.config.clearStorageData
-        );
-        await defSession.clearStorageData(this.configGroup.clearStorageData);
+      // startupConfig, not configGroup: AppConfiguration keeps the parsed
+      // config behind a getter, so reading an option straight off the instance
+      // is always undefined and silently clears everything (#2860).
+      const clearOptions = this.configGroup.startupConfig.clearStorageData;
+      if (clearOptions) {
+        // The value is a clearStorageDataOptions object which can carry an
+        // origin, so log that it is configured rather than what it contains.
+        console.debug("Clearing storage data on quit using configured options");
+        await defSession.clearStorageData(clearOptions);
       } else {
-        console.debug(
-          "Clearing storage on quit",
-          this.configGroup.clearStorageData
-        );
+        console.debug("Clearing all storage data on quit");
         await defSession.clearStorageData();
       }
     }

--- a/tests/unit/appConfigurationAccess.test.js
+++ b/tests/unit/appConfigurationAccess.test.js
@@ -44,7 +44,9 @@ describe('AppConfiguration access', () => {
 		for (const file of jsFiles(APP_DIR)) {
 			const lines = fs.readFileSync(file, 'utf8').split('\n');
 			lines.forEach((line, index) => {
-				for (const match of line.matchAll(/\b(?:configGroup|appConfig)\??\.([a-zA-Z_$]+)/g)) {
+				// Digits belong in the identifier class: without them a member such
+				// as `oauth2Config` would truncate to `oauth` and misreport.
+				for (const match of line.matchAll(/\b(?:configGroup|appConfig)\??\.([\w$]+)/g)) {
 					if (!ALLOWED.has(match[1])) {
 						offenders.push(
 							`${path.relative(APP_DIR, file)}:${index + 1} reads .${match[1]}, ` +

--- a/tests/unit/appConfigurationAccess.test.js
+++ b/tests/unit/appConfigurationAccess.test.js
@@ -4,24 +4,22 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
+const { AppConfiguration } = require('../../app/appConfiguration');
 
 // Guards against the #2860 class of bug. AppConfiguration keeps the parsed
 // config behind a `startupConfig` getter, with the state in module-level
-// WeakMaps and no proxy or property forwarding. So reading a config option
-// straight off the instance (`configGroup.clearStorageData`) is not a type
-// error, it just silently yields undefined, and the branch guarding on it
+// WeakMaps and no proxy or property forwarding. Reading a config option
+// straight off the instance (`configGroup.clearStorageData`) is therefore not
+// a type error; it silently yields undefined, so the branch guarding on it
 // never runs. That shipped unnoticed from #1627 until the ADR-025 rename work.
 //
-// The allowed set is derived from the class itself so adding a getter does not
-// require editing this test.
+// The allowed set comes from the class itself, so adding a getter or a method
+// needs no edit here.
 
 const APP_DIR = path.join(__dirname, '..', '..', 'app');
-const CONFIG_CLASS = path.join(APP_DIR, 'appConfiguration', 'index.js');
-
-function declaredGetters() {
-	const source = fs.readFileSync(CONFIG_CLASS, 'utf8');
-	return new Set([...source.matchAll(/^\s*get ([a-zA-Z]+)\(\)/gm)].map((m) => m[1]));
-}
+const ALLOWED = new Set(
+	Object.getOwnPropertyNames(AppConfiguration.prototype).filter((n) => n !== 'constructor')
+);
 
 function* jsFiles(dir) {
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -32,33 +30,31 @@ function* jsFiles(dir) {
 }
 
 describe('AppConfiguration access', () => {
-	it('exposes getters, so the config is not readable off the instance', () => {
-		const getters = declaredGetters();
-		assert.ok(getters.has('startupConfig'), 'startupConfig getter went missing');
-		assert.ok(getters.size >= 4, 'expected at least four getters');
+	it('keeps the parsed config behind startupConfig, not on the instance', () => {
+		assert.ok(ALLOWED.has('startupConfig'), 'startupConfig accessor went missing');
+		assert.ok(!ALLOWED.has('clearStorageData'), 'config options must not be instance members');
 	});
 
+	// Matches the two names an AppConfiguration is bound to across the codebase.
+	// Deliberately literal: it cannot see an instance stored under some other
+	// name, so it is a backstop for the common shape rather than a proof.
 	it('no source file reads a config option straight off an AppConfiguration', () => {
-		const allowed = declaredGetters();
 		const offenders = [];
 
 		for (const file of jsFiles(APP_DIR)) {
 			const lines = fs.readFileSync(file, 'utf8').split('\n');
 			lines.forEach((line, index) => {
-				for (const match of line.matchAll(/\b(?:configGroup|appConfig)\.([a-zA-Z_]+)/g)) {
-					if (!allowed.has(match[1])) {
+				for (const match of line.matchAll(/\b(?:configGroup|appConfig)\??\.([a-zA-Z_$]+)/g)) {
+					if (!ALLOWED.has(match[1])) {
 						offenders.push(
-							`${path.relative(APP_DIR, file)}:${index + 1} reads .${match[1]}`
+							`${path.relative(APP_DIR, file)}:${index + 1} reads .${match[1]}, ` +
+								`use .startupConfig.${match[1]}`
 						);
 					}
 				}
 			});
 		}
 
-		assert.deepStrictEqual(
-			offenders,
-			[],
-			`Read the option through .startupConfig instead:\n  ${offenders.join('\n  ')}`
-		);
+		assert.deepStrictEqual(offenders, [], `\n  ${offenders.join('\n  ')}\n`);
 	});
 });

--- a/tests/unit/appConfigurationAccess.test.js
+++ b/tests/unit/appConfigurationAccess.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Guards against the #2860 class of bug. AppConfiguration keeps the parsed
+// config behind a `startupConfig` getter, with the state in module-level
+// WeakMaps and no proxy or property forwarding. So reading a config option
+// straight off the instance (`configGroup.clearStorageData`) is not a type
+// error, it just silently yields undefined, and the branch guarding on it
+// never runs. That shipped unnoticed from #1627 until the ADR-025 rename work.
+//
+// The allowed set is derived from the class itself so adding a getter does not
+// require editing this test.
+
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+const CONFIG_CLASS = path.join(APP_DIR, 'appConfiguration', 'index.js');
+
+function declaredGetters() {
+	const source = fs.readFileSync(CONFIG_CLASS, 'utf8');
+	return new Set([...source.matchAll(/^\s*get ([a-zA-Z]+)\(\)/gm)].map((m) => m[1]));
+}
+
+function* jsFiles(dir) {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) yield* jsFiles(full);
+		else if (entry.name.endsWith('.js')) yield full;
+	}
+}
+
+describe('AppConfiguration access', () => {
+	it('exposes getters, so the config is not readable off the instance', () => {
+		const getters = declaredGetters();
+		assert.ok(getters.has('startupConfig'), 'startupConfig getter went missing');
+		assert.ok(getters.size >= 4, 'expected at least four getters');
+	});
+
+	it('no source file reads a config option straight off an AppConfiguration', () => {
+		const allowed = declaredGetters();
+		const offenders = [];
+
+		for (const file of jsFiles(APP_DIR)) {
+			const lines = fs.readFileSync(file, 'utf8').split('\n');
+			lines.forEach((line, index) => {
+				for (const match of line.matchAll(/\b(?:configGroup|appConfig)\.([a-zA-Z_]+)/g)) {
+					if (!allowed.has(match[1])) {
+						offenders.push(
+							`${path.relative(APP_DIR, file)}:${index + 1} reads .${match[1]}`
+						);
+					}
+				}
+			});
+		}
+
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			`Read the option through .startupConfig instead:\n  ${offenders.join('\n  ')}`
+		);
+	});
+});


### PR DESCRIPTION
"Quit (Clear Storage)" read `this.configGroup.clearStorageData`, but `configGroup` is the `AppConfiguration` instance, which keeps the parsed config behind a `startupConfig` getter with no property forwarding. That read was always `undefined`, so the branch never ran and the else path wiped every storage, ignoring the configured options. The dead branch also logged `this.config`, which is never assigned on `Menus`, so fixing only the guard would have thrown.

Adds a source-level guard test asserting no file reads a config option straight off a `configGroup`, with the allowed names derived from the getters `AppConfiguration` declares so it stays current. Verified it fails against the original code and names the offending file, line and property.

Debug logs no longer print the options object, which can carry an `origin`.

closes #2860
