### PR TITLE
feat(config): add toNestedConfigFile to migrate flat keys to nested

### DIFF
--- a/app/config/renames.js
+++ b/app/config/renames.js
@@ -74,4 +74,58 @@ function applyRenamedOptions(config, configFile, renames = RENAMES) {
   }
 }
 
-module.exports = { RENAMES, applyRenamedOptions };
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Rewrites a config file's flat keys onto their nested targets, the inverse of
+ * applyRenamedOptions. Never mutates the input.
+ *
+ * `coerce` serves both directions: negation is symmetric, and an array-typed
+ * option needs wrapping on the way out for the same reason as on the way in.
+ * Where both spellings are present the nested one is kept, matching runtime
+ * precedence, so the result resolves to the same settings as the original.
+ *
+ * @param {Record<string, unknown>} configFile the merged system and user
+ *   config file contents.
+ * @param {typeof RENAMES} renames override for tests.
+ * @returns {Record<string, unknown>} a new config file object.
+ */
+function toNestedConfigFile(configFile, renames = RENAMES) {
+  if (!isPlainObject(configFile)) return {};
+
+  const result = structuredClone(configFile);
+
+  for (const { flat, nested, inverted, type } of renames) {
+    // Object.hasOwn, matching validator.js, so an inherited key cannot match.
+    if (!Object.hasOwn(result, flat)) continue;
+
+    const parts = nested.split(".");
+    const leaf = parts.pop();
+
+    let node = result;
+    let reachable = true;
+    for (const part of parts) {
+      if (!Object.hasOwn(node, part)) node[part] = {};
+      else if (!isPlainObject(node[part])) {
+        reachable = false;
+        break;
+      }
+      node = node[part];
+    }
+
+    // A namespace occupied by a non-object is the user's to fix; leave the
+    // flat key rather than clobber it.
+    if (!reachable) continue;
+
+    if (!Object.hasOwn(node, leaf)) {
+      node[leaf] = coerce(result[flat], inverted, type);
+    }
+    delete result[flat];
+  }
+
+  return result;
+}
+
+module.exports = { RENAMES, applyRenamedOptions, toNestedConfigFile };

--- a/app/config/renames.js
+++ b/app/config/renames.js
@@ -1,5 +1,6 @@
 // Flat-to-nested option renames from ADR-025, applied during the deprecation
-// window. Pure data module, no Electron imports, mirroring validator.js.
+// window. Pure data module, no Electron imports, mirroring validator.js and
+// borrowing its isPlainObject rather than keeping a fourth copy of it.
 //
 // Both names work while a rename is in its window. The FLAT name stays the one
 // every module reads, so no feature code is swept; a nested value is projected
@@ -17,6 +18,8 @@
 // while `shortcuts.global: "Control+Shift+M"` would arrive as a bare string,
 // which fails the Array.isArray check in app/globalShortcuts/index.js and makes
 // a for..of over disableGlobalShortcuts iterate characters or throw.
+const { isPlainObject } = require("./validator");
+
 /** @type {{flat: string, nested: string, inverted?: boolean, type?: string}[]} */
 const RENAMES = [
   // Batch 1 (2.17.0)
@@ -74,10 +77,6 @@ function applyRenamedOptions(config, configFile, renames = RENAMES) {
   }
 }
 
-function isPlainObject(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
 /**
  * Rewrites a config file's flat keys onto their nested targets, the inverse of
  * applyRenamedOptions. Never mutates the input.
@@ -85,10 +84,18 @@ function isPlainObject(value) {
  * `coerce` serves both directions: negation is symmetric, and an array-typed
  * option needs wrapping on the way out for the same reason as on the way in.
  * Where both spellings are present the nested one is kept, matching runtime
- * precedence, so the result resolves to the same settings as the original.
+ * precedence.
  *
- * @param {Record<string, unknown>} configFile the merged system and user
- *   config file contents.
+ * Values otherwise move verbatim, which is not what yargs does. A flat option
+ * declares a type, so yargs turns `"clearStorageData": "false"` into boolean
+ * `false`; the nested leaf is undeclared and stays the truthy string. Callers
+ * should run the result through validator.js, which reports type mismatches,
+ * rather than assume the two files resolve alike.
+ *
+ * @param {Record<string, unknown>} configFile the USER config file, not the
+ *   system-and-user merge from index.js: migrating that and writing it back as
+ *   the user file would copy /etc values in, turning per-key admin policy into
+ *   a whole-namespace user override.
  * @param {typeof RENAMES} renames override for tests.
  * @returns {Record<string, unknown>} a new config file object.
  */

--- a/app/config/validator.js
+++ b/app/config/validator.js
@@ -139,4 +139,4 @@ function validateConfigFile(configFile, optionDefinitions) {
   return warnings;
 }
 
-module.exports = { validateConfigFile };
+module.exports = { validateConfigFile, isPlainObject };

--- a/docs-site/docs/development/adr/025-config-option-naming-convention.md
+++ b/docs-site/docs/development/adr/025-config-option-naming-convention.md
@@ -28,7 +28,7 @@ Spell words out rather than abbreviating (`customBackground`, not `customBG`), a
 
 The table maps every flat option to its nested target. Four renames invert a boolean, marked in the Inverted column, so tooling must negate those values rather than copy them; a blank cell means copy unchanged. For example `disableNotifications: true` becomes `notifications.enabled: false`, and defaults stay behaviour-preserving under inversion (`disableNotifications` defaults to `false`, so `notifications.enabled` defaults to `true`).
 
-None of these nested targets are implemented yet. The flat names on the left are the only names the app accepts today, and applying this table to a config file now will get those keys ignored with a startup warning. When a rename does ship, the old name will not disappear silently: it produces a startup warning and the change is announced in the release notes. Whether it also keeps applying for a deprecation window, or stops taking effect the day the rename lands, is still being decided in [#2841](https://github.com/IsmaelMartinez/teams-for-linux/issues/2841), where immediate removal is one of the live outcomes. That decision must be settled before the first rename.
+The table ships in batches. The `shortcuts` and `storage` renames landed in 2.17.0, and the ten remaining brand-new namespaces are in flight; the rest are still flat-only, and naming one of those nested targets today gets the key ignored with a startup warning. [#2841](https://github.com/IsmaelMartinez/teams-for-linux/issues/2841) settled what happens to the old name: both spellings keep working until the flat declarations are removed in 2.30.0, and `app/config/renames.js` projects a nested value onto the flat key that modules still read. A deprecated key in a config file is reported at startup by `checkUsedDeprecatedValues`, and each batch is announced in the release notes.
 
 The `notifications`, `idleDetection`, `network` and `auth` targets are shipped objects that already hold unrelated leaves; merging renamed options into them is intentional, and every leaf key below was checked against the shipped fields with no collisions.
 
@@ -110,15 +110,17 @@ An alias layer keeping flat names working forever was rejected by the original r
 
 ### Positive
 
-Contributors get one canonical answer for naming a new option and for where an existing flat option will land, without reading a 1600-line research document. The mapping is stable enough for tooling to consume once a migration mechanism is chosen, and that choice is deliberately left open here and tracked in [#2841](https://github.com/IsmaelMartinez/teams-for-linux/issues/2841). One candidate already exists in the codebase and is worth evaluating first: yargs' own `deprecated` field, which `checkUsedDeprecatedValues` in `app/config/index.js` reads on every startup, warning for any deprecated key present in the config file, system-wide or user, and which no option declares yet. On its own it only warns, since it neither maps an old name to its successor nor handles the four inversions, so it covers part of the problem rather than all of it.
+Contributors get one canonical answer for naming a new option and for where an existing flat option will land, without reading a 1600-line research document. The mapping is stable enough for tooling to consume, and [#2841](https://github.com/IsmaelMartinez/teams-for-linux/issues/2841) chose the mechanism: yargs' own `deprecated` field, which `checkUsedDeprecatedValues` in `app/config/index.js` reads on every startup for any deprecated key present in the config file, system-wide or user. That only warns, since it neither maps an old name to its successor nor handles the four inversions, so `app/config/renames.js` supplies both.
 
 ### Negative
 
-The four inversions mean a naive key-copy migration would silently flip user intent, so tooling must consult the Inverted column. This table is hand-maintained and can drift from `app/config/options.js` until something pins the two together in code.
+The four inversions mean a naive key-copy migration would silently flip user intent, so tooling must consult the Inverted column; `coerce` in `app/config/renames.js` is what does that, in both directions. The table in this document is hand-maintained, but its code counterpart no longer drifts unnoticed: the `config renames - table integrity` suite in `tests/unit/configRenames.test.js` pins every entry against `app/config/options.js`.
+
+Migration is not full equivalence. A flat option declares a type and yargs coerces the config-file value to it, while a nested leaf is not a declared option, so a config that leans on that coercion (`"disableGpu": "false"` as a string) changes meaning when rewritten. Tooling should validate its output rather than assume the two files resolve alike.
 
 ### Neutral
 
-A permanent alias layer and a `--migrate-config` codemod stay deferred, renames proceed namespace by namespace as tracked in [#2842](https://github.com/IsmaelMartinez/teams-for-linux/issues/2842), and the four occupied namespaces will mix long-shipped and newly-arrived leaves.
+A permanent alias layer stays rejected. The codemod no longer does: `toNestedConfigFile` in `app/config/renames.js` rewrites a config file onto the nested names, and [#2913](https://github.com/IsmaelMartinez/teams-for-linux/issues/2913) tracks the surface that offers it to users. Renames proceed namespace by namespace as tracked in [#2842](https://github.com/IsmaelMartinez/teams-for-linux/issues/2842), and the four occupied namespaces will mix long-shipped and newly-arrived leaves.
 
 ## Related
 

--- a/tests/unit/configRenames.test.js
+++ b/tests/unit/configRenames.test.js
@@ -215,11 +215,28 @@ describe('toNestedConfigFile', () => {
 		};
 		const migrated = toNestedConfigFile(original, table);
 
-		// Values as yargs would have resolved them from the flat spellings.
-		const resolved = { ...original };
+		// Resolved from nothing but the migrated file, so the projection has to
+		// rebuild every flat value on its own. Seeding this from `original`
+		// would pass even for a migration that did nothing at all.
+		const resolved = {};
 		applyRenamedOptions(resolved, migrated, table);
 
 		assert.deepStrictEqual(resolved, original);
+	});
+
+	// A flat name that is also someone's namespace makes migration depend on
+	// table order: whichever entry runs second finds the namespace occupied by
+	// a non-object and is skipped. No collision exists today; this keeps it so.
+	it('has no flat name that is also a namespace segment', () => {
+		const flatNames = new Set(RENAMES.map(({ flat }) => flat));
+		for (const { nested } of RENAMES) {
+			for (const segment of nested.split('.').slice(0, -1)) {
+				assert.ok(
+					!flatNames.has(segment),
+					`"${segment}" is both a flat option and a namespace in ${nested}`,
+				);
+			}
+		}
 	});
 
 	it('migrates away every flat name in the real table', () => {

--- a/tests/unit/configRenames.test.js
+++ b/tests/unit/configRenames.test.js
@@ -2,7 +2,11 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { RENAMES, applyRenamedOptions } = require('../../app/config/renames');
+const {
+	RENAMES,
+	applyRenamedOptions,
+	toNestedConfigFile,
+} = require('../../app/config/renames');
 const options = require('../../app/config/options');
 
 // Reads a dotted path against the options schema, walking `fields` maps.
@@ -135,5 +139,94 @@ describe('applyRenamedOptions - precedence', () => {
 		applyRenamedOptions(config, undefined, table);
 		assert.deepStrictEqual(config.globalShortcuts, ['Ctrl+1']);
 		assert.doesNotThrow(() => applyRenamedOptions(null, {}, table));
+	});
+});
+
+describe('toNestedConfigFile', () => {
+	const table = [
+		{ flat: 'globalShortcuts', nested: 'shortcuts.global', type: 'array' },
+		{ flat: 'clearStorageData', nested: 'storage.clearData' },
+		{ flat: 'disableNotifications', nested: 'notifications.enabled', inverted: true },
+	];
+
+	it('moves a flat key onto its nested target and drops the old name', () => {
+		const migrated = toNestedConfigFile({ clearStorageData: true }, table);
+		assert.deepStrictEqual(migrated, { storage: { clearData: true } });
+	});
+
+	it('does not mutate the config it was given', () => {
+		const original = { clearStorageData: true };
+		toNestedConfigFile(original, table);
+		assert.deepStrictEqual(original, { clearStorageData: true });
+	});
+
+	it('passes keys outside the table through untouched', () => {
+		const migrated = toNestedConfigFile({ appTitle: 'Teams', mqtt: { enabled: true } }, table);
+		assert.deepStrictEqual(migrated, { appTitle: 'Teams', mqtt: { enabled: true } });
+	});
+
+	it('negates an inverted boolean rather than copying it', () => {
+		const migrated = toNestedConfigFile({ disableNotifications: true }, table);
+		assert.deepStrictEqual(migrated, { notifications: { enabled: false } });
+	});
+
+	it('wraps a scalar for an array-typed rename, as yargs would have', () => {
+		const migrated = toNestedConfigFile({ globalShortcuts: 'Ctrl+1' }, table);
+		assert.deepStrictEqual(migrated, { shortcuts: { global: ['Ctrl+1'] } });
+	});
+
+	it('merges into a namespace the config already uses', () => {
+		const migrated = toNestedConfigFile(
+			{ clearStorageData: true, storage: { cacheManagement: { enabled: true } } },
+			table,
+		);
+		assert.deepStrictEqual(migrated, {
+			storage: { cacheManagement: { enabled: true }, clearData: true },
+		});
+	});
+
+	// Matches the precedence applyRenamedOptions applies at runtime, so the
+	// migrated file resolves to the same settings as the file it came from.
+	it('keeps the nested value and drops the flat one when both are set', () => {
+		const migrated = toNestedConfigFile(
+			{ clearStorageData: true, storage: { clearData: false } },
+			table,
+		);
+		assert.deepStrictEqual(migrated, { storage: { clearData: false } });
+	});
+
+	it('leaves the flat key alone when its namespace is occupied by a non-object', () => {
+		const migrated = toNestedConfigFile({ clearStorageData: true, storage: 'nonsense' }, table);
+		assert.deepStrictEqual(migrated, { clearStorageData: true, storage: 'nonsense' });
+	});
+
+	it('tolerates a missing or non-object config file', () => {
+		assert.deepStrictEqual(toNestedConfigFile(undefined, table), {});
+		assert.deepStrictEqual(toNestedConfigFile(null, table), {});
+		assert.deepStrictEqual(toNestedConfigFile('nonsense', table), {});
+	});
+
+	// The contract that makes the generated file safe to adopt.
+	it('round-trips through applyRenamedOptions to the same flat values', () => {
+		const original = {
+			globalShortcuts: ['Ctrl+1'],
+			clearStorageData: true,
+			disableNotifications: true,
+		};
+		const migrated = toNestedConfigFile(original, table);
+
+		// Values as yargs would have resolved them from the flat spellings.
+		const resolved = { ...original };
+		applyRenamedOptions(resolved, migrated, table);
+
+		assert.deepStrictEqual(resolved, original);
+	});
+
+	it('migrates away every flat name in the real table', () => {
+		const flatOnly = Object.fromEntries(RENAMES.map(({ flat }) => [flat, 'x']));
+		const migrated = toNestedConfigFile(flatOnly);
+		for (const { flat } of RENAMES) {
+			assert.ok(!Object.hasOwn(migrated, flat), `${flat} should have been migrated away`);
+		}
 	});
 });


### PR DESCRIPTION
First piece of #2913. Adds `toNestedConfigFile`, the pure transform that rewrites a config file's flat keys onto their ADR-025 nested targets, so a later Settings entry can write a migrated copy the user reviews and moves over. That menu entry belongs beside the "Open config file" entries from #2885 and waits on #2893; the transform does not.

`coerce` is reused rather than mirrored, since negation is symmetric and an array-typed option needs wrapping on the way out for the same reason as on the way in. Where both spellings are present the nested one wins, matching runtime precedence, so a migrated config resolves to the values the original did.

Lint and the unit suite pass. The new tests go red against a reverted source, and a mutation of the both-spellings branch is caught by one test rather than slipping through.

Refs #2913
