### PR TITLE
Fix Ubuntu Wayland screen sharing

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -80,7 +80,13 @@ function bindDisplayMediaHandler(targetSession) {
         console.error("[SCREEN_SHARE] Wayland portal selection failed:", {
           error: error.message,
         });
-        callback({});
+        setImmediate(() => {
+          try {
+            callback({});
+          } catch {
+            console.debug("[SCREEN_SHARE] Failed to complete Wayland portal callback");
+          }
+        });
       }
     });
     return;

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -50,10 +50,6 @@ let menus = null;
 
 const isMac = os.platform() === "darwin";
 
-function findSelectedSource(sources, source) {
-  return sources.find((s) => s.id === source.id);
-}
-
 function setupScreenSharing(selectedSource) {
   screenSharingService.setSelectedSource(selectedSource);
   createScreenSharePreviewWindow();
@@ -63,6 +59,33 @@ function setupScreenSharing(selectedSource) {
 // fires only for the session it is bound to, so multi-account profile views (running against
 // their own partition session) need their own binding. See #2529.
 function bindDisplayMediaHandler(targetSession) {
+  const isNativeWayland =
+    process.env.XDG_SESSION_TYPE === "wayland" &&
+    app.commandLine.getSwitchValue("ozone-platform") !== "x11";
+
+  if (isNativeWayland) {
+    targetSession.setDisplayMediaRequestHandler(async (_request, callback) => {
+      try {
+        // This single enumeration opens xdg-desktop-portal. Pass its selected
+        // source directly to Teams instead of opening the in-app picker.
+        const [source] = await desktopCapturer.getSources({
+          types: ["screen", "window"],
+        });
+        if (source) {
+          handleScreenSourceSelection(source, callback);
+        } else {
+          callback({});
+        }
+      } catch (error) {
+        console.error("[SCREEN_SHARE] Wayland portal selection failed:", {
+          error: error.message,
+        });
+        callback({});
+      }
+    });
+    return;
+  }
+
   targetSession.setDisplayMediaRequestHandler((_request, callback) => {
     streamSelector.show((source) => {
       if (source) {
@@ -82,41 +105,24 @@ function bindDisplayMediaHandler(targetSession) {
 }
 
 function handleScreenSourceSelection(source, callback) {
-  desktopCapturer
-    .getSources({ types: ["window", "screen"] })
-    .then((sources) => {
-      const selectedSource = findSelectedSource(sources, source);
-      if (selectedSource) {
-        setupScreenSharing(selectedSource);
-        callback({ video: selectedSource });
-      } else {
-        // Source not found - use setImmediate and try-catch to allow retry
-        setImmediate(() => {
-          try {
-            callback({});
-          } catch {
-            console.debug("[SCREEN_SHARE] Selected source not found");
-          }
-        });
-      }
-    })
-    .catch((error) => {
-      // Handle desktopCapturer failures gracefully - can crash on certain hardware
-      // configurations (USB-C docking stations, DisplayLink drivers, etc.)
-      // See issues #2058, #2041
-      console.error("[SCREEN_SHARE] Failed to get sources for selection:", {
-        error: error.message,
-        stack: error.stack,
-        sourceId: source?.id
-      });
-      setImmediate(() => {
-        try {
-          callback({});
-        } catch {
-          console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
-        }
-      });
+  try {
+    // Every Wayland/PipeWire enumeration creates a portal session with new IDs,
+    // so the source selected by the picker must be used directly. See #2713.
+    setupScreenSharing(source);
+    callback({ video: { id: source.id, name: source.name || "" } });
+  } catch (error) {
+    console.error("[SCREEN_SHARE] Failed to setup screen sharing:", {
+      error: error.message,
+      sourceId: source?.id,
     });
+    setImmediate(() => {
+      try {
+        callback({});
+      } catch {
+        console.debug("[SCREEN_SHARE] Failed to complete screen selection callback");
+      }
+    });
+  }
 }
 
 function createScreenSharePreviewWindow() {

--- a/app/screenSharing/README.md
+++ b/app/screenSharing/README.md
@@ -65,6 +65,10 @@ The picker is a modal overlay over the main Teams window. Issue #2524.
 
 ## Platform Notes
 
-**Wayland:** Requires source IDs in `screen:x:y` or `window:x:y` format from desktopCapturer. MediaStream UUIDs will fail.
+**Native Wayland:** The display-media handler calls `desktopCapturer.getSources()` once, which opens the xdg-desktop-portal picker, then passes its selected source directly to Teams. Do not open the in-app picker as well, because its enumeration would create a redundant selection stage.
+
+**X11 and XWayland:** The in-app picker requires source IDs in `screen:x:y` or `window:x:y` format from desktopCapturer. MediaStream UUIDs will fail.
+
+**Single enumeration rule:** the ID the picker returns must be passed straight to the `setDisplayMediaRequestHandler` callback. Never re-query `desktopCapturer.getSources()` to refresh the selected source: on Wayland/PipeWire every call opens a fresh portal session with new source IDs, so the share fails (#2713).
 
 See [ADR 001](../../docs-site/docs/development/adr/001-use-desktopcapturer-source-id-format.md) for technical details.

--- a/app/startup/commandLine.js
+++ b/app/startup/commandLine.js
@@ -158,7 +158,7 @@ class CommandLineManager {
   // Handles three independent concerns:
   //   1. PipeWire — always enabled for screen sharing
   //   2. GPU — auto-disabled unless user overrides or XWayland optimizations are on
-  //   3. Fake media UI — applied unless XWayland optimizations skip it
+  //   3. Fake media UI — applied only to legacy XWayland mode
   static #configureWayland(config) {
     // 1. PipeWire is always required for screen sharing on Wayland
     if (app.commandLine.hasSwitch("enable-features")) {
@@ -197,9 +197,10 @@ class CommandLineManager {
       config.disableGpu = true;
     }
 
-    // 3. Fake media UI: needed for screen sharing (#2217), but breaks camera
-    //    under XWayland (#2169). Only skip when XWayland optimizations are on.
-    if (!xwaylandOptimizations) {
+    // 3. Fake media UI: legacy XWayland needs this for the in-app picker (#2217),
+    //    but native Wayland must allow Chromium to open the PipeWire portal picker.
+    //    The flag also breaks cameras under XWayland, so its optimizations skip it (#2169).
+    if (isXWayland && !xwaylandOptimizations) {
       app.commandLine.appendSwitch("use-fake-ui-for-media-stream");
     }
   }

--- a/tests/unit/commandLine.test.js
+++ b/tests/unit/commandLine.test.js
@@ -9,17 +9,18 @@ const commandLinePath = require.resolve('../../app/startup/commandLine');
 const originalElectron = require.cache[electronPath];
 const originalPlatform = process.platform;
 const originalArch = process.arch;
+const originalSessionType = process.env.XDG_SESSION_TYPE;
 
 // Run CommandLineManager.addSwitchesAfterConfigLoad under a mocked Electron
 // `app.commandLine`, forced platform and arch, returning the list of switches
 // the manager appended as [name, value] pairs.
-function appendedSwitches(config, platform = 'darwin', arch = 'arm64') {
+function appendedSwitches(config, platform = 'darwin', arch = 'arm64', existingSwitches = {}) {
   const switches = [];
   const app = {
     commandLine: {
       appendSwitch: (name, value) => switches.push([name, value]),
-      hasSwitch: () => false,
-      getSwitchValue: () => '',
+      hasSwitch: (name) => Object.hasOwn(existingSwitches, name),
+      getSwitchValue: (name) => existingSwitches[name] ?? '',
     },
     setName: () => {},
     setDesktopName: () => {},
@@ -54,6 +55,11 @@ describe('CommandLineManager macOS performance gate', () => {
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+    if (originalSessionType === undefined) {
+      delete process.env.XDG_SESSION_TYPE;
+    } else {
+      process.env.XDG_SESSION_TYPE = originalSessionType;
+    }
     if (originalElectron) {
       require.cache[electronPath] = originalElectron;
     } else {
@@ -115,5 +121,58 @@ describe('CommandLineManager macOS performance gate', () => {
   it('does not apply the macOS switches on non-darwin platforms', () => {
     const switches = appendedSwitches({ authServerWhitelist: '*' }, 'linux');
     assert.ok(!hasSwitch(switches, 'use-angle'), 'mac perf path not taken off macOS');
+  });
+});
+
+describe('CommandLineManager Wayland media switches', () => {
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+    if (originalSessionType === undefined) {
+      delete process.env.XDG_SESSION_TYPE;
+    } else {
+      process.env.XDG_SESSION_TYPE = originalSessionType;
+    }
+    if (originalElectron) {
+      require.cache[electronPath] = originalElectron;
+    } else {
+      delete require.cache[electronPath];
+    }
+    delete require.cache[commandLinePath];
+  });
+
+  it('allows the portal picker on native Wayland', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland';
+
+    const switches = appendedSwitches({ authServerWhitelist: '*' }, 'linux', 'x64');
+
+    assert.ok(!hasSwitch(switches, 'use-fake-ui-for-media-stream'));
+    assert.strictEqual(switchValue(switches, 'enable-features'), 'WebRTCPipeWireCapturer');
+  });
+
+  it('keeps fake media UI for legacy XWayland screen sharing', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland';
+
+    const switches = appendedSwitches(
+      { authServerWhitelist: '*', wayland: { xwaylandOptimizations: false } },
+      'linux',
+      'x64',
+      { 'ozone-platform': 'x11' },
+    );
+
+    assert.ok(hasSwitch(switches, 'use-fake-ui-for-media-stream'));
+  });
+
+  it('skips fake media UI when XWayland optimizations are enabled', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland';
+
+    const switches = appendedSwitches(
+      { authServerWhitelist: '*', wayland: { xwaylandOptimizations: true } },
+      'linux',
+      'x64',
+      { 'ozone-platform': 'x11' },
+    );
+
+    assert.ok(!hasSwitch(switches, 'use-fake-ui-for-media-stream'));
   });
 });


### PR DESCRIPTION
## Summary

Fix screen sharing on native Ubuntu Wayland by:

- Allowing the PipeWire portal chooser instead of suppressing it with `--use-fake-ui-for-media-stream`.
- Calling `desktopCapturer.getSources()` exactly once on native Wayland.
- Passing the portal-selected source directly to Teams.
- Retaining the existing custom picker behavior for X11 and XWayland.
- Adding regression tests for native Wayland and XWayland startup flags.

This prevents camera/content-sharing errors, duplicate picker transitions, and failures caused by transient PipeWire source IDs.

closes #2871

## Testing

- [x] `npm run lint`
- [x] `npm run test:unit` (468 passed, 1 skipped)
- [ ] `npm run test:e2e`
- [x] Built and ran the packaged application manually on Ubuntu 26.04 GNOME Wayland
- [x] Built the AMD64 Debian package
- [ ] Cross-distro testing

Manual testing confirmed that the Ubuntu portal chooser appears once and screen sharing starts after selecting a source.

## Documentation

- [ ] Updated `docs-site/docs/...`
- [x] Updated module `[README.md](https://github.com/home/rusty/.t3/worktrees/teams-for-linux/t3code-faa7708d/app/screenSharing/README.md)`
- [ ] Added or changed an IPC channel
- [x] No new PII added to logs
- [ ] N/A

Updated `app/screenSharing/README.md` with native Wayland behavior and the PipeWire single-enumeration requirement.

## Notes for reviewers

Electron 42 does not support `useSystemPicker` on Linux. Leaving the display-media handler unset also fails, while using the existing custom picker causes an additional portal-selection stage.

The native Wayland path therefore invokes `desktopCapturer.getSources()` once. That opens `xdg-desktop-portal`, and the returned source is passed directly to the display-media callback. Re-enumerating is unsafe because each PipeWire portal session produces new transient source IDs.