### PR TITLE
fix(network): treat ERR_TIMED_OUT as recoverable so the retry loop survives

### DIFF
--- a/app/config/defaults.js
+++ b/app/config/defaults.js
@@ -14,6 +14,12 @@ const NETWORK_ERROR_PATTERNS = [
   'ERR_CONNECTION_RESET',
   'ERR_CONNECTION_REFUSED',
   'ERR_CONNECTION_TIMED_OUT',
+  // Distinct from ERR_CONNECTION_TIMED_OUT (-118): Chromium reports the generic
+  // ERR_TIMED_OUT (-7) when a host is black-holed rather than refusing, which is
+  // what a firewall that drops packets for an unallowed domain looks like. It was
+  // missing here, so did-fail-load scheduled no retry and the window sat on
+  // "Waiting for network..." with nothing left to recover it (#2875).
+  'ERR_TIMED_OUT',
   'ERR_NAME_NOT_RESOLVED',
 ];
 

--- a/tests/unit/connectionManagerOnlineCheck.test.js
+++ b/tests/unit/connectionManagerOnlineCheck.test.js
@@ -167,3 +167,71 @@ describe('ConnectionManager connectivity sweep', () => {
 		assert.strictEqual(requestsCreated, 1, 'a healthy network needs one probe');
 	});
 });
+
+// did-fail-load is the only thing that restarts the retry loop once a load has
+// failed: refresh() takes the reload() branch from then on, and reload() cannot
+// reject, so nothing else schedules another attempt. A network error missing
+// from the recoverable set therefore wedges the window permanently (#2875).
+describe('ConnectionManager did-fail-load retry scheduling', () => {
+	before(() => {
+		installElectronMock();
+	});
+
+	after(() => {
+		delete require.cache[electronPath];
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	beforeEach(() => {
+		installElectronMock();
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	// Drives start() far enough to capture the registered did-fail-load handler.
+	// refresh() is stubbed out because start() kicks one off and the sweep is
+	// covered by the tests above.
+	function managerWithFakeWindow() {
+		const ConnectionManager = require('../../app/connectionManager');
+		const manager = new ConnectionManager();
+		const listeners = {};
+		const window = {
+			isDestroyed: () => false,
+			setTitle() {},
+			webContents: {
+				on(event, fn) { listeners[event] = fn; },
+				removeListener() {},
+				getURL: () => '',
+			},
+		};
+		manager.refresh = () => {};
+		manager.start('https://teams.cloud.microsoft', {
+			window,
+			config: { url: 'https://teams.cloud.microsoft' },
+		});
+		let scheduled = 0;
+		manager.debouncedRefresh = () => { scheduled += 1; };
+		return { didFailLoad: listeners['did-fail-load'], scheduledCount: () => scheduled };
+	}
+
+	// -7 is what a firewall dropping packets for an unallowed domain produces,
+	// -118 what a host that refuses does. Both must schedule a retry.
+	for (const [code, description] of [[-7, 'ERR_TIMED_OUT'], [-118, 'ERR_CONNECTION_TIMED_OUT']]) {
+		it(`schedules a retry after a main-frame ${description}`, () => {
+			const { didFailLoad, scheduledCount } = managerWithFakeWindow();
+			didFailLoad({}, code, description, 'https://teams.cloud.microsoft/', true);
+			assert.strictEqual(scheduledCount(), 1, `${description} should be recoverable`);
+		});
+	}
+
+	it('ignores a non-network failure', () => {
+		const { didFailLoad, scheduledCount } = managerWithFakeWindow();
+		didFailLoad({}, -3, 'ERR_ABORTED', 'https://teams.cloud.microsoft/', true);
+		assert.strictEqual(scheduledCount(), 0);
+	});
+
+	it('ignores sub-frame failures, which are routine on restricted networks', () => {
+		const { didFailLoad, scheduledCount } = managerWithFakeWindow();
+		didFailLoad({}, -7, 'ERR_TIMED_OUT', 'https://telemetry.example/', false);
+		assert.strictEqual(scheduledCount(), 0);
+	});
+});


### PR DESCRIPTION
Reported in #2875: the window sits on "Waiting for network..." indefinitely and never retries.

## Cause

`NETWORK_ERROR_PATTERNS` carried `ERR_CONNECTION_TIMED_OUT` (-118) but not the generic `ERR_TIMED_OUT` (-7). Chromium reports -118 when a host actively refuses and -7 when packets are simply dropped, which is what a firewall blocking an unallowed domain looks like. So `did-fail-load` logged the failure and scheduled nothing.

That is terminal rather than merely slow, because `did-fail-load` is the only thing that can restart the loop once a load has failed. The first failure still gets one retry from the `await loadURL(...)` rejection in `refresh()`, but from then on `refresh()` takes the `reload()` branch (`getURL()` returns the intended URL even while the frame shows `chrome-error://`), and `reload()` is not awaited and cannot reject. Nothing else schedules another attempt.

## Fix

Add `ERR_TIMED_OUT` to the shared list, so the reload failure re-enters `debouncedRefresh()` and the loop continues until the network returns.

The list is also consumed by `isNetworkError()` in `app/index.js` via substring matching. `ERR_CONNECTION_TIMED_OUT` does not contain `ERR_TIMED_OUT` as a substring, so there is no overlap and no change to what that already classified.

## Testing

- `npm run test:unit` 476 passing, `npm run lint` clean
- New `did-fail-load` tests assert both timeout codes schedule a retry, and that a non-network failure and a sub-frame failure do not. Verified they fail without the one-line change: removing `ERR_TIMED_OUT` fails exactly the `ERR_TIMED_OUT` case and nothing else.

Not a fix for the reporter's underlying problem, which is that `teams.cloud.microsoft` is unreachable on their network. It fixes the app wedging instead of retrying when that happens.

Refs #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)