### PR TITLE
Add Open config file / Open config folder to Settings menu

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -182,3 +182,4 @@ function argv(configPath, appVersion) {
 }
 
 exports = module.exports = argv;
+exports.getConfigFilePath = getConfigFilePath;

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -111,6 +111,17 @@ function getSettingsMenu(Menus) {
         label: "Restore",
         click: () => Menus.restoreSettings(),
       },
+      {
+        type: "separator",
+      },
+      {
+        label: "Open config file",
+        click: () => Menus.openConfigFile(),
+      },
+      {
+        label: "Open config folder",
+        click: () => Menus.openConfigFolder(),
+      },
     ],
   };
 }

--- a/app/menus/configFileActions.js
+++ b/app/menus/configFileActions.js
@@ -1,0 +1,21 @@
+const fs = require("node:fs");
+const { getConfigFilePath } = require("../config");
+
+// config.json usually doesn't exist yet ("No config file found ... using
+// default values" is the common startup case), and shell.openPath on a
+// missing path just errors silently instead of doing anything useful, so a
+// stub is written first (and the directory created if needed).
+function openConfigFile(shell, configPath) {
+  const configFilePath = getConfigFilePath(configPath);
+  if (!fs.existsSync(configFilePath)) {
+    fs.mkdirSync(configPath, { recursive: true });
+    fs.writeFileSync(configFilePath, "{}\n");
+  }
+  shell.openPath(configFilePath);
+}
+
+function openConfigFolder(shell, configPath) {
+  shell.openPath(configPath);
+}
+
+module.exports = { openConfigFile, openConfigFolder };

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -5,10 +5,12 @@ const {
   clipboard,
   dialog,
   ipcMain,
+  shell,
 } = require("electron");
 const fs = require("node:fs"),
   path = require("node:path");
 const { fileURLToPath } = require("node:url");
+const configFileActions = require("./configFileActions");
 const appMenu = require("./appMenu");
 const buildProfilesMenu = require("./profilesMenu");
 const {
@@ -328,6 +330,17 @@ class Menus {
         type: "warning",
       });
     }
+  }
+
+  // Users have no reliable way to find config.json themselves: the directory
+  // differs per install format (deb/rpm/tar.gz/AppImage vs snap vs flatpak vs
+  // from-source), so guessing it is real friction (#2885).
+  openConfigFile() {
+    configFileActions.openConfigFile(shell, this.configGroup.configPath);
+  }
+
+  openConfigFolder() {
+    configFileActions.openConfigFolder(shell, this.configGroup.configPath);
   }
 
   addProfile() {

--- a/tests/unit/appMenuSettings.test.js
+++ b/tests/unit/appMenuSettings.test.js
@@ -1,0 +1,55 @@
+const { test, describe } = require("node:test");
+const assert = require("node:assert");
+const appMenu = require("../../app/menus/appMenu");
+
+// #2885: config.json's location differs per install format (deb/rpm/tar.gz/
+// AppImage vs snap vs flatpak vs from-source) and is not something a user can
+// reasonably guess, so the Settings menu gets a direct way to reach it.
+
+function fakeMenus(overrides = {}) {
+  return {
+    configGroup: { startupConfig: {} },
+    saveSettings: () => {},
+    restoreSettings: () => {},
+    openConfigFile: () => {},
+    openConfigFolder: () => {},
+    ...overrides,
+  };
+}
+
+function settingsSubmenu(menus) {
+  const menu = appMenu(menus);
+  return menu.submenu.find((i) => i.label === "Settings").submenu;
+}
+
+describe("appMenu Settings submenu", () => {
+  test("adds Open config file and Open config folder after a separator", () => {
+    const submenu = settingsSubmenu(fakeMenus());
+    const labels = submenu.map((i) => i.label || i.type);
+    assert.deepStrictEqual(labels, [
+      "Save",
+      "Restore",
+      "separator",
+      "Open config file",
+      "Open config folder",
+    ]);
+  });
+
+  test("Open config file calls Menus.openConfigFile", () => {
+    let called = false;
+    const submenu = settingsSubmenu(
+      fakeMenus({ openConfigFile: () => (called = true) })
+    );
+    submenu.find((i) => i.label === "Open config file").click();
+    assert.strictEqual(called, true);
+  });
+
+  test("Open config folder calls Menus.openConfigFolder", () => {
+    let called = false;
+    const submenu = settingsSubmenu(
+      fakeMenus({ openConfigFolder: () => (called = true) })
+    );
+    submenu.find((i) => i.label === "Open config folder").click();
+    assert.strictEqual(called, true);
+  });
+});

--- a/tests/unit/configFileActions.test.js
+++ b/tests/unit/configFileActions.test.js
@@ -1,0 +1,82 @@
+const { test, describe, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  openConfigFile,
+  openConfigFolder,
+} = require("../../app/menus/configFileActions");
+
+function fakeShell() {
+  const openedPaths = [];
+  return {
+    openedPaths,
+    openPath: (p) => {
+      openedPaths.push(p);
+      return Promise.resolve("");
+    },
+  };
+}
+
+describe("configFileActions", () => {
+  let configPath;
+
+  beforeEach(() => {
+    configPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "teams-for-linux-config-test-")
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(configPath, { recursive: true, force: true });
+  });
+
+  describe("openConfigFile", () => {
+    test("creates a stub config.json when none exists, then opens it", () => {
+      const shell = fakeShell();
+      const configFilePath = path.join(configPath, "config.json");
+
+      openConfigFile(shell, configPath);
+
+      assert.strictEqual(fs.existsSync(configFilePath), true);
+      assert.strictEqual(fs.readFileSync(configFilePath, "utf8"), "{}\n");
+      assert.deepStrictEqual(shell.openedPaths, [configFilePath]);
+    });
+
+    test("does not overwrite an existing config.json", () => {
+      const shell = fakeShell();
+      const configFilePath = path.join(configPath, "config.json");
+      fs.writeFileSync(configFilePath, '{"url":"https://example.com"}');
+
+      openConfigFile(shell, configPath);
+
+      assert.strictEqual(
+        fs.readFileSync(configFilePath, "utf8"),
+        '{"url":"https://example.com"}'
+      );
+      assert.deepStrictEqual(shell.openedPaths, [configFilePath]);
+    });
+
+    test("creates the config directory when it doesn't exist yet", () => {
+      const shell = fakeShell();
+      const nestedConfigPath = path.join(configPath, "nested", "dir");
+      const configFilePath = path.join(nestedConfigPath, "config.json");
+
+      openConfigFile(shell, nestedConfigPath);
+
+      assert.strictEqual(fs.existsSync(configFilePath), true);
+      assert.deepStrictEqual(shell.openedPaths, [configFilePath]);
+    });
+  });
+
+  describe("openConfigFolder", () => {
+    test("opens the config directory itself", () => {
+      const shell = fakeShell();
+
+      openConfigFolder(shell, configPath);
+
+      assert.deepStrictEqual(shell.openedPaths, [configPath]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2885.

- Add **Open config file** and **Open config folder** entries to the Settings menu.
- Backed by a new `configFileActions.js` module (`openConfigFile`, `openConfigFolder`), kept separate from `Menus` so it's unit-testable without mocking Electron.
- `Open config file` writes a `{}` stub (and creates the config directory) when `config.json` doesn't exist yet, then opens it; `Open config folder` opens the containing directory directly.
- Added unit tests for the new module and for the Settings submenu structure.