### PR TITLE
docs(idle): document driving the idle state file on Wayland

### DIFF
--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -205,6 +205,70 @@ rm /tmp/teams-for-linux-idle-state-$USER
 
 The state file is automatically cleaned up when the app exits.
 
+:::note Requires `awayOnSystemIdle`
+The state file only controls what the app *believes* the system idle state is. Presence is
+still only changed when `awayOnSystemIdle` is `true`, so set both:
+
+```json
+{
+  "awayOnSystemIdle": true,
+  "idleDetection": { "forceState": true }
+}
+```
+:::
+
+#### Driving the state file automatically (Wayland)
+
+Under Wayland, `powerMonitor` cannot see user input, so nothing populates the state file on its
+own. Any idle daemon that can run a command on timeout and on resume will do. On a compositor
+implementing `ext-idle-notify-v1` (KWin, sway, Hyprland, and most wlroots compositors), `swayidle`
+works well as a user service:
+
+`~/.config/systemd/user/teams-idle-watcher.service`
+
+```ini
+[Unit]
+Description=Teams for Linux presence idle watcher (swayidle -> state file)
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+Environment=STATEFILE=/tmp/teams-for-linux-idle-state-%u
+ExecStartPre=/bin/sh -c 'echo active > "$STATEFILE"'
+ExecStart=/usr/bin/swayidle -w \
+  timeout 300 'echo inactive > "$STATEFILE"' \
+  resume 'echo active > "$STATEFILE"' \
+  before-sleep 'echo inactive > "$STATEFILE"'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target
+```
+
+Enable it with `systemctl --user enable --now teams-idle-watcher.service`.
+
+Three things are worth knowing before you rely on this:
+
+**The daemon's timeout is the idle delay, not `appIdleTimeout`.** When the state file says
+`inactive` the app reports idle straight away and never consults `powerMonitor`, so
+`appIdleTimeout` has no effect on this path. Set the delay you want in the `timeout` line above.
+`appIdleTimeout` still applies when the state file is absent and detection falls back to
+`powerMonitor`.
+
+**The app deletes the state file when it exits.** `swayidle` only writes on a transition, so after
+restarting Teams for Linux the file stays missing until the next idle or resume. The
+`ExecStartPre` line above re-seeds it, which means restarting the watcher alongside the app
+restores a known state.
+
+**A stale `inactive` pins you idle.** If the watcher stops while the file still reads `inactive`,
+the app keeps reporting idle indefinitely with nothing to correct it. Removing the file returns
+you to automatic detection.
+
+Content other than `active` or `inactive` is logged as a warning and ignored, falling through to
+`powerMonitor`.
+
 ### Authentication & SSO
 
 | Option | Type | Default | Description |


### PR DESCRIPTION
`idleDetection.forceState` documented the hook (the state file and `echo inactive > ...`) but nothing about producing the signal, and under Wayland `powerMonitor` cannot see input, so that is the whole job. Reported by @danlii in #2851, whose swayidle unit this is.

Three things I verified against `app/idle/monitor.js` while writing it, since two of them contradict the obvious reading:

- `awayOnSystemIdle` is a separate prerequisite (`activityManager.js:21`). Setting only `forceState` does nothing to presence, which is what cost the reporter the most time.
- The daemon's timeout is the idle delay, not `appIdleTimeout`. A state file reading `inactive` returns idle immediately (`monitor.js:81-90`) and never reaches `powerMonitor.getSystemIdleState()`, so `appIdleTimeout` only governs the fallback path.
- A stale `inactive` pins you idle indefinitely, and the app deletes the file on exit (`monitor.js:35-49`), so a transition-driven watcher needs to re-seed it.

Docs only, no code change.

Closes #2851

🤖 Generated with [Claude Code](https://claude.com/claude-code)