### PR TITLE
fix(notifications): show Teams for Linux as the notification title on Linux

### DIFF
--- a/.github/workflows/remove-awaiting-feedback.yml
+++ b/.github/workflows/remove-awaiting-feedback.yml
@@ -1,11 +1,20 @@
-name: Remove awaiting feedback label on comment
+name: Remove awaiting feedback label on reply
 
-# When a non-bot user comments on an issue that has the "awaiting user feedback"
-# label, automatically remove the label so maintainers know the user has responded.
+# When someone other than a maintainer replies on an issue or pull request that
+# carries the "awaiting user feedback" label, remove the label so maintainers
+# know the reporter or contributor has responded.
+#
+# Maintainer activity (OWNER / MEMBER / COLLABORATOR) and bot activity are
+# ignored: a maintainer asking the question must not clear the flag that says
+# the question is still outstanding.
 
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 # Restrict default permissions — each job declares only what it needs
 permissions: {}
@@ -13,21 +22,53 @@ permissions: {}
 jobs:
   remove-label:
     runs-on: ubuntu-latest
+    # `comment` is absent on pull_request_review, `review` on the other two, so
+    # each pair falls through to whichever the event actually supplied.
+    #
+    # Bots are matched on `user.type`, not on a "[bot]" login suffix: the PR
+    # reviewer posts as plain `Copilot` with author_association CONTRIBUTOR, so
+    # a suffix test would let its automated review clear the label.
+    #
+    # issue_comment is by far the highest-volume trigger, and its payload does
+    # carry labels, so gate it here and spare the runner. The review events have
+    # no documented labels in their payload and are checked in the step instead.
     if: >-
-      !github.event.issue.pull_request
-      && !endsWith(github.event.comment.user.login, '[bot]')
-      && contains(github.event.issue.labels.*.name, 'awaiting user feedback')
+      (github.event.comment.user.type || github.event.review.user.type) != 'Bot'
+      && !contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.comment.author_association || github.event.review.author_association
+      )
+      && (
+        github.event_name != 'issue_comment'
+        || contains(github.event.issue.labels.*.name, 'awaiting user feedback')
+      )
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - name: Remove awaiting user feedback label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const LABEL = 'awaiting user feedback';
+            // issue_comment carries `issue` (for issues and PRs alike); the
+            // pull_request_review* events carry `pull_request` instead. Labels
+            // are read back from the API rather than the payload, because the
+            // pull_request payload object is not documented to include them.
+            const issue_number = (context.payload.issue ?? context.payload.pull_request).number;
+            const { data: target } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+            if (!target.labels.some((label) => label.name === LABEL)) {
+              core.info(`No "${LABEL}" label on #${issue_number}, nothing to do.`);
+              return;
+            }
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'awaiting user feedback',
+              issue_number,
+              name: LABEL,
             });

--- a/app/index.js
+++ b/app/index.js
@@ -35,13 +35,21 @@ const WebAuthn = require("./webauthn");
 const os = require("node:os");
 const isMac = os.platform() === "darwin";
 
-// Tell Chromium which .desktop entry this process belongs to. Without it,
-// notifications go out with no desktop-entry hint and desktop environments
-// fall back to the raw app name, so KDE and GNOME title every notification
-// "teams-for-linux" instead of the desktop entry's Name. Sandboxed installs
-// export the entry under their own id; an externally set CHROME_DESKTOP
-// (the same mechanism, as an env var) is left alone.
-if (process.platform === "linux" && !process.env.CHROME_DESKTOP) {
+// Name notifications "Teams for Linux" instead of the raw app name.
+// Desktop environments read two different fields for the header: KDE shows
+// the notification's app_name (which Electron takes from app.name), GNOME
+// resolves the desktop-entry hint and shows that entry's Name. Cover both.
+// app.name also seeds the default userData path, so pin the path first or
+// existing installs would silently switch config directory.
+if (process.platform === "linux") {
+  const userDataPath = app.getPath("userData");
+  app.setName("Teams for Linux");
+  app.setPath("userData", userDataPath);
+
+  // The desktop-entry hint must be set unconditionally: Electron pre-sets
+  // CHROME_DESKTOP itself before app code runs, so guarding on the env var
+  // being absent would be a no-op. Sandboxed installs export the entry
+  // under their own id.
   if (process.env.FLATPAK_ID) {
     app.setDesktopName(`${process.env.FLATPAK_ID}.desktop`);
   } else if (process.env.SNAP_INSTANCE_NAME) {

--- a/app/index.js
+++ b/app/index.js
@@ -35,6 +35,22 @@ const WebAuthn = require("./webauthn");
 const os = require("node:os");
 const isMac = os.platform() === "darwin";
 
+// Tell Chromium which .desktop entry this process belongs to. Without it,
+// notifications go out with no desktop-entry hint and desktop environments
+// fall back to the raw app name, so KDE and GNOME title every notification
+// "teams-for-linux" instead of the desktop entry's Name. Sandboxed installs
+// export the entry under their own id; an externally set CHROME_DESKTOP
+// (the same mechanism, as an env var) is left alone.
+if (process.platform === "linux" && !process.env.CHROME_DESKTOP) {
+  if (process.env.FLATPAK_ID) {
+    app.setDesktopName(`${process.env.FLATPAK_ID}.desktop`);
+  } else if (process.env.SNAP_INSTANCE_NAME) {
+    app.setDesktopName(`${process.env.SNAP_INSTANCE_NAME}_teams-for-linux.desktop`);
+  } else {
+    app.setDesktopName("teams-for-linux.desktop");
+  }
+}
+
 const { NETWORK_ERROR_PATTERNS } = require("./config/defaults");
 
 function isNetworkError(message) {


### PR DESCRIPTION
## Summary

Desktop notifications on Linux are titled with the raw application name, so KDE Plasma shows "teams-for-linux" as the notification header (and a plain Electron dev build shows "Electron").

Fixing this turned out to need two fields, because desktop environments disagree on where the header comes from. KDE Plasma titles the notification with the D-Bus app_name field, which Electron takes from app.name, and uses the desktop-entry hint only for the icon and the notification settings grouping. GNOME resolves the header from the desktop-entry hint. So the app now sets both at startup on Linux: app.name to "Teams for Linux", and the desktop entry via app.setDesktopName(), resolved from FLATPAK_ID and SNAP_INSTANCE_NAME for sandboxed installs. Since the default userData path derives from app.name, the path is pinned before renaming, so existing installs keep their config directory.

The first commit guarded setDesktopName on CHROME_DESKTOP being unset, intending to leave an externally set value alone. That made the fix a no-op everywhere: Electron pre-sets CHROME_DESKTOP itself before any app code runs, so the guard never passed. Found by capturing the session bus, where notifications still went out with desktop-entry: electron. electron-builder has also been warning about the missing desktopName on every Linux build.

## Testing

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] Verified on KDE Plasma 6 (Fedora Kinoite, Wayland) by capturing the org.freedesktop.Notifications.Notify call: app_name "Teams for Linux", desktop-entry "teams-for-linux", and a real incoming Teams message shows the header "Teams for Linux" with the right icon
- [x] Verified the userData pin: config path unchanged before and after the rename

Not tested: snap and flatpak launches (naming per snapd export convention and flatpak app id), and GNOME (which reads the desktop-entry hint this PR also sets).

## Documentation

- No config options, IPC channels, or documented behaviour changed

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59254983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The behavior appears sound, but the repository’s explicit modularity requirement must be satisfied before merging.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapp%2Findex.js%3A44-59%0AThis%20adds%20the%20Linux%20application-name%2C%20user-data-path%2C%20and%20desktop-entry%20initialization%20directly%20to%20%60app%2Findex.js%60.%20That%20violates%20the%20repository%20directive%20that%20new%20functionality%20must%20be%20placed%20in%20a%20separate%20module%20rather%20than%20the%20main-process%20entry%20point.%20Extract%20this%20initialization%20into%20a%20focused%20startup%20module%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ismaelmartinez%2Fteams-for-linux&pr=2898&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Startup logic bypasses modularity** <a href="https://github.com/IsmaelMartinez/teams-for-linux/pull/2898#discussion_r4054333024">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
app/index.js:44-59
This adds the Linux application-name, user-data-path, and desktop-entry initialization directly to `app/index.js`. That violates the repository directive that new functionality must be placed in a separate module rather than the main-process entry point. Extract this initialization into a focused startup module before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

This PR updates Linux desktop identity initialization so notifications use the human-readable application name while retaining the installed desktop-entry identity and existing user-data directory.

- Sets the Linux application display name and packaging-specific desktop entry during startup.
- Preserves the pre-existing user-data path across the application rename.
- Makes launcher progress use Electron’s recorded desktop entry and adds focused unit coverage.
- The initialization should be extracted from `app/index.js` to comply with the repository’s modularity requirement.

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Linux startup] --> B[Capture existing userData path]
  B --> C[Set app.name to Teams for Linux]
  C --> D[Restore captured userData path]
  D --> E{Packaging environment}
  E -->|FLATPAK_ID| F[Set Flatpak desktop entry]
  E -->|SNAP_INSTANCE_NAME| G[Set Snap desktop entry]
  E -->|Neither| H[Set teams-for-linux.desktop]
  F --> I[Electron records desktop identity]
  G --> I
  H --> I
  I --> J[Launcher emitter uses packaging ID or CHROME_DESKTOP]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(badge): read the desktop entry from ..."](https://github.com/ismaelmartinez/teams-for-linux/commit/7f42327ea9e812b1ad57cf75a9bbc2d4f474d7b9)</sub>

<!-- /greptile_comment -->