### PR TITLE
feat(menu): add Open config file and Open config folder to Settings

### DIFF
--- a/app/appConfiguration/index.js
+++ b/app/appConfiguration/index.js
@@ -44,6 +44,16 @@ class AppConfiguration {
     return _AppConfiguration_configPath.get(this);
   }
 
+  /**
+   * Absolute path to config.json inside {@link configPath}. Derived from the
+   * config module rather than re-joining the name here, so the menu that opens
+   * the file cannot drift from the loader that reads it.
+   * @returns {string}
+   */
+  get configFilePath() {
+    return require("../config").getConfigFilePath(this.configPath);
+  }
+
   get startupConfig() {
     return _AppConfiguration_startupConfig.get(this);
   }

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -182,3 +182,7 @@ function argv(configPath, appVersion) {
 }
 
 exports = module.exports = argv;
+// Exposed so the menu can open the very file this module reads, without
+// a second copy of the "config.json" literal drifting from this one.
+module.exports.getConfigFilePath = getConfigFilePath;
+

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -111,6 +111,20 @@ function getSettingsMenu(Menus) {
         label: "Restore",
         click: () => Menus.restoreSettings(),
       },
+      {
+        type: "separator",
+      },
+      // Most config options are restart-only, so the file is the interface.
+      // Its directory differs per packaging format (deb, snap, flatpak,
+      // source), which is not something anyone should have to look up.
+      {
+        label: "Open config file",
+        click: () => Menus.openConfigFile(),
+      },
+      {
+        label: "Open config folder",
+        click: () => Menus.openConfigFolder(),
+      },
     ],
   };
 }

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -5,6 +5,7 @@ const {
   clipboard,
   dialog,
   ipcMain,
+  shell,
 } = require("electron");
 const fs = require("node:fs"),
   path = require("node:path");
@@ -328,6 +329,52 @@ class Menus {
         type: "warning",
       });
     }
+  }
+
+  // Opens config.json in the user's default editor. The file usually does not
+  // exist — startup logs "No config file found ... using default values" — and
+  // shell.openPath on a missing path just returns an error string, so an empty
+  // stub is written first. That also gives the user something to edit rather
+  // than an empty buffer they have to save into the right place themselves.
+  async openConfigFile() {
+    const configFile = this.configGroup.configFilePath;
+    try {
+      if (!fs.existsSync(configFile)) {
+        fs.mkdirSync(path.dirname(configFile), { recursive: true });
+        fs.writeFileSync(configFile, "{}\n");
+      }
+    } catch (err) {
+      this.#reportOpenFailure("config file", configFile, err.message);
+      return;
+    }
+    await this.#openPath("config file", configFile);
+  }
+
+  async openConfigFolder() {
+    await this.#openPath("config folder", this.configGroup.configPath);
+  }
+
+  // shell.openPath resolves to an empty string on success and to the reason as
+  // a string on failure — it does not reject — so the result has to be checked.
+  async #openPath(what, target) {
+    let reason;
+    try {
+      reason = await shell.openPath(target);
+    } catch (err) {
+      reason = err.message;
+    }
+    if (reason) {
+      this.#reportOpenFailure(what, target, reason);
+    }
+  }
+
+  #reportOpenFailure(what, target, reason) {
+    console.error(`Failed to open ${what} at ${target}: ${reason}`);
+    dialog.showMessageBoxSync(this.window, {
+      message: `Could not open the ${what}.\n\n${target}\n\n${reason}`,
+      title: "Open config",
+      type: "error",
+    });
   }
 
   addProfile() {

--- a/tests/unit/openConfigMenu.test.js
+++ b/tests/unit/openConfigMenu.test.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert");
+
+// #2885: config.json was unreachable from inside the app, and its directory
+// differs per packaging format (deb, snap, flatpak, from source) — not
+// somewhere anyone guesses. These pin the two Settings entries that open it.
+//
+// The menu builder is a pure function of a Menus-shaped object, so the
+// structure and the wiring are testable without a real Electron runtime;
+// appMenu only destructures `shell` at module scope, so the stub below is
+// enough (same approach as cacheManager.test.js).
+
+const electronPath = require.resolve("electron");
+const appMenuPath = require.resolve("../../app/menus/appMenu");
+
+let appMenu;
+
+before(() => {
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: { shell: { openExternal: () => {} } },
+  };
+  delete require.cache[appMenuPath];
+  appMenu = require("../../app/menus/appMenu");
+});
+
+after(() => {
+  delete require.cache[electronPath];
+  delete require.cache[appMenuPath];
+});
+
+// Any method the menu calls is recorded rather than stubbed one by one, so
+// this does not need updating when an unrelated entry is added.
+function fakeMenus(calls) {
+  return new Proxy(
+    { configGroup: { startupConfig: {} } },
+    {
+      get(target, prop) {
+        if (prop in target) return target[prop];
+        return () => calls.push(prop);
+      },
+    },
+  );
+}
+
+function settingsSubmenu(calls) {
+  const menu = appMenu(fakeMenus(calls));
+  const settings = menu.submenu.find((item) => item.label === "Settings");
+  assert.ok(settings, "Settings menu went missing");
+  return settings.submenu;
+}
+
+describe("Settings menu config entries", () => {
+  it("offers both Open config file and Open config folder", () => {
+    const labels = settingsSubmenu([])
+      .filter((item) => item.label)
+      .map((item) => item.label);
+
+    assert.deepStrictEqual(labels, [
+      "Save",
+      "Restore",
+      "Open config file",
+      "Open config folder",
+    ]);
+  });
+
+  it("wires Open config file to openConfigFile", () => {
+    const calls = [];
+    settingsSubmenu(calls)
+      .find((i) => i.label === "Open config file")
+      .click();
+
+    assert.deepStrictEqual(calls, ["openConfigFile"]);
+  });
+
+  it("wires Open config folder to openConfigFolder", () => {
+    const calls = [];
+    settingsSubmenu(calls)
+      .find((i) => i.label === "Open config folder")
+      .click();
+
+    assert.deepStrictEqual(calls, ["openConfigFolder"]);
+  });
+
+  it("separates the new entries from Save and Restore", () => {
+    const submenu = settingsSubmenu([]);
+    const separator = submenu.findIndex((i) => i.type === "separator");
+    const openFile = submenu.findIndex((i) => i.label === "Open config file");
+
+    assert.ok(separator > 0, "expected a separator before the config entries");
+    assert.ok(separator < openFile);
+  });
+});


### PR DESCRIPTION
Closes #2885.

## What

Two entries under **Settings**, after a separator so Save/Restore stay grouped:

```
Settings
  Save
  Restore
  ──────────────
  Open config file
  Open config folder
```

`config.json` had no route from inside the app, and its directory differs per packaging format — the flatpak and snap paths especially are not somewhere anyone guesses. With 68 of the 74 options restart-only, that file *is* the interface.

## The decisions in the issue

**The stub file.** `config.json` usually does not exist (startup logs `No config file found (user or system-wide), using default values`), and `shell.openPath` on a missing path just returns an error string. So *Open config file* writes `{}` first, creating the directory if needed, then opens it. The user gets something to edit rather than an editor complaining or an empty buffer they have to save into the right place themselves.

**Error handling.** `shell.openPath` resolves to a reason string on failure — it does not reject — so a bare `await` would swallow every failure. Both handlers check the result and show a dialog naming the path and the reason, and log it.

**Where the path comes from.** The issue suggested `getConfigFilePath(configPath)` in the menu. I routed it through a new `AppConfiguration.configFilePath` getter instead, for two reasons: it keeps one definition of the `"config.json"` literal (the menu that opens the file cannot drift from the loader that reads it), and it avoids adding `require("../config")` to `app/menus/index.js`, which does not otherwise depend on the config module — that import pulls yargs and an `ipcMain` registration into the menu module graph for the sake of one `path.join`. `getConfigFilePath` is now exported from `app/config` so the getter can use it.

`app/menus/index.js` gains `shell` in its existing `electron` destructure, as the issue described.

## Tests

New `tests/unit/openConfigMenu.test.js` — 4 tests. The menu builder is a pure function of a Menus-shaped object, so the structure and wiring are testable without a real Electron runtime; the electron stub follows the `require.cache` pattern already used in `cacheManager.test.js`. The fake Menus is a Proxy recording every method the menu calls, so it needs no update when an unrelated entry is added.

- both entries exist, in order, after Save and Restore;
- each `click` calls its handler;
- a separator sits between Restore and the new entries.

```
node --test tests/unit/        # 471 tests, 468 pass
npx eslint <changed files>     # clean
```

The 3 failures are pre-existing on `main` (`electron-store` / `yargs` are ESM-only and the suite is run under Node 20 here); same 3 before and after.

## What I could not verify

The issue asks whether `shell.openPath` actually escapes the sandbox on **Flatpak and Snap**. I could not test that — I have neither runtime available — so it is unverified. On Flatpak it goes through the portal and the app owns `~/.var/app/...`, so it should be fine, but that is reasoning rather than a measurement. If it turns out the portal refuses, the failure is at least visible now rather than silent: the dialog names the path and the reason. Worth a check on both before release.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59255001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not safe to merge until configuration files are created with restrictive permissions and the explicit repository privacy rule is satisfied by removing per-user paths from production logs.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapp%2Fmenus%2Findex.js%3A486%0AIf%20the%20process%20has%20a%20normal%20permissive%20umask%2C%20this%20creates%20%60config.json%60%20as%20a%20file%20such%20as%20%600644%60.%20The%20file%20can%20later%20contain%20supported%20secrets%2C%20including%20MQTT%20and%20client-certificate%20passwords%2C%20so%20other%20local%20users%20may%20be%20able%20to%20read%20those%20credentials.%20Create%20it%20with%20an%20explicit%20owner-only%20mode%2C%20consistent%20with%20the%20existing%20migration%20writer.%0A%0A**How%20this%20was%20verified%3A**%20The%20new%20writer%20relies%20on%20the%20ambient%20umask%20for%20a%20file%20that%20can%20contain%20declared%20credential%20fields%2C%20while%20the%20existing%20configuration%20writer%20explicitly%20enforces%20restrictive%20permissions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20fs.writeFileSync%28configFile%2C%20%22%7B%7D%5Cn%22%2C%20%7B%20mode%3A%200o600%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Aapp%2Fmenus%2Findex.js%3A514%0AThis%20writes%20the%20absolute%20per-user%20configuration%20path%20and%20raw%20failure%20reason%20to%20production%20logs.%20On%20standard%20home-directory%20layouts%2C%20that%20path%20contains%20the%20operating-system%20username.%20This%20violates%20the%20repository%20directive%20that%20production%20logs%20must%20not%20contain%20usernames%20or%20other%20PII%2C%20so%20it%20must%20be%20fixed%20before%20merging%20by%20using%20a%20path-free%20error%20message.%0A%0A**How%20this%20was%20verified%3A**%20The%20logged%20target%20is%20the%20absolute%20per-user%20configuration%20path%2C%20which%20exposes%20the%20operating-system%20username%20on%20standard%20home-directory%20layouts.%0A%0A%60%60%60suggestion%0A%20%20%20%20console.error%28%60Failed%20to%20open%20%24%7Bwhat%7D%60%2C%20%7B%20failed%3A%20true%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0Atests%2Funit%2FopenConfigMenu.test.js%3A57%0AThese%20tests%20cover%20only%20menu%20labels%20and%20click%20delegation.%20They%20do%20not%20exercise%20the%20substantive%20new%20behavior%20in%20%60openConfigFile%60%2C%20%60openConfigFolder%60%2C%20or%20the%20error-reporting%20path%2C%20so%20regressions%20in%20file%20creation%2C%20permissions%2C%20directory%20creation%2C%20%60shell.openPath%60%20failures%2C%20and%20dialogs%20can%20pass%20the%20suite.%20Add%20focused%20tests%20with%20stubbed%20filesystem%2C%20shell%2C%20and%20dialog%20behavior.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ismaelmartinez%2Fteams-for-linux&pr=2893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Config file permissions exposed** <a href="https://github.com/IsmaelMartinez/teams-for-linux/pull/2893#discussion_r4054324706">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Logs expose user paths** <a href="https://github.com/IsmaelMartinez/teams-for-linux/pull/2893#discussion_r4054324713">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Handlers remain untested** <a href="https://github.com/IsmaelMartinez/teams-for-linux/pull/2893#discussion_r4054324715">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
app/menus/index.js:486
If the process has a normal permissive umask, this creates `config.json` as a file such as `0644`. The file can later contain supported secrets, including MQTT and client-certificate passwords, so other local users may be able to read those credentials. Create it with an explicit owner-only mode, consistent with the existing migration writer.

**How this was verified:** The new writer relies on the ambient umask for a file that can contain declared credential fields, while the existing configuration writer explicitly enforces restrictive permissions.

```suggestion
        fs.writeFileSync(configFile, "{}\n", { mode: 0o600 });
```

### Issue 2
app/menus/index.js:514
This writes the absolute per-user configuration path and raw failure reason to production logs. On standard home-directory layouts, that path contains the operating-system username. This violates the repository directive that production logs must not contain usernames or other PII, so it must be fixed before merging by using a path-free error message.

**How this was verified:** The logged target is the absolute per-user configuration path, which exposes the operating-system username on standard home-directory layouts.

```suggestion
    console.error(`Failed to open ${what}`, { failed: true });
```

### Issue 3
tests/unit/openConfigMenu.test.js:57
These tests cover only menu labels and click delegation. They do not exercise the substantive new behavior in `openConfigFile`, `openConfigFolder`, or the error-reporting path, so regressions in file creation, permissions, directory creation, `shell.openPath` failures, and dialogs can pass the suite. Add focused tests with stubbed filesystem, shell, and dialog behavior.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

This PR adds native Settings actions for opening the active user configuration file and its containing directory, exposes the loader’s canonical config-file path through `AppConfiguration`, and creates an empty configuration file when needed.

- Adds “Open config file” and “Open config folder” to the shared application/tray menu.
- Handles both resolved and rejected `shell.openPath` failures with user-visible dialogs.
- Adds unit coverage for menu ordering and click delegation.
- The file-creation path needs restrictive permissions, and production error logs should not expose the absolute per-user path.

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Settings menu] --> B{Selected action}
  B -->|Open config file| C[Resolve canonical config.json path]
  C --> D{File exists?}
  D -->|No| E[Create directory and stub file]
  D -->|Yes| F[Open file through Electron shell]
  E --> F
  B -->|Open config folder| G[Open configuration directory]
  F --> H{Open succeeded?}
  G --> H
  H -->|No| I[Log failure and show error dialog]
  H -->|Yes| J[Default editor or file manager]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["Merge main into feat/2885-open-config-me..."](https://github.com/ismaelmartinez/teams-for-linux/commit/826b3d99e804a8508ca9bb8d7534e63e4089905e)</sub>

<!-- /greptile_comment -->