### PR TITLE
feat(multi-account): sender→profile attribution map (ADR-020 Phase 2 foundation)

### DIFF
--- a/app/mainAppWindow/profileViewManager.js
+++ b/app/mainAppWindow/profileViewManager.js
@@ -1,5 +1,6 @@
 const { WebContentsView, session, ipcMain } = require("electron");
 const path = require("node:path");
+const SenderProfileMap = require("./senderProfileMap");
 
 const LEGACY_PARTITION = "persist:teams-4-linux";
 
@@ -82,6 +83,13 @@ class ProfileViewManager {
   #config;
   #bindDisplayMediaHandler;
   #views = new Map();
+  // Phase 2 foundation: webContents → profile attribution for main-process
+  // IPC handlers (tray/badge/notification aggregation consumes this next).
+  #registry;
+  // profileId → { wcId, partition }, captured at view creation so teardown
+  // never depends on the WebContents still being reachable (a page can
+  // destroy its own webContents, e.g. an auth flow calling window.close()).
+  #viewMeta = new Map();
   #handlers = null;
   #resizeHandler = null;
   #navigationHandler = null;
@@ -108,11 +116,22 @@ class ProfileViewManager {
     this.#profilesManager = profilesManager;
     this.#config = config;
     this.#bindDisplayMediaHandler = bindDisplayMediaHandler;
+    this.#registry = new SenderProfileMap(profilesManager);
   }
 
   initialize() {
     if (this.#initialized) return;
     this.#initialized = true;
+
+    // The root window hosts Profile 0 (legacy partition).
+    this.#registry.setRootWebContentsId(this.#window.webContents.id);
+    // Seed the cached root profile id; afterwards the add/remove handlers
+    // keep it current, so resolution never touches the settings store
+    // (electron-store re-reads its JSON file on every access — too costly
+    // for the per-badge-tick hot path Phase 2 puts lookups on).
+    this.#registry.setRootProfileId(
+      this.#profilesManager.getLegacyProfile()?.id ?? null
+    );
 
     this.#handlers = {
       add: (profile) => this.#onAdd(profile),
@@ -308,16 +327,50 @@ class ProfileViewManager {
       }
       this.#chromeView = null;
     }
+    this.#registry.clear();
+    this.#viewMeta.clear();
     this.#initialized = false;
+  }
+
+  // --- Profile attribution (Phase 2 foundation) ------------------------
+
+  /**
+   * Resolve a webContents to the id of the profile that owns it: a profile
+   * view's id, or the root window's Profile 0. Returns null for any
+   * unattributed sender: the switcher pill, dialog windows, the root window
+   * while Profile 0 does not exist (pre-bootstrap, or after its removal) —
+   * and, for now, child windows / webview guests spawned by a profile view
+   * (see the KNOWN GAP note in senderProfileMap.js). Null means
+   * "unattributed", never "safe to ignore".
+   * @param {Electron.WebContents} webContents
+   * @returns {string|null}
+   */
+  resolveProfileId(webContents) {
+    if (!webContents || typeof webContents.id !== "number") return null;
+    return this.#registry.resolveProfileId(webContents.id);
+  }
+
+  /**
+   * Resolve an IPC event straight to the sender's full profile record.
+   * Null under the same contract as {@link resolveProfileId}, plus when the
+   * mapped profile record no longer exists in the store.
+   * @param {Electron.IpcMainEvent|Electron.IpcMainInvokeEvent} event
+   * @returns {object|null}
+   */
+  getProfileFor(event) {
+    return this.#registry.getProfileFor(event);
   }
 
   // --- Event handlers --------------------------------------------------
 
   #onAdd(profile) {
     // Profile 0 (legacy partition) lives on the root window; no overlay
-    // needed. Other profiles get a WebContentsView. Either way the pill
-    // must re-render to show the new profile.
-    if (profile.partition !== LEGACY_PARTITION) {
+    // needed — but its arrival (first-run bootstrap) is what makes root-
+    // window senders attributable. Other profiles get a WebContentsView.
+    // Either way the pill must re-render to show the new profile.
+    if (profile.partition === LEGACY_PARTITION) {
+      this.#registry.setRootProfileId(profile.id);
+    } else {
       this.#createView(profile);
     }
     this.#pushSwitcherState();
@@ -330,6 +383,12 @@ class ProfileViewManager {
 
   #onRemove({ removedId, activeId }) {
     this.#destroyView(removedId);
+    // Re-derive the cached root profile id: removing Profile 0 must make
+    // root-window senders unattributed again. One settings read on a rare
+    // event, keeping the lookup path I/O-free.
+    this.#registry.setRootProfileId(
+      this.#profilesManager.getLegacyProfile()?.id ?? null
+    );
     if (activeId) {
       const next = this.#profilesManager
         .list()
@@ -366,7 +425,22 @@ class ProfileViewManager {
     // binding does not carry across to profile partitions (#2529).
     this.#bindDisplayMediaHandler(view.webContents.session);
 
-    this.#views.set(profile.id, view);
+    const wcId = view.webContents.id;
+    const profileId = profile.id;
+    this.#views.set(profileId, view);
+    this.#viewMeta.set(profileId, { wcId, partition: profile.partition });
+    this.#registry.register(wcId, profileId);
+    // Full symmetric cleanup when the webContents dies outside profile
+    // removal (a page can destroy its own webContents): drop the view AND
+    // the attribution mapping, so a later remove/dispose of this profile
+    // doesn't tear down through a dead view. Idempotent with #destroyView.
+    // #viewMeta is deliberately retained: the profile record still exists,
+    // and a later remove must clear the partition's storage (ADR-020 remove
+    // contract) even though the view is gone.
+    view.webContents.once("destroyed", () => {
+      this.#views.delete(profileId);
+      this.#registry.unregister(wcId);
+    });
     this.#applyBounds(view);
 
     const url = profile.url || this.#config.url;
@@ -376,32 +450,45 @@ class ProfileViewManager {
   }
 
   #destroyView(profileId) {
+    // Keyed on the creation-time meta, not the live view: if the view's
+    // webContents destroyed itself earlier (see #createView), the view entry
+    // is already gone but the removal contract below must still run.
     const view = this.#views.get(profileId);
-    if (!view) return;
+    const meta = this.#viewMeta.get(profileId);
     this.#views.delete(profileId);
+    this.#viewMeta.delete(profileId);
+    if (!view && !meta) return;
+    if (meta) this.#registry.unregister(meta.wcId);
 
-    try {
-      this.#window.contentView.removeChildView(view);
-    } catch {
-      // View may not be currently attached; ignore.
+    if (view) {
+      try {
+        this.#window.contentView.removeChildView(view);
+      } catch {
+        // View may not be currently attached; ignore.
+      }
     }
 
     // Clear the partition's storage so a re-added profile with the same
     // name does not see the previous tenant's data. ADR-020 § "Remove a
     // profile" requires this destructive clear; UI confirmation is the
-    // caller's responsibility (Phase 1c.2 dialog).
-    const partitionSession = view.webContents.session;
-    partitionSession
-      .clearStorageData()
-      .catch((error) =>
-        console.warn(
-          "[ProfileViewManager] clearStorageData failed",
-          { profileId, message: error.message }
-        )
-      );
+    // caller's responsibility (Phase 1c.2 dialog). Resolved from the cached
+    // partition string, never through the view's webContents — that may be
+    // gone if the page destroyed it.
+    if (meta?.partition) {
+      session
+        .fromPartition(meta.partition)
+        .clearStorageData()
+        .catch((error) =>
+          console.warn(
+            "[ProfileViewManager] clearStorageData failed",
+            { profileId, message: error.message }
+          )
+        );
+    }
 
-    if (!view.webContents.isDestroyed()) {
-      view.webContents.close();
+    const wc = view?.webContents;
+    if (wc && !wc.isDestroyed()) {
+      wc.close();
     }
   }
 

--- a/app/mainAppWindow/senderProfileMap.js
+++ b/app/mainAppWindow/senderProfileMap.js
@@ -18,9 +18,9 @@
  * KNOWN GAP (correct before relying on "null ⇒ not a profile"): child
  * surfaces spawned BY a profile view — `window.open()` popups and `<webview>`
  * guests inherit the view's partition and preload but are not registered
- * here, so they currently resolve to null. The consuming PR must either
- * register descendants (`did-create-window` / `did-attach-webview`) or treat
- * null as "unattributed", never as "safe to ignore".
+ * here, so they currently resolve to null. The consuming PR registers
+ * descendants (`did-create-window` / `did-attach-webview`); until it lands,
+ * null means "unattributed", never "safe to ignore".
  *
  * Pure module (no Electron imports) so the mapping logic is unit-testable
  * directly under `node --test`.

--- a/app/mainAppWindow/senderProfileMap.js
+++ b/app/mainAppWindow/senderProfileMap.js
@@ -1,0 +1,111 @@
+/**
+ * SenderProfileMap — ADR-020 Phase 2 foundation. Maps a `webContents` id to
+ * the profile that owns it, so main-process IPC handlers can attribute a
+ * message to the profile view that sent it (`event.sender`) instead of
+ * assuming everything came from the single main window.
+ *
+ * Profile `WebContentsView`s are registered explicitly by
+ * `ProfileViewManager` at view creation. The ROOT window is special: it hosts
+ * Profile 0 (the legacy partition), but that profile record may not exist yet
+ * at window creation — first-run bootstrap only registers it after a
+ * successful login navigation. The owner therefore pushes the root profile id
+ * in via `setRootProfileId` when the legacy profile appears (or goes away),
+ * driven by the ProfilesManager events it already subscribes to. Lookups are
+ * pure map reads — deliberately no ProfilesManager call on the resolve path,
+ * because the settings store re-reads its JSON file on every access and
+ * resolution sits on the per-badge-tick hot path once aggregation consumes it.
+ *
+ * KNOWN GAP (correct before relying on "null ⇒ not a profile"): child
+ * surfaces spawned BY a profile view — `window.open()` popups and `<webview>`
+ * guests inherit the view's partition and preload but are not registered
+ * here, so they currently resolve to null. The consuming PR must either
+ * register descendants (`did-create-window` / `did-attach-webview`) or treat
+ * null as "unattributed", never as "safe to ignore".
+ *
+ * Pure module (no Electron imports) so the mapping logic is unit-testable
+ * directly under `node --test`.
+ */
+class SenderProfileMap {
+  /** @type {Map<number, string>} webContents.id → profile id */
+  #byWebContentsId = new Map();
+  /** @type {number|null} */
+  #rootWebContentsId = null;
+  /** @type {string|null} Profile 0's id once bootstrapped, else null. */
+  #rootProfileId = null;
+  #profilesManager;
+
+  /**
+   * @param {ProfilesManager} profilesManager  Used only by `getProfileFor`
+   *   to return the full profile record; resolution itself never touches it.
+   */
+  constructor(profilesManager) {
+    this.#profilesManager = profilesManager;
+  }
+
+  /** The root window's webContents hosts the legacy-partition profile. */
+  setRootWebContentsId(webContentsId) {
+    this.#rootWebContentsId = webContentsId;
+  }
+
+  /**
+   * The legacy-partition profile's id, or null while Profile 0 does not
+   * exist (pre-bootstrap, or after its removal). Owned by ProfileViewManager,
+   * updated from the ProfilesManager add/remove events.
+   */
+  setRootProfileId(profileId) {
+    this.#rootProfileId = profileId ?? null;
+  }
+
+  register(webContentsId, profileId) {
+    this.#byWebContentsId.set(webContentsId, profileId);
+  }
+
+  unregister(webContentsId) {
+    this.#byWebContentsId.delete(webContentsId);
+  }
+
+  clear() {
+    this.#byWebContentsId.clear();
+    this.#rootWebContentsId = null;
+    this.#rootProfileId = null;
+  }
+
+  /**
+   * Pure map lookup — no I/O.
+   * @param {number} webContentsId
+   * @returns {string|null} The owning profile's id, or null when the sender
+   *   is unattributed: the switcher pill, a dialog window, the root window
+   *   before Profile 0 is bootstrapped — or (see KNOWN GAP above) a child
+   *   window / webview guest spawned by a profile view.
+   */
+  resolveProfileId(webContentsId) {
+    const direct = this.#byWebContentsId.get(webContentsId);
+    if (direct !== undefined) return direct;
+    if (
+      this.#rootWebContentsId !== null &&
+      webContentsId === this.#rootWebContentsId
+    ) {
+      return this.#rootProfileId;
+    }
+    return null;
+  }
+
+  /**
+   * Convenience for IPC handlers: resolve an `IpcMainEvent` /
+   * `IpcMainInvokeEvent` straight to the sender's full profile record. Reads
+   * the profile list once — hot-path consumers that only need the id should
+   * use `resolveProfileId`.
+   * @returns {object|null}
+   */
+  getProfileFor(event) {
+    const senderId = event?.sender?.id;
+    if (typeof senderId !== "number") return null;
+    const profileId = this.resolveProfileId(senderId);
+    if (profileId === null) return null;
+    return (
+      this.#profilesManager.list().find((p) => p.id === profileId) ?? null
+    );
+  }
+}
+
+module.exports = SenderProfileMap;

--- a/app/profilesManager/index.js
+++ b/app/profilesManager/index.js
@@ -95,6 +95,16 @@ class ProfilesManager {
     return list.find((p) => p.id === activeId) || null;
   }
 
+  // The profile living on the ROOT window's webContents (Profile 0, bound to
+  // the legacy partition), or null before first-run bootstrap registers it.
+  // Main-process consumers (SenderProfileMap) use this to attribute IPC from
+  // the root window to a profile without duplicating the partition constant.
+  getLegacyProfile() {
+    return (
+      this.#read().list.find((p) => p.partition === LEGACY_PARTITION) || null
+    );
+  }
+
   switch(id) {
     const state = this.#read();
     const profile = state.list.find((p) => p.id === id);

--- a/tests/unit/profileViewManager.test.js
+++ b/tests/unit/profileViewManager.test.js
@@ -1,0 +1,252 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const electronPath = require.resolve('electron');
+const pvmPath = require.resolve('../../app/mainAppWindow/profileViewManager');
+const mapPath = require.resolve('../../app/mainAppWindow/senderProfileMap');
+
+// ADR-020 Phase 2 foundation: assert ProfileViewManager actually WIRES the
+// SenderProfileMap (root id + root profile at initialize, register on view
+// creation, cleanup on self-destroyed webContents / profile removal, clear on
+// dispose) and that teardown survives a view whose page destroyed its own
+// webContents. The pure map is covered in senderProfileMap.test.js. Electron
+// is mocked via the repo's require.cache pattern (see downloadManager.test.js).
+
+let nextWcId;
+let createdViews;
+let partitionSessions; // partition → { clearCalls }
+
+class FakeWebContents {
+  constructor() {
+    this.id = nextWcId++;
+    this.session = { clearStorageData: async () => {} };
+    this._once = {};
+    this._destroyed = false;
+  }
+  loadURL() {}
+  async loadFile() {}
+  on() {}
+  once(event, cb) {
+    (this._once[event] ||= []).push(cb);
+  }
+  removeListener() {}
+  send() {}
+  isDestroyed() {
+    return this._destroyed;
+  }
+  close() {}
+}
+
+class FakeWebContentsView {
+  constructor() {
+    this.webContents = new FakeWebContents();
+    createdViews.push(this);
+  }
+  setBounds() {}
+  setBackgroundColor() {}
+  // Mirror Electron's observed behaviour when a page destroys its own
+  // webContents: the `destroyed` handlers fire and afterwards the view's
+  // `webContents` accessor no longer returns a usable object. Any production
+  // code that reads `view.webContents.<x>` after this throws, like it would
+  // in the real app.
+  destroyWebContents() {
+    const wc = this.webContents;
+    wc._destroyed = true;
+    for (const cb of wc._once['destroyed'] || []) cb();
+    wc._once['destroyed'] = [];
+    this.webContents = undefined;
+    return wc;
+  }
+}
+
+function installElectronMock() {
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: {
+      WebContentsView: FakeWebContentsView,
+      session: {
+        fromPartition: (partition) => {
+          const entry = (partitionSessions[partition] ||= { clearCalls: 0 });
+          return {
+            cookies: { get: async () => [] },
+            clearStorageData: async () => {
+              entry.clearCalls++;
+            },
+          };
+        },
+      },
+      ipcMain: {
+        handle() {},
+        on() {},
+        removeHandler() {},
+        removeListener() {},
+      },
+    },
+  };
+}
+
+function fakeWindow() {
+  return {
+    webContents: new FakeWebContents(),
+    on() {},
+    once() {},
+    removeListener() {},
+    getContentSize: () => [1200, 800],
+    contentView: { addChildView() {}, removeChildView() {} },
+  };
+}
+
+const LEGACY = { id: 'profile-0', partition: 'persist:teams-4-linux', name: 'My account' };
+const PROFILE_A = { id: 'profile-a', partition: 'persist:teams-profile-a', name: 'A' };
+
+function fakeProfilesManager(profiles) {
+  const handlers = {};
+  return {
+    on(event, handler) {
+      (handlers[event] ||= []).push(handler);
+    },
+    off() {},
+    emit(event, payload) {
+      for (const h of handlers[event] || []) h(payload);
+    },
+    list: () => profiles,
+    getActive: () => profiles[0] ?? null,
+    getLegacyProfile: () =>
+      profiles.find((p) => p.partition === LEGACY.partition) ?? null,
+  };
+}
+
+let ProfileViewManager;
+
+beforeEach(() => {
+  nextWcId = 100;
+  createdViews = [];
+  partitionSessions = {};
+  installElectronMock();
+  delete require.cache[pvmPath];
+  delete require.cache[mapPath];
+  ProfileViewManager = require(pvmPath);
+});
+
+afterEach(() => {
+  delete require.cache[pvmPath];
+  delete require.cache[mapPath];
+  delete require.cache[electronPath];
+});
+
+function build(profiles) {
+  const win = fakeWindow();
+  const pm = fakeProfilesManager(profiles);
+  const pvm = new ProfileViewManager(win, pm, { url: 'https://teams.cloud.microsoft' }, () => {});
+  pvm.initialize();
+  return { win, pm, pvm };
+}
+
+describe('ProfileViewManager sender attribution wiring', () => {
+  it('resolves the root window to the legacy profile after initialize', () => {
+    const { win, pvm } = build([LEGACY, PROFILE_A]);
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), 'profile-0');
+  });
+
+  it('resolves the root window to null pre-bootstrap, then to Profile 0 when the bootstrap add fires', () => {
+    const profiles = [PROFILE_A];
+    const { win, pm, pvm } = build(profiles);
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), null);
+    const viewsBefore = createdViews.length;
+    profiles.push(LEGACY);
+    pm.emit('add', LEGACY);
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), 'profile-0');
+    // The legacy profile lives on the root window — no overlay materializes.
+    assert.strictEqual(createdViews.length, viewsBefore);
+  });
+
+  it('getProfileFor covers the root path: null pre-bootstrap, full record after', () => {
+    const profiles = [PROFILE_A];
+    const { win, pm, pvm } = build(profiles);
+    const event = { sender: { id: win.webContents.id } };
+    assert.strictEqual(pvm.getProfileFor(event), null);
+    profiles.push(LEGACY);
+    pm.emit('add', LEGACY);
+    assert.deepStrictEqual(pvm.getProfileFor(event), LEGACY);
+  });
+
+  it('root attribution goes quiet again when Profile 0 is removed', () => {
+    const profiles = [LEGACY, PROFILE_A];
+    const { win, pm, pvm } = build(profiles);
+    profiles.splice(profiles.indexOf(LEGACY), 1);
+    pm.emit('remove', { removedId: 'profile-0', activeId: 'profile-a' });
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), null);
+  });
+
+  it('registers materialized profile views and resolves their webContents', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    // Views created at initialize: PROFILE_A's view + the switcher pill.
+    const profileView = createdViews[0];
+    assert.strictEqual(pvm.resolveProfileId(profileView.webContents), 'profile-a');
+  });
+
+  it('does not attribute the switcher pill (or unknown senders) to any profile', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const pillView = createdViews[createdViews.length - 1];
+    assert.strictEqual(pvm.resolveProfileId(pillView.webContents), null);
+    assert.strictEqual(pvm.resolveProfileId({ id: 9999 }), null);
+    assert.strictEqual(pvm.resolveProfileId(null), null);
+  });
+
+  it('getProfileFor returns the full record for a profile-view sender', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const profileView = createdViews[0];
+    assert.deepStrictEqual(
+      pvm.getProfileFor({ sender: { id: profileView.webContents.id } }),
+      PROFILE_A
+    );
+  });
+
+  it('unregisters when the view webContents destroys itself (no profile removal)', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const wc = createdViews[0].destroyWebContents();
+    assert.strictEqual(pvm.resolveProfileId(wc), null);
+  });
+
+  it('removing a profile whose webContents already died does not throw and still clears its partition storage', () => {
+    const { pm, pvm } = build([LEGACY, PROFILE_A]);
+    const wc = createdViews[0].destroyWebContents();
+    assert.doesNotThrow(() =>
+      pm.emit('remove', { removedId: 'profile-a', activeId: 'profile-0' })
+    );
+    assert.strictEqual(pvm.resolveProfileId(wc), null);
+    // ADR-020 remove contract: the partition's storage is cleared via the
+    // cached partition string, not via the dead webContents.
+    assert.strictEqual(
+      partitionSessions['persist:teams-profile-a'].clearCalls,
+      1
+    );
+  });
+
+  it('dispose after a self-destroyed view does not throw and completes cleanup', () => {
+    const { win, pvm } = build([LEGACY, PROFILE_A]);
+    createdViews[0].destroyWebContents();
+    assert.doesNotThrow(() => pvm.dispose());
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), null);
+  });
+
+  it('unregisters on profile remove', () => {
+    const { pm, pvm } = build([LEGACY, PROFILE_A]);
+    const profileView = createdViews[0];
+    pm.emit('remove', { removedId: 'profile-a', activeId: 'profile-0' });
+    assert.strictEqual(pvm.resolveProfileId(profileView.webContents), null);
+  });
+
+  it('dispose clears all attribution including the root window', () => {
+    const { win, pvm } = build([LEGACY, PROFILE_A]);
+    const profileView = createdViews[0];
+    const profileWc = profileView.webContents;
+    pvm.dispose();
+    assert.strictEqual(pvm.resolveProfileId(win.webContents), null);
+    assert.strictEqual(pvm.resolveProfileId(profileWc), null);
+  });
+});

--- a/tests/unit/profilesManager.test.js
+++ b/tests/unit/profilesManager.test.js
@@ -91,3 +91,36 @@ describe('ProfilesManager pin cap', () => {
     assert.strictEqual(pm.update(sixth, { pinned: true }).pinned, true);
   });
 });
+
+// Phase 2 foundation: SenderProfileMap resolves the root window through this
+// accessor, so it must be null before bootstrap and the Profile 0 record after.
+describe('ProfilesManager getLegacyProfile', () => {
+  it('returns null before the legacy profile is bootstrapped', () => {
+    const pm = new ProfilesManager(makeStore());
+    pm.add({ name: 'Regular' });
+    assert.strictEqual(pm.getLegacyProfile(), null);
+  });
+
+  it('returns the bootstrapped Profile 0 record', () => {
+    const pm = new ProfilesManager(makeStore());
+    const bootstrapped = pm.bootstrapLegacyProfile('My account');
+    const legacy = pm.getLegacyProfile();
+    assert.strictEqual(legacy.id, bootstrapped.id);
+    assert.strictEqual(legacy.partition, 'persist:teams-4-linux');
+  });
+
+  it('does not confuse regular partitions with the legacy one', () => {
+    const pm = new ProfilesManager(makeStore());
+    pm.add({ name: 'Regular' });
+    pm.bootstrapLegacyProfile('My account');
+    assert.strictEqual(pm.getLegacyProfile().name, 'My account');
+  });
+
+  it('returns null again after Profile 0 is removed', () => {
+    const pm = new ProfilesManager(makeStore());
+    const bootstrapped = pm.bootstrapLegacyProfile('My account');
+    pm.add({ name: 'Regular' });
+    pm.remove(bootstrapped.id);
+    assert.strictEqual(pm.getLegacyProfile(), null);
+  });
+});

--- a/tests/unit/senderProfileMap.test.js
+++ b/tests/unit/senderProfileMap.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const SenderProfileMap = require('../../app/mainAppWindow/senderProfileMap');
+
+// ADR-020 Phase 2 foundation: webContents → profile attribution. The module
+// is pure (no Electron imports), so the mapping logic is tested directly.
+// Root resolution is push-based (setRootProfileId, driven by the owner's
+// ProfilesManager event subscriptions) — lookups must be pure map reads.
+
+function fakeProfilesManager(profiles) {
+  return { list: () => profiles };
+}
+
+describe('SenderProfileMap', () => {
+  it('resolves a registered profile view to its profile id', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.register(42, 'profile-a');
+    assert.strictEqual(reg.resolveProfileId(42), 'profile-a');
+  });
+
+  it('returns null for unknown senders (pill, dialogs)', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.register(42, 'profile-a');
+    assert.strictEqual(reg.resolveProfileId(99), null);
+  });
+
+  it('resolves the root window to the pushed root profile id', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    reg.setRootProfileId('profile-0');
+    assert.strictEqual(reg.resolveProfileId(7), 'profile-0');
+  });
+
+  it('resolves the root window to null before the root profile is pushed, then to it after', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    assert.strictEqual(reg.resolveProfileId(7), null);
+    reg.setRootProfileId('profile-0');
+    assert.strictEqual(reg.resolveProfileId(7), 'profile-0');
+  });
+
+  it('resolves the root window back to null after the root profile is cleared (Profile 0 removed)', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    reg.setRootProfileId('profile-0');
+    reg.setRootProfileId(null);
+    assert.strictEqual(reg.resolveProfileId(7), null);
+  });
+
+  it('does not leak the root fallback to unrelated senders', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    reg.setRootProfileId('profile-0');
+    // Sanity: the root itself still resolves, so this test cannot pass vacuously.
+    assert.strictEqual(reg.resolveProfileId(7), 'profile-0');
+    // The contract: a non-profile surface (pill, dialog, devtools) is NOT Profile 0.
+    assert.strictEqual(reg.resolveProfileId(8), null);
+  });
+
+  it('a registered view wins over the root fallback for its own id', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    reg.setRootProfileId('profile-0');
+    reg.register(7, 'profile-b'); // pathological, but explicit wins
+    assert.strictEqual(reg.resolveProfileId(7), 'profile-b');
+  });
+
+  it('unregister removes the mapping and is idempotent', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.register(42, 'profile-a');
+    reg.unregister(42);
+    reg.unregister(42);
+    assert.strictEqual(reg.resolveProfileId(42), null);
+  });
+
+  it('clear drops all mappings including the root id and root profile', () => {
+    const reg = new SenderProfileMap(fakeProfilesManager([]));
+    reg.setRootWebContentsId(7);
+    reg.setRootProfileId('profile-0');
+    reg.register(42, 'profile-a');
+    reg.clear();
+    assert.strictEqual(reg.resolveProfileId(42), null);
+    assert.strictEqual(reg.resolveProfileId(7), null);
+    // A stale root profile must not survive clear + a new root id.
+    reg.setRootWebContentsId(7);
+    assert.strictEqual(reg.resolveProfileId(7), null);
+  });
+
+  describe('getProfileFor', () => {
+    const profileA = { id: 'profile-a', name: 'A' };
+    const profileZero = { id: 'profile-0', name: 'My account' };
+
+    it('returns the full profile record for a registered sender', () => {
+      const reg = new SenderProfileMap(fakeProfilesManager([profileA]));
+      reg.register(42, 'profile-a');
+      assert.deepStrictEqual(
+        reg.getProfileFor({ sender: { id: 42 } }),
+        profileA
+      );
+    });
+
+    it('returns the full Profile 0 record for the root window sender', () => {
+      const reg = new SenderProfileMap(
+        fakeProfilesManager([profileZero, profileA])
+      );
+      reg.setRootWebContentsId(7);
+      reg.setRootProfileId('profile-0');
+      assert.deepStrictEqual(
+        reg.getProfileFor({ sender: { id: 7 } }),
+        profileZero
+      );
+    });
+
+    it('returns null for the root window before Profile 0 exists, then the record after', () => {
+      const profiles = [profileA];
+      const reg = new SenderProfileMap(fakeProfilesManager(profiles));
+      reg.setRootWebContentsId(7);
+      assert.strictEqual(reg.getProfileFor({ sender: { id: 7 } }), null);
+      profiles.push(profileZero);
+      reg.setRootProfileId('profile-0');
+      assert.deepStrictEqual(
+        reg.getProfileFor({ sender: { id: 7 } }),
+        profileZero
+      );
+    });
+
+    it('returns null for non-profile senders and malformed events', () => {
+      const reg = new SenderProfileMap(fakeProfilesManager([profileA]));
+      reg.register(42, 'profile-a');
+      assert.strictEqual(reg.getProfileFor({ sender: { id: 99 } }), null);
+      assert.strictEqual(reg.getProfileFor({}), null);
+      assert.strictEqual(reg.getProfileFor(null), null);
+      assert.strictEqual(reg.getProfileFor({ sender: {} }), null);
+    });
+
+    it('returns null when the mapped profile record no longer exists', () => {
+      // Mapping outlives the record only transiently (destroyView unregisters
+      // on remove), but the lookup must not throw in that window.
+      const reg = new SenderProfileMap(fakeProfilesManager([]));
+      reg.register(42, 'profile-gone');
+      assert.strictEqual(reg.getProfileFor({ sender: { id: 42 } }), null);
+    });
+  });
+});


### PR DESCRIPTION
## What

The first Phase 2 (background notifications) PR — foundation only, **zero behavior change**.

Main-process IPC handlers today can't tell *which* profile view sent a message: `event.sender` is ignored in `tray-update`, `set-badge-count`, `show-notification`, `user-status-changed`, etc. With several profiles running warm, those handlers are last-write-wins across views — e.g. a background profile settling to 0 unread can clear the tray badge for the profile you're looking at. Fixing that requires attribution first; this PR lands it. The unread aggregator (next PR) is its first consumer — **nothing resolves through it yet**, by design (same foundation-first pattern as the Phase 1 flag/data PRs).

### Changes
- **`SenderProfileMap`** (new, pure module — unit-testable without Electron): `webContents.id → profileId`. The root window hosts Profile 0, whose record may not exist until first-run bootstrap; the owner pushes the root profile id in from the `ProfilesManager` `add`/`remove` events it already subscribes to. Lookups are pure map reads — deliberately no settings-store access on the resolve path, since `electron-store` re-reads its JSON file on every access and resolution lands on the per-badge-tick hot path once aggregation consumes it.
- **`ProfileViewManager` wiring**: register at view creation (id captured up front), symmetric cleanup when a page destroys its own `webContents` (`destroyed` listener), clear on dispose; public `resolveProfileId(webContents)` / `getProfileFor(event)`.
- **Teardown hardening**: `#destroyView` is keyed on creation-time `{wcId, partition}` meta, so the ADR-required partition storage clear now runs via `session.fromPartition()` even when the view's `webContents` is already gone — previously that path threw before clearing.
- **`ProfilesManager.getLegacyProfile()`**: the legacy-partition record or null; owns the concept instead of duplicating the partition constant.
- **Documented gap** for the consuming PR (in the module JSDoc): child windows / `<webview>` guests spawned by a profile view aren't registered yet (profile views install no `setWindowOpenHandler`), so they resolve to null — null means *unattributed*, never *safe to ignore*.

### Flag-off safety
`ProfileViewManager` is never constructed with `multiAccount.enabled` off, and this PR adds nothing outside it beyond the side-effect-free `getLegacyProfile()` accessor. `multi-account-disabled.spec.js` is untouched and green.

## Testing
- `npm run lint` — clean
- `npm run test:unit` — **487 passed** (+26 new: the pure map incl. root pre/post-bootstrap and post-removal transitions; the `ProfileViewManager` wiring with Electron mocked — the fake reproduces `webContents` death, so the teardown paths can actually fail CI; `getLegacyProfile` lifecycle)
- `npm run test:e2e` — 16 passed
- Manual smoke on Linux with existing multi-profile config: Phase 1 behavior unchanged

## Notes
Opened as **draft** pending the SonarCloud quality gate. Part of #2495 — Phase 2 sequence: this → unread aggregator (tray badge = sum, top-3 tooltip) → switcher unread dots → per-profile notification flags → sender-aware NotificationService.

## Release notes
Two lines worth carrying into the changelog (the second is a user-facing fix, not just foundation):
- `feat(multi-account): sender→profile attribution map (ADR-020 Phase 2 foundation)`
- `fix(multi-account): removing a profile whose view had already closed itself skipped the partition storage clear — the next tenant of that partition inherited the old data`
