### PR TITLE
fix(packaging): recommend fido2-tools in deb and rpm packages

### DIFF
--- a/app/webauthn/README.md
+++ b/app/webauthn/README.md
@@ -11,7 +11,7 @@ On Linux, Chromium's WebAuthn implementation lacks hardware support. This module
 
 ## Prerequisites
 
-Install `fido2-tools` on your Linux system:
+Install `fido2-tools` on your Linux system (the official deb and rpm packages list it as a recommended dependency, so most installs already have it):
 
 ```bash
 # Debian/Ubuntu

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -349,7 +349,7 @@ Report-only Content Security Policy headers are automatically stripped for all n
 
 Hardware security key authentication (YubiKey, SoloKeys, etc.) for Microsoft Entra ID login. On Linux, Electron's Chromium lacks native WebAuthn hardware support, so this module intercepts `navigator.credentials` calls and routes them to `fido2-tools`. On macOS and Windows, Electron handles WebAuthn natively and this feature is not needed.
 
-Requires the `fido2-tools` system package: `sudo apt install fido2-tools` (Debian/Ubuntu) or `sudo dnf install fido2-tools` (Fedora) or `sudo pacman -S libfido2` (Arch).
+Requires the `fido2-tools` system package: `sudo apt install fido2-tools` (Debian/Ubuntu) or `sudo dnf install fido2-tools` (Fedora) or `sudo pacman -S libfido2` (Arch). The official deb and rpm packages list it as a recommended dependency, so it is installed automatically unless weak dependencies are disabled.
 
 ```json
 {

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -323,7 +323,7 @@ Since v2.7.13, report-only CSP headers are automatically stripped for all non-Te
 
 **Solutions/Workarounds:**
 
-1. Install `fido2-tools` on your system:
+1. Install `fido2-tools` on your system (the official deb and rpm packages list it as a recommended dependency, so most installs already have it):
     - Debian / Ubuntu: `sudo apt install fido2-tools`
     - Fedora: `sudo dnf install fido2-tools`
     - Arch: `sudo pacman -S libfido2`

--- a/package.json
+++ b/package.json
@@ -135,7 +135,14 @@
       ],
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links  none",
-        "--rpm-digest=sha256"
+        "--rpm-digest=sha256",
+        "--rpm-tag=Recommends: fido2-tools"
+      ]
+    },
+    "deb": {
+      "recommends": [
+        "libappindicator3-1",
+        "fido2-tools"
       ]
     },
     "snapcraft": {


### PR DESCRIPTION
## Summary

Hardware security key sign-in (`auth.webauthn.enabled`) needs the fido2-tools CLI at runtime. Without it the webauthn module logs a warning and bails, and a user whose account requires a passkey is left on a Microsoft sign-in page that spins forever. Rough first experience for a 44 kB package.

This adds fido2-tools as a weak dependency (Recommends) to the deb and rpm packages. apt and dnf install recommends by default, so most users get it automatically, while minimal installs and distros without the package are unaffected. The feature itself stays opt-in; this only removes the missing-binary failure mode for people who enable it.

For the deb this uses electron-builder's `deb.recommends`, re-listing `libappindicator3-1` because setting the key replaces the default list. For the rpm, electron-builder has no recommends option, so the tag goes through the existing fpm passthrough.

## Testing

- [x] `npm run lint` (required)
- [x] `npm run test:unit`
- [x] Built the deb locally: `dpkg-deb -I` shows `Recommends: libappindicator3-1, fido2-tools` with the default Depends unchanged

The rpm could not be built on this machine (no rpmbuild), but the flag passes fpm argument parsing and CI builds the rpm as usual.

## Documentation

- [x] Updated `docs-site/docs/configuration.md` and `docs-site/docs/troubleshooting.md`: one-line note that the official deb and rpm packages install fido2-tools automatically
- [x] Updated `app/webauthn/README.md` prerequisites with the same note
- [x] No new PII added to logs (no logging changes)

## Notes for reviewers

Recommends rather than Depends on purpose: the app runs fine without fido2-tools, so a hard dependency would be wrong packaging-wise. Weak deps on rpm need rpm 4.12+, which every current Fedora/RHEL has, and a weak dep on a package name a distro does not ship (openSUSE calls it libfido2-utils) is silently ignored rather than an error.

This removes one of the two hurdles for #2714-style setups. `auth.webauthn.enabled` still defaults to false; changing that default is a separate discussion while the feature is labeled beta.
