### PR TITLE
feat(menus): add a menu option to choose a custom app icon

### DIFF
--- a/app/browser/tools/trayIconChooser.js
+++ b/app/browser/tools/trayIconChooser.js
@@ -17,7 +17,7 @@ class TrayIconChooser {
     this.config = config;
   }
   getFile() {
-    if (this.config.appIcon.trim() !== "") {
+    if (this.config.appIcon?.trim()) {
       return this.config.appIcon;
     }
     return path.join(

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -18,10 +18,15 @@ class TrayIconRenderer {
       "unread-count",
       this.updateActivityCount.bind(this),
     );
+    // Read the new path from the delta, not from this.config: preload's own
+    // config-changed listener registers after this one, so this.config still
+    // holds the previous value when we run.
     ipcRenderer.on('config-changed', (_event, changes) => {
-      if ('appIcon' in changes) {
-        this.baseIcon = nativeImage.createFromPath(new TrayIconChooser(this.config).getFile());
+      if ('appIcon' in changes && changes.appIcon !== this.config.appIcon) {
+        const chooser = new TrayIconChooser({ ...this.config, appIcon: changes.appIcon });
+        this.baseIcon = nativeImage.createFromPath(chooser.getFile());
         this.iconSize = this.baseIcon.getSize();
+        this.#baseIconDataUrl = null;
         this.#lastRequestedCount = undefined;
       }
     });

--- a/app/browser/tools/trayIconRenderer.js
+++ b/app/browser/tools/trayIconRenderer.js
@@ -18,6 +18,13 @@ class TrayIconRenderer {
       "unread-count",
       this.updateActivityCount.bind(this),
     );
+    ipcRenderer.on('config-changed', (_event, changes) => {
+      if ('appIcon' in changes) {
+        this.baseIcon = nativeImage.createFromPath(new TrayIconChooser(this.config).getFile());
+        this.iconSize = this.baseIcon.getSize();
+        this.#lastRequestedCount = undefined;
+      }
+    });
   }
 
   async updateActivityCount(event) {

--- a/app/config/options.js
+++ b/app/config/options.js
@@ -68,7 +68,7 @@ module.exports = {
         default: "",
         describe: "Custom app icon (PNG) used for the tray, window, and dock",
         type: "string",
-        applyMode: "restart",
+        applyMode: "live",
       },
       appIconType: {
         default: "default",

--- a/app/config/options.js
+++ b/app/config/options.js
@@ -66,7 +66,7 @@ module.exports = {
       },
       appIcon: {
         default: "",
-        describe: "Teams app icon to show in the tray",
+        describe: "Custom app icon (PNG) used for the tray, window, and dock",
         type: "string",
         applyMode: "restart",
       },

--- a/app/config/options.js
+++ b/app/config/options.js
@@ -66,7 +66,8 @@ module.exports = {
       },
       appIcon: {
         default: "",
-        describe: "Custom app icon (PNG) used for the tray, window, and dock",
+        describe:
+          "Custom app icon (PNG) for the tray, the window icon on Windows and Linux, and the dock on macOS. Also settable from the App Icon menu",
         type: "string",
         applyMode: "live",
       },

--- a/app/index.js
+++ b/app/index.js
@@ -590,7 +590,8 @@ function loadMenuToggleSettings() {
     'disableNotificationSoundIfNotAvailable',
     'disableNotificationWindowFlash',
     'disableBadgeCount',
-    'defaultNotificationUrgency'
+    'defaultNotificationUrgency',
+    'appIcon'
   ];
 
   for (const setting of menuToggleSettings) {

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -63,6 +63,9 @@ exports = module.exports = (Menus) => ({
       type: "separator",
     },
     getSettingsMenu(Menus),
+    ...(Menus.configGroup.startupConfig.trayIconEnabled
+      ? [getAppIconMenu(Menus)]
+      : []),
     getPreferencesMenu(),
     getNotificationsMenu(Menus),
     ...(Menus.configGroup.startupConfig.multiAccount?.enabled
@@ -110,6 +113,24 @@ function getSettingsMenu(Menus) {
       {
         label: "Restore",
         click: () => Menus.restoreSettings(),
+      },
+    ],
+  };
+}
+
+function getAppIconMenu(Menus) {
+  const hasCustomIcon = !!Menus.configGroup.startupConfig.appIcon;
+  return {
+    label: "App Icon",
+    submenu: [
+      {
+        label: "Choose App Icon...",
+        click: () => Menus.chooseAppIcon(),
+      },
+      {
+        label: "Reset to default",
+        enabled: hasCustomIcon,
+        click: () => Menus.resetAppIcon(),
       },
     ],
   };

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -63,9 +63,7 @@ exports = module.exports = (Menus) => ({
       type: "separator",
     },
     getSettingsMenu(Menus),
-    ...(Menus.configGroup.startupConfig.trayIconEnabled
-      ? [getAppIconMenu(Menus)]
-      : []),
+    getAppIconMenu(Menus),
     getPreferencesMenu(),
     getNotificationsMenu(Menus),
     ...(Menus.configGroup.startupConfig.multiAccount?.enabled

--- a/app/menus/appMenu.js
+++ b/app/menus/appMenu.js
@@ -117,12 +117,12 @@ function getSettingsMenu(Menus) {
 }
 
 function getAppIconMenu(Menus) {
-  const hasCustomIcon = !!Menus.configGroup.startupConfig.appIcon;
+  const hasCustomIcon = !!Menus.configGroup.startupConfig.appIcon?.trim();
   return {
     label: "App Icon",
     submenu: [
       {
-        label: "Choose App Icon...",
+        label: "Choose App Icon…",
         click: () => Menus.chooseAppIcon(),
       },
       {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -17,6 +17,7 @@ const {
   clearStorageForPartitions,
 } = require("../utils/storagePartitions");
 const Tray = require("./tray");
+const TrayIconChooser = require("../browser/tools/trayIconChooser");
 const { SpellCheckProvider } = require("../spellCheckProvider");
 const DocumentationWindow = require("../documentationWindow");
 const GpuInfoWindow = require("../gpuInfoWindow");
@@ -306,14 +307,14 @@ class Menus {
 
   chooseAppIcon() {
     const result = dialog.showOpenDialogSync(this.window, {
-      title: 'Choose App Icon',
-      filters: [{ name: 'Images', extensions: ['png'] }],
-      properties: ['openFile'],
+      title: "Choose App Icon",
+      filters: [{ name: "Images", extensions: ["png"] }],
+      properties: ["openFile"],
     });
     if (result && result.length > 0) {
       const selectedPath = result[0];
       this.configGroup.startupConfig.appIcon = selectedPath;
-      this.configGroup.legacyConfigStore.set('appIcon', selectedPath);
+      this.configGroup.legacyConfigStore.set("appIcon", selectedPath);
       this.tray?.setBaseIconPath(selectedPath);
       this.#updateWindowIcon(selectedPath);
       this.updateMenu();
@@ -321,9 +322,8 @@ class Menus {
   }
 
   resetAppIcon() {
-    this.configGroup.startupConfig.appIcon = '';
-    this.configGroup.legacyConfigStore.set('appIcon', '');
-    const TrayIconChooser = require('../browser/tools/trayIconChooser');
+    this.configGroup.startupConfig.appIcon = "";
+    this.configGroup.legacyConfigStore.set("appIcon", "");
     const iconChooser = new TrayIconChooser(this.configGroup.startupConfig);
     const iconPath = iconChooser.getFile();
     this.tray?.setBaseIconPath(iconPath);
@@ -332,9 +332,20 @@ class Menus {
   }
 
   #updateWindowIcon(iconPath) {
-    const icon = nativeImage.createFromPath(iconPath);
-    this.window.setIcon(icon);
-    app.dock?.setIcon(icon);
+    this.window.setIcon(nativeImage.createFromPath(iconPath));
+    if (!app.dock) return;
+    // The tray asset is 16px on macOS but the dock needs >=128px, so the
+    // default is resolved separately here, exactly as startup does it.
+    const custom = this.configGroup.startupConfig.appIcon?.trim();
+    const dockIconPath = custom
+      ? custom
+      : path.join(this.configGroup.startupConfig.appPath, "assets/icons/icon-256x256.png");
+    const dockIcon = nativeImage.createFromPath(dockIconPath);
+    app.dock.setIcon(
+      dockIcon.getSize().width < 128
+        ? dockIcon.resize({ width: 128, height: 128 })
+        : dockIcon,
+    );
   }
 
   saveSettings() {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -412,6 +412,7 @@ class Menus {
       disableNotificationWindowFlash: this.configGroup.startupConfig.disableNotificationWindowFlash,
       disableBadgeCount: this.configGroup.startupConfig.disableBadgeCount,
       defaultNotificationUrgency: this.configGroup.startupConfig.defaultNotificationUrgency,
+      appIcon: this.configGroup.startupConfig.appIcon,
     });
   }
 

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -316,6 +316,7 @@ class Menus {
       this.configGroup.legacyConfigStore.set('appIcon', selectedPath);
       this.tray?.setBaseIconPath(selectedPath);
       this.#updateWindowIcon(selectedPath);
+      this.updateMenu();
     }
   }
 
@@ -327,6 +328,7 @@ class Menus {
     const iconPath = iconChooser.getFile();
     this.tray?.setBaseIconPath(iconPath);
     this.#updateWindowIcon(iconPath);
+    this.updateMenu();
   }
 
   #updateWindowIcon(iconPath) {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -313,6 +313,15 @@ class Menus {
     });
     if (result && result.length > 0) {
       const selectedPath = result[0];
+      if (nativeImage.createFromPath(selectedPath).isEmpty()) {
+        dialog.showMessageBoxSync(this.window, {
+          type: "error",
+          title: "Choose App Icon",
+          message: "That file could not be read as an image.",
+          detail: selectedPath,
+        });
+        return;
+      }
       this.configGroup.startupConfig.appIcon = selectedPath;
       this.configGroup.legacyConfigStore.set("appIcon", selectedPath);
       this.tray?.setBaseIconPath(selectedPath);

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -4,6 +4,7 @@ const {
   MenuItem,
   clipboard,
   dialog,
+  nativeImage,
   ipcMain,
 } = require("electron");
 const fs = require("node:fs"),
@@ -301,6 +302,37 @@ class Menus {
       this.tray?.close();
       this.window.webContents.session.flushStorageData();
     }
+  }
+
+  chooseAppIcon() {
+    const result = dialog.showOpenDialogSync(this.window, {
+      title: 'Choose App Icon',
+      filters: [{ name: 'Images', extensions: ['png'] }],
+      properties: ['openFile'],
+    });
+    if (result && result.length > 0) {
+      const selectedPath = result[0];
+      this.configGroup.startupConfig.appIcon = selectedPath;
+      this.configGroup.legacyConfigStore.set('appIcon', selectedPath);
+      this.tray?.setBaseIconPath(selectedPath);
+      this.#updateWindowIcon(selectedPath);
+    }
+  }
+
+  resetAppIcon() {
+    this.configGroup.startupConfig.appIcon = '';
+    this.configGroup.legacyConfigStore.set('appIcon', '');
+    const TrayIconChooser = require('../browser/tools/trayIconChooser');
+    const iconChooser = new TrayIconChooser(this.configGroup.startupConfig);
+    const iconPath = iconChooser.getFile();
+    this.tray?.setBaseIconPath(iconPath);
+    this.#updateWindowIcon(iconPath);
+  }
+
+  #updateWindowIcon(iconPath) {
+    const icon = nativeImage.createFromPath(iconPath);
+    this.window.setIcon(icon);
+    app.dock?.setIcon(icon);
   }
 
   saveSettings() {

--- a/app/menus/tray.js
+++ b/app/menus/tray.js
@@ -71,6 +71,13 @@ class ApplicationTray {
     }
   }
 
+  setBaseIconPath(iconPath) {
+    this.iconPath = iconPath;
+    if (this.tray && !this.tray.isDestroyed()) {
+      this.tray.setImage(this.getIconImage(iconPath));
+    }
+  }
+
   close() {
     if (!this.tray.isDestroyed()) {
       this.tray.destroy();

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -12,7 +12,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 |--------|------|---------|-------------|-------|
 | `appActiveCheckInterval` | `number` | `2` | A numeric value in seconds as poll interval to check if the system is active from being idle | `restart` |
 | `screenSharing` | `object` | `{"thumbnail":{"enabled":true,"alwaysOnTop":true},"lockInhibitionMethod":"Electron"}` | Screen sharing configuration. thumbnail: controls the preview window shown during active sharing. lockInhibitionMethod: screen lock inhibition method (Electron/WakeLockSentinel). | `restart` |
-| `appIcon` | `string` | `""` | Custom app icon (PNG) used for the tray, window, and dock | `live` |
+| `appIcon` | `string` | `""` | Custom app icon (PNG) for the tray, the window icon on Windows and Linux, and the dock on macOS. Also settable from the App Icon menu | `live` |
 | `appIconType` | `string` | `"default"` | Type of tray icon to be used | `restart` |
 | `appIdleTimeout` | `number` | `300` | A numeric value in seconds as duration before app considers the system as idle | `restart` |
 | `appIdleTimeoutCheckInterval` | `number` | `10` | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | `restart` |

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -12,7 +12,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 |--------|------|---------|-------------|-------|
 | `appActiveCheckInterval` | `number` | `2` | A numeric value in seconds as poll interval to check if the system is active from being idle | `restart` |
 | `screenSharing` | `object` | `{"thumbnail":{"enabled":true,"alwaysOnTop":true},"lockInhibitionMethod":"Electron"}` | Screen sharing configuration. thumbnail: controls the preview window shown during active sharing. lockInhibitionMethod: screen lock inhibition method (Electron/WakeLockSentinel). | `restart` |
-| `appIcon` | `string` | `""` | Teams app icon to show in the tray | `restart` |
+| `appIcon` | `string` | `""` | Custom app icon (PNG) used for the tray, window, and dock | `restart` |
 | `appIconType` | `string` | `"default"` | Type of tray icon to be used | `restart` |
 | `appIdleTimeout` | `number` | `300` | A numeric value in seconds as duration before app considers the system as idle | `restart` |
 | `appIdleTimeoutCheckInterval` | `number` | `10` | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | `restart` |

--- a/docs-site/docs/configuration-generated.md
+++ b/docs-site/docs/configuration-generated.md
@@ -12,7 +12,7 @@ For configuration examples, file locations, and platform-specific notes, see the
 |--------|------|---------|-------------|-------|
 | `appActiveCheckInterval` | `number` | `2` | A numeric value in seconds as poll interval to check if the system is active from being idle | `restart` |
 | `screenSharing` | `object` | `{"thumbnail":{"enabled":true,"alwaysOnTop":true},"lockInhibitionMethod":"Electron"}` | Screen sharing configuration. thumbnail: controls the preview window shown during active sharing. lockInhibitionMethod: screen lock inhibition method (Electron/WakeLockSentinel). | `restart` |
-| `appIcon` | `string` | `""` | Custom app icon (PNG) used for the tray, window, and dock | `restart` |
+| `appIcon` | `string` | `""` | Custom app icon (PNG) used for the tray, window, and dock | `live` |
 | `appIconType` | `string` | `"default"` | Type of tray icon to be used | `restart` |
 | `appIdleTimeout` | `number` | `300` | A numeric value in seconds as duration before app considers the system as idle | `restart` |
 | `appIdleTimeoutCheckInterval` | `number` | `10` | A numeric value in seconds as poll interval to check if the appIdleTimeout is reached | `restart` |

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -122,7 +122,7 @@ Each option's **Apply** mode (whether a change takes effect immediately or after
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `trayIconEnabled` | `boolean` | `true` | Enable tray icon |
-| `appIcon` | `string` | `""` | Teams app icon to show in the tray |
+| `appIcon` | `string` | `""` | Custom app icon (PNG) for the tray, the window icon on Windows and Linux, and the dock on macOS. Also settable from the App Icon menu |
 | `appIconType` | `string` | `"default"` | Type of tray icon. Choices: `default`, `light`, `dark` |
 | `useMutationTitleLogic` | `boolean` | `true` | Use MutationObserver to update counter from title |
 | `disableBadgeCount` | `boolean` | `false` | Disable the badge counter on the taskbar/dock icon |

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -51,7 +51,7 @@
       "name": "appIcon",
       "type": "string",
       "default": "",
-      "description": "Custom app icon (PNG) used for the tray, window, and dock",
+      "description": "Custom app icon (PNG) for the tray, the window icon on Windows and Linux, and the dock on macOS. Also settable from the App Icon menu",
       "applyMode": "live"
     },
     {

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -52,7 +52,7 @@
       "type": "string",
       "default": "",
       "description": "Custom app icon (PNG) used for the tray, window, and dock",
-      "applyMode": "restart"
+      "applyMode": "live"
     },
     {
       "name": "appIconType",

--- a/docs-site/static/config-schema.json
+++ b/docs-site/static/config-schema.json
@@ -51,7 +51,7 @@
       "name": "appIcon",
       "type": "string",
       "default": "",
-      "description": "Teams app icon to show in the tray",
+      "description": "Custom app icon (PNG) used for the tray, window, and dock",
       "applyMode": "restart"
     },
     {

--- a/tests/unit/trayIconChooser.test.js
+++ b/tests/unit/trayIconChooser.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const TrayIconChooser = require('../../app/browser/tools/trayIconChooser');
+
+const defaultsTo = (config) =>
+  path.basename(new TrayIconChooser(config).getFile());
+
+describe('trayIconChooser appIcon resolution', () => {
+  it('returns the custom icon when one is set', () => {
+    const chooser = new TrayIconChooser({
+      appIcon: '/custom/icon.png',
+      appIconType: 'default',
+    });
+    assert.strictEqual(chooser.getFile(), '/custom/icon.png');
+  });
+
+  it('falls back to the bundled icon for empty and whitespace paths', () => {
+    for (const appIcon of ['', '   ']) {
+      assert.match(defaultsTo({ appIcon, appIconType: 'default' }), /^icon-/);
+    }
+  });
+
+  // A config.json with an explicit "appIcon": null bypasses the yargs default,
+  // which used to throw on .trim() and take the whole app down at startup.
+  it('falls back instead of throwing when appIcon is null or undefined', () => {
+    for (const appIcon of [null, undefined]) {
+      assert.match(defaultsTo({ appIcon, appIconType: 'default' }), /^icon-/);
+    }
+  });
+});

--- a/tests/unit/trayIconRenderer.test.js
+++ b/tests/unit/trayIconRenderer.test.js
@@ -45,3 +45,90 @@ describe('trayIconRenderer base icon cache', () => {
     assert.strictEqual(toDataURLCalls, 1);
   });
 });
+
+describe('trayIconRenderer appIcon config changes', () => {
+  let createdPaths;
+  let handler;
+  let dataUrlCalls;
+
+  const fakeIcon = () => ({
+    getSize: () => ({ width: 96, height: 96 }),
+    toDataURL: () => {
+      dataUrlCalls += 1;
+      return 'data:image/png;base64,TEST';
+    },
+  });
+
+  beforeEach(() => {
+    createdPaths = [];
+    handler = null;
+    dataUrlCalls = 0;
+    require.cache[electronPath] = {
+      id: electronPath,
+      filename: electronPath,
+      loaded: true,
+      exports: {
+        nativeImage: {
+          createFromPath: (p) => {
+            createdPaths.push(p);
+            return fakeIcon();
+          },
+        },
+      },
+    };
+    delete require.cache[rendererPath];
+    globalThis.addEventListener = () => {};
+  });
+
+  afterEach(() => {
+    delete require.cache[electronPath];
+    delete require.cache[rendererPath];
+    delete globalThis.addEventListener;
+  });
+
+  const initRenderer = () => {
+    const renderer = require(rendererPath);
+    renderer.init(
+      { appIcon: '/old/icon.png', appIconType: 'default' },
+      { on: (channel, cb) => { if (channel === 'config-changed') handler = cb; } },
+    );
+    return renderer;
+  };
+
+  it('rebuilds the base icon from the incoming path, not the stale config', () => {
+    initRenderer();
+    createdPaths.length = 0;
+
+    handler(null, { appIcon: '/new/icon.png' });
+
+    assert.deepStrictEqual(createdPaths, ['/new/icon.png']);
+  });
+
+  it('ignores a config-changed payload that does not move appIcon', () => {
+    initRenderer();
+    createdPaths.length = 0;
+
+    handler(null, { appIcon: '/old/icon.png', someOtherToggle: true });
+
+    assert.deepStrictEqual(createdPaths, []);
+  });
+
+  it('drops the cached data URL so the badge renders on the new icon', () => {
+    globalThis.document = { createElement: () => ({}) };
+    globalThis.Image = class {};
+    try {
+      const renderer = initRenderer();
+      renderer.render(1);
+      const encodedBeforeChange = dataUrlCalls;
+
+      handler(null, { appIcon: '/new/icon.png' });
+      renderer.render(2);
+
+      assert.strictEqual(encodedBeforeChange, 1);
+      assert.strictEqual(dataUrlCalls, 2);
+    } finally {
+      delete globalThis.document;
+      delete globalThis.Image;
+    }
+  });
+});


### PR DESCRIPTION
Continues @nikolai-nikolajevic's #2711, rebased onto current main with the outstanding review points applied. Their five commits are preserved as authored.

Adds an App Icon menu to pick a custom PNG for the tray, window and dock, with a reset to default, applied without a restart.

On top of their work:

- the `config-changed` handler reads the new path from the delta, since the renderer registers its listener before preload updates the config object
- reset no longer shrinks the macOS dock icon to the 16px tray asset
- an unreadable file is rejected instead of silently blanking the tray, window and dock
- `appIcon` becomes `applyMode: "live"`, with the description corrected per platform and docs regenerated

520 unit tests pass.

Supersedes #2711. Closes #2792.

Co-authored-by: niko <vriic@mail.de>
