### PR TITLE
docs(adr): add ADR-028 to the docs sidebar

### DIFF
--- a/docs-site/docs/development/adr/README.md
+++ b/docs-site/docs/development/adr/README.md
@@ -364,13 +364,13 @@ When referencing code in ADRs:
 
 ## ADR Statistics
 
-- **Total ADRs**: 22
-- **Implemented**: 12
-- **Accepted**: 3
+- **Total ADRs**: 27
+- **Implemented**: 14
+- **Accepted**: 6
 - **Proposed**: 2
 - **Rejected**: 5
-- **Average length**: ~500 words
-- **Topics covered**: 9 (Authentication & Security, Screen Sharing, Testing & Quality, Documentation & Standards, Release Process & Automation, Community & Metrics, MQTT & Integration, UI Features, Distribution & Packaging)
+- **Average length**: ~1050 words
+- **Topics covered**: 10 (Authentication & Security, Screen Sharing, Testing & Quality, Performance, Documentation & Standards, Release Process & Automation, Community & Metrics, MQTT & Integration, UI Features, Distribution & Packaging)
 
 ## Related Documentation
 

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
             'development/adr/024-smartcard-pkcs11-pin-dialog',
             'development/adr/025-config-option-naming-convention',
             'development/adr/026-performance-audit-outcomes',
+            'development/adr/028-third-party-idp-otc-prefill',
           ],
         },
         {


### PR DESCRIPTION
ADR-028 landed in #2881 but never appeared in the site navigation. `docs-site/sidebars.ts` enumerates every ADR by hand and stopped at `026`, so the page was reachable only by direct URL.

One line added. Verified with `npm run build`: the page generates and now renders as a sidebar link ("ADR 028: One-Time-Code Pre-fill on Third-Party Identity Providers"). The two broken-anchor warnings in the build output are pre-existing and unrelated, both from the `ipc-api` pages linking to `security-architecture#ipc-channel-validation`.

Note there is no `027` on main: that number is claimed by the unmerged #2845, so the list goes 026 then 028 deliberately.
