### PR TITLE
fix(webauthn): return PublicKeyCredential-compatible responses

### DIFF
--- a/app/browser/tools/webauthnOverride.js
+++ b/app/browser/tools/webauthnOverride.js
@@ -230,13 +230,20 @@ function serializeGetOptions(publicKey) {
 }
 
 /**
- * Reconstruct a PublicKeyCredential-shaped object from IPC response.
- * We cannot create real PublicKeyCredential instances, but the shape
- * is sufficient for login.microsoftonline.com's JavaScript to process.
+ * The native PublicKeyCredential constructor cannot be called directly. Start
+ * with its prototype so instanceof checks pass, then add the response fields as
+ * properties of the new object.
  */
+function createPublicKeyCredential(properties) {
+  return Object.create(
+    PublicKeyCredential.prototype,
+    Object.getOwnPropertyDescriptors(properties),
+  );
+}
+
 function reconstructCreateResponse(data) {
   const rawId = base64urlToBuffer(data.rawId);
-  return {
+  return createPublicKeyCredential({
     id: data.credentialId,
     rawId: rawId,
     type: data.type,
@@ -259,7 +266,7 @@ function reconstructCreateResponse(data) {
         clientDataJSON: data.clientDataJson,
       },
     }),
-  };
+  });
 }
 
 function reconstructGetResponse(data) {
@@ -278,7 +285,7 @@ function reconstructGetResponse(data) {
     getAuthenticatorData: () => authDataBuf,
   };
 
-  const credential = {
+  const credential = createPublicKeyCredential({
     id: data.credentialId,
     rawId: rawId,
     type: data.type,
@@ -298,7 +305,7 @@ function reconstructGetResponse(data) {
         userHandle: data.userHandle || null,
       },
     }),
-  };
+  });
 
   console.info("[WEBAUTHN] Reconstructed get response", {
     authDataBytes: authDataBuf.byteLength,

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -206,7 +206,7 @@ function injectIntoFrame(wf) {
         const CHUNK = 8192;
         let bin = "";
         for (let i = 0; i < bytes.length; i += CHUNK) bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-        return btoa(bin).replace(/\\+/g, "-").replace(/\\//g, "_").replace(/=+$/, "");
+        return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replace(/={1,2}$/, "");
       }
 
       function b64urlToBuf(s) {

--- a/app/webauthn/index.js
+++ b/app/webauthn/index.js
@@ -216,6 +216,13 @@ function injectIntoFrame(wf) {
         return Uint8Array.from(d, c => c.charCodeAt(0)).buffer;
       }
 
+      function createPublicKeyCredential(properties) {
+        return Object.create(
+          PublicKeyCredential.prototype,
+          Object.getOwnPropertyDescriptors(properties)
+        );
+      }
+
       function serCreate(pk) {
         return {
           challenge: bufToB64url(pk.challenge), rpId: pk.rp?.id || "", rpName: pk.rp?.name || "",
@@ -258,13 +265,13 @@ function injectIntoFrame(wf) {
         console.info("[WEBAUTHN:frame] Intercepting credentials.create()");
         const r = await ipcInvoke("webauthn:create", serCreate(opts.publicKey));
         const raw = b64urlToBuf(r.rawId);
-        return { id: r.credentialId, rawId: raw, type: r.type, authenticatorAttachment: "cross-platform",
+        return createPublicKeyCredential({ id: r.credentialId, rawId: raw, type: r.type, authenticatorAttachment: "cross-platform",
           response: { attestationObject: b64urlToBuf(r.attestationObject), clientDataJSON: b64urlToBuf(r.clientDataJson),
             getAuthenticatorData: () => b64urlToBuf(r.authenticatorData), getTransports: () => r.transports || ["usb"],
             getPublicKey: () => null, getPublicKeyAlgorithm: () => r.publicKeyAlgorithm || -7 },
           getClientExtensionResults: () => ({}),
           toJSON: () => ({ id: r.credentialId, rawId: r.rawId, type: r.type,
-            response: { attestationObject: r.attestationObject, clientDataJSON: r.clientDataJson } }) };
+            response: { attestationObject: r.attestationObject, clientDataJSON: r.clientDataJson } }) });
       };
 
       navigator.credentials.get = async function(opts) {
@@ -274,7 +281,7 @@ function injectIntoFrame(wf) {
         const r = await ipcInvoke("webauthn:get", serGet(opts.publicKey));
         const raw = b64urlToBuf(r.rawId);
         const authData = b64urlToBuf(r.authenticatorData);
-        return { id: r.credentialId, rawId: raw, type: r.type, authenticatorAttachment: "cross-platform",
+        return createPublicKeyCredential({ id: r.credentialId, rawId: raw, type: r.type, authenticatorAttachment: "cross-platform",
           response: { authenticatorData: authData, clientDataJSON: b64urlToBuf(r.clientDataJson),
             signature: b64urlToBuf(r.signature), userHandle: r.userHandle ? b64urlToBuf(r.userHandle) : null,
             getAuthenticatorData: () => authData },
@@ -282,7 +289,7 @@ function injectIntoFrame(wf) {
           toJSON: () => ({ id: r.credentialId, rawId: r.rawId, type: r.type,
             authenticatorAttachment: "cross-platform", clientExtensionResults: {},
             response: { authenticatorData: r.authenticatorData, clientDataJSON: r.clientDataJson,
-              signature: r.signature, userHandle: r.userHandle || null } }) };
+              signature: r.signature, userHandle: r.userHandle || null } }) });
       };
 
       console.info("[WEBAUTHN:frame] navigator.credentials patched in subframe");

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -529,6 +529,51 @@ describe('WebAuthn fido2Backend - stdin line construction', () => {
 	});
 });
 
+const credentialResponse = {
+	credentialId: 'credential',
+	rawId: '',
+	type: 'public-key',
+	attestationObject: '',
+	authenticatorData: '',
+	clientDataJson: '',
+	signature: '',
+	userHandle: null,
+};
+
+describe('WebAuthn main-frame override', () => {
+	const override = readFileSync(path.join(__dirname, '..', '..', 'app', 'browser', 'tools', 'webauthnOverride.js'), 'utf8');
+
+	it('returns PublicKeyCredential instances for create and get', async () => {
+		class PublicKeyCredential {}
+		const credentials = { create: () => {}, get: () => {} };
+		const module = { exports: {} };
+
+		new vm.Script(override, { filename: 'webauthnOverride.js' }).runInNewContext({
+			PublicKeyCredential,
+			DOMException,
+			atob: () => '',
+			btoa: () => '',
+			console: { debug: () => {}, error: () => {}, info: () => {}, warn: () => {} },
+			module,
+			navigator: { credentials },
+			process: { platform: 'linux' },
+			window: { addEventListener: () => {} },
+		});
+		module.exports.init(
+			{ auth: { webauthn: { enabled: true } } },
+			{ invoke: async () => ({ success: true, data: credentialResponse }) },
+		);
+
+		const created = await credentials.create({
+			publicKey: { challenge: new Uint8Array(), user: { id: new Uint8Array() }, pubKeyCredParams: [] },
+		});
+		const asserted = await credentials.get({ publicKey: { challenge: new Uint8Array() } });
+
+		assert.ok(created instanceof PublicKeyCredential);
+		assert.ok(asserted instanceof PublicKeyCredential);
+	});
+});
+
 // The subframe override is a template string run through executeJavaScript, so
 // a syntax error in it fails silently at runtime and surfaces only as logins
 // not working inside the login iframe. Nothing else parses it.
@@ -552,5 +597,40 @@ describe('WebAuthn subframe injection - injected script', () => {
 	it('gives the relayed credential toJSON and getAuthenticatorData', () => {
 		assert.ok(injected.includes('toJSON'));
 		assert.ok(injected.includes('getAuthenticatorData'));
+	});
+
+	it('returns PublicKeyCredential instances for create and get', async () => {
+		class PublicKeyCredential {}
+		let messageListener;
+		const credentials = { create: () => {}, get: () => {} };
+		const window = {
+			addEventListener: (_type, listener) => { messageListener = listener; },
+			removeEventListener: () => {},
+			parent: {
+				postMessage: ({ id }) => messageListener({
+					data: { type: 'webauthn-response', id, result: credentialResponse },
+				}),
+			},
+		};
+
+		new vm.Script(injected, { filename: 'injected-subframe.js' }).runInNewContext({
+			PublicKeyCredential,
+			DOMException,
+			atob: () => '',
+			btoa: () => '',
+			console: { info: () => {} },
+			crypto: { randomUUID: () => 'request-id' },
+			navigator: { credentials },
+			setTimeout: () => 0,
+			window,
+		});
+
+		const created = await credentials.create({
+			publicKey: { challenge: new Uint8Array(), user: { id: new Uint8Array() }, pubKeyCredParams: [] },
+		});
+		const asserted = await credentials.get({ publicKey: { challenge: new Uint8Array() } });
+
+		assert.ok(created instanceof PublicKeyCredential);
+		assert.ok(asserted instanceof PublicKeyCredential);
 	});
 });


### PR DESCRIPTION
## Summary

Debugging #2719 I noticed that the requested endpoints are differen. The 2nd try uses `common/login` while the new one calls `/common/api/v1.0-internal/auth/methods/fido/.../verify`.

The js that is loaded currently points to this file:
https://aadcdn.msftauth.net/shared/4/js/signin-fabric_v2_en-gb_8BSZxloPlinjEVbINH0NbQ2.js

Which basically checks for `r instanceof PublicKeyCredential`.

So to fix we just make this test pass.

Fixes #2719

## Testing

  - [x] `npm run lint` (required)
  - [x] `npm run test:unit`
  - [ ] `npm run test:e2e`
  - [ ] Ran the app manually (`npm start`) and exercised the affected path
  - [ ] Cross-distro / packaging build (`npm run cross-distro`)


## Documentation


  - [ ] Updated `docs-site/docs/...`
  - [ ] Updated module `README.md`
  - [ ] Added the new channel to `app/security/ipcValidator.js` and ran `npm run generate-ipc-docs` (IPC channel added or changed)
  - [ ] No new PII added to logs (see CLAUDE.md "Logging Guidelines")
  - [x] N/A


## Notes for reviewers


