### PR TITLE
fix(snap): revert core22 -> core24 migration (#2758)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,14 @@ updates:
           - "patch"
     open-pull-requests-limit: 10
     ignore:
-      # electron-builder is frozen at the known-good 26.8.1 — the last release
-      # that builds on both snap and the windows-2025 runner. 26.15.0+ rewrote
-      # the snap build into pure-TS and broke snap launch (#2684: command.sh
-      # sources a missing desktop-init.sh). 26.14.0's bundled node-gyp cannot
-      # find Visual Studio on windows-2025, breaking the exe build. Ignore ALL
-      # updates — including 26.8.x patches, which would otherwise auto-merge
-      # unreviewed via dependabot-auto-merge.yml — until the snap build migrates
-      # to core24 (#2590).
+      # electron-builder is frozen at the known-good 26.15.7 (#2756) — the
+      # first v26 release that fixes the snap-template extraction bug behind
+      # DOA snaps (#2684, electron-userland/electron-builder#10004) while
+      # still building the exe on windows-2025. Ignore ALL updates —
+      # including patches, which would otherwise auto-merge unreviewed via
+      # dependabot-auto-merge.yml — a Dependabot unpin is how 2.14.0's snap
+      # shipped broken. The core24 migration that would relax this (#2590,
+      # #2758) was reverted in #2905 (snaps core-dump on launch).
       - dependency-name: "electron-builder"
 
   # npm dependencies for docs site

--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -62,17 +62,11 @@ jobs:
 
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
-      SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+      # Note: No LXD - electron-builder handles armv7l cross-compilation directly
 
     steps:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
-
-      - name: Install and initialize LXD
-        # core24 builds run `snapcraft pack --use-lxd` on every arch (no more
-        # direct app-builder template packing). armv7l is a snapcraft
-        # cross-build: platforms build-on amd64 / build-for armhf.
-        uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main
 
       - name: Check out Git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -112,11 +106,15 @@ jobs:
 
     steps:
       - name: Install Snapcraft
-        # The core24 `snapcraft` target builds via `snapcraft pack`, which is
-        # supported on snapcraft 8.x and 9.x alike, so the former 8.x/stable
-        # pin (needed only for the legacy core22 `snapcraft snap` command,
-        # #2590/#2592) is no longer required.
+        # snapcraft 9.0.0 removed the legacy `snap` packing command that
+        # electron-builder's deprecated core22 `snap` target invokes
+        # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
+        # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
+        # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
+        # armv7l jobs pack via app-builder directly and are unaffected.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
+        with:
+          channel: 8.x/stable
 
       - name: Install and initialize LXD
         uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main

--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -111,7 +111,9 @@ jobs:
         # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
         # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
         # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
-        # armv7l jobs pack via app-builder directly and are unaffected.
+        # armv7l jobs pack via app-builder directly and are unaffected. A
+        # first core24 migration (#2758) shipped snaps that core-dump on
+        # launch and was reverted (#2905), restoring this pin.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
         with:
           channel: 8.x/stable

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -83,17 +83,11 @@ jobs:
 
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
-      SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+      # Note: No LXD - electron-builder handles armv7l cross-compilation directly
 
     steps:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
-
-      - name: Install and initialize LXD
-        # core24 builds run `snapcraft pack --use-lxd` on every arch (no more
-        # direct app-builder template packing). armv7l is a snapcraft
-        # cross-build: platforms build-on amd64 / build-for armhf.
-        uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main
 
       - name: Check out Git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -151,11 +145,15 @@ jobs:
 
     steps:
       - name: Install Snapcraft
-        # The core24 `snapcraft` target builds via `snapcraft pack`, which is
-        # supported on snapcraft 8.x and 9.x alike, so the former 8.x/stable
-        # pin (needed only for the legacy core22 `snapcraft snap` command,
-        # #2590/#2592) is no longer required.
+        # snapcraft 9.0.0 removed the legacy `snap` packing command that
+        # electron-builder's deprecated core22 `snap` target invokes
+        # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
+        # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
+        # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
+        # armv7l jobs pack via app-builder directly and are unaffected.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
+        with:
+          channel: 8.x/stable
 
       - name: Install and initialize LXD
         uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -150,7 +150,9 @@ jobs:
         # (`snapcraft snap --output`), so the native-arm64 build fails. Pin
         # below 9.0.0 until the snap build migrates to the core24 `snapcraft`
         # target, which uses `snapcraft pack` (#2590, #2592). The amd64 and
-        # armv7l jobs pack via app-builder directly and are unaffected.
+        # armv7l jobs pack via app-builder directly and are unaffected. A
+        # first core24 migration (#2758) shipped snaps that core-dump on
+        # launch and was reverted (#2905), restoring this pin.
         uses: samuelmeuli/action-snapcraft@d33c176a9b784876d966f80fb1b461808edc0641 # v2.1.1
         with:
           channel: 8.x/stable

--- a/package.json
+++ b/package.json
@@ -145,30 +145,29 @@
         "fido2-tools"
       ]
     },
-    "snapcraft": {
-      "base": "core24",
+    "snap": {
+      "summary": "Teams for Linux",
+      "confinement": "strict",
+      "grade": "stable",
+      "base": "core22",
+      "executableArgs": [
+        "--ozone-platform=x11"
+      ],
+      "plugs": [
+        "default",
+        "audio-record",
+        "camera",
+        "hardware-observe",
+        "network-bind",
+        "network-manager-observe",
+        "removable-media",
+        "screen-inhibit-control",
+        "system-observe",
+        "upower-observe"
+      ],
       "publish": [
         "snapStore"
-      ],
-      "core24": {
-        "summary": "Teams for Linux",
-        "confinement": "strict",
-        "grade": "stable",
-        "useLXD": true,
-        "plugs": [
-          "default",
-          "browser-support",
-          "audio-record",
-          "camera",
-          "hardware-observe",
-          "network-bind",
-          "network-manager-observe",
-          "removable-media",
-          "screen-inhibit-control",
-          "system-observe",
-          "upower-observe"
-        ]
-      }
+      ]
     },
     "mac": {
       "category": "public.app-category.productivity",


### PR DESCRIPTION
Reverts #2758. core24 snaps (2.17.1, 2.18.0) crash on launch with `Trace/breakpoint trap`; this restores the known-good 2.17.0 snap config: core22 base, snap-level ozone x11 args, arm64 snapcraft 8.x pin, no LXD on armv7l. electron-builder stays at 26.15.7 (#2756 was separate). #2590 will need reopening; core24 needs a different approach.

A green snap CI job is not proof the snap launches — verify the built artifact before the release cut.

closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3tgt52EPNQX1qUgmMu537