### PR TITLE
feat(multi-account): attribute descendants + profile-view window-open policy (ADR-020 Phase 2)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -709,7 +709,8 @@ async function handleAppReady() {
           mainWindow,
           profilesManager,
           config,
-          mainAppWindow.bindDisplayMediaHandler
+          mainAppWindow.bindDisplayMediaHandler,
+          mainAppWindow.bindWindowOpenHandler
         );
         profileViewManager.initialize();
         await profileViewManager.bootstrapProfileZeroIfNeeded();

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -62,11 +62,7 @@ function setupScreenSharing(selectedSource) {
 // window, which is a different profile. Profile views previously had no
 // handler at all; see profileWindowOpenPolicy.js for what is deliberately
 // still left on Electron's default and why.
-function bindWindowOpenHandler(
-  targetWebContents,
-  loadTargetWebContents = targetWebContents,
-  activate
-) {
+function bindWindowOpenHandler(targetWebContents, loadTargetWebContents, activate) {
   installProfileWindowOpenHandler(targetWebContents, {
     config,
     loadTargetWebContents,

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -23,6 +23,7 @@ const BrowserWindowManager = require("../mainAppWindow/browserWindowManager");
 const deepLinkRouter = require("./deepLinkRouter");
 const os = require("node:os");
 const path = require("node:path");
+const { installProfileWindowOpenHandler } = require("./profileWindowOpenPolicy");
 
 const DEFAULT_SCREEN_SHARING_THUMBNAIL_CONFIG = {
   enabled: true,
@@ -53,6 +54,24 @@ const isMac = os.platform() === "darwin";
 function setupScreenSharing(selectedSource) {
   screenSharingService.setSelectedSource(selectedSource);
   createScreenSharePreviewWindow();
+}
+
+// Install the profile-view window-open policy on a webContents (a profile
+// view or one of its descendants). Teams deep links load into
+// `loadTargetWebContents` — the originating profile view — never the root
+// window, which is a different profile. Profile views previously had no
+// handler at all; see profileWindowOpenPolicy.js for what is deliberately
+// still left on Electron's default and why.
+function bindWindowOpenHandler(
+  targetWebContents,
+  loadTargetWebContents = targetWebContents,
+  activate
+) {
+  installProfileWindowOpenHandler(targetWebContents, {
+    config,
+    loadTargetWebContents,
+    activate,
+  });
 }
 
 // Register the in-app screen-share picker on a given session. `setDisplayMediaRequestHandler`
@@ -858,6 +877,7 @@ exports.getWindow = function () {
 };
 
 exports.bindDisplayMediaHandler = bindDisplayMediaHandler;
+exports.bindWindowOpenHandler = bindWindowOpenHandler;
 
 exports.setQuickChatManager = function (quickChatManager) {
   if (menus) {

--- a/app/mainAppWindow/profileViewManager.js
+++ b/app/mainAppWindow/profileViewManager.js
@@ -82,6 +82,7 @@ class ProfileViewManager {
   #profilesManager;
   #config;
   #bindDisplayMediaHandler;
+  #bindWindowOpenHandler;
   #views = new Map();
   // Phase 2 foundation: webContents → profile attribution for main-process
   // IPC handlers (tray/badge/notification aggregation consumes this next).
@@ -90,6 +91,11 @@ class ProfileViewManager {
   // never depends on the WebContents still being reachable (a page can
   // destroy its own webContents, e.g. an auth flow calling window.close()).
   #viewMeta = new Map();
+  // profileId → Map<webContents.id, webContents> of live popups / webview
+  // guests spawned by that profile's view (recursively). Drained — and the
+  // windows closed — when the profile is removed, so no surface keeps running
+  // an account the user just deleted, and no id resolves to a gone profile.
+  #descendants = new Map();
   #handlers = null;
   #resizeHandler = null;
   #navigationHandler = null;
@@ -110,12 +116,25 @@ class ProfileViewManager {
    *   Binds the in-app screen-share picker to a session. Called for each
    *   profile view's partition session so multi-account screen-share
    *   matches Profile 0's behaviour (#2529).
+   * @param {(target: Electron.WebContents, loadTarget: Electron.WebContents, activate: () => void) => void} [bindWindowOpenHandler]
+   *   Installs the profile-view window-open policy on `target` (a profile
+   *   view or one of its descendants); Teams deep links load into
+   *   `loadTarget`, the originating profile view, and `activate` then makes
+   *   that profile the visible one. Profile views previously had no handler
+   *   at all; see mainAppWindow/profileWindowOpenPolicy.js.
    */
-  constructor(window, profilesManager, config, bindDisplayMediaHandler) {
+  constructor(
+    window,
+    profilesManager,
+    config,
+    bindDisplayMediaHandler,
+    bindWindowOpenHandler = () => {}
+  ) {
     this.#window = window;
     this.#profilesManager = profilesManager;
     this.#config = config;
     this.#bindDisplayMediaHandler = bindDisplayMediaHandler;
+    this.#bindWindowOpenHandler = bindWindowOpenHandler;
     this.#registry = new SenderProfileMap(profilesManager);
   }
 
@@ -123,8 +142,14 @@ class ProfileViewManager {
     if (this.#initialized) return;
     this.#initialized = true;
 
-    // The root window hosts Profile 0 (legacy partition).
+    // The root window hosts Profile 0 (legacy partition). Its popups and
+    // webview guests attribute to whatever Profile 0 is at lookup time.
     this.#registry.setRootWebContentsId(this.#window.webContents.id);
+    this.#watchDescendants(this.#window.webContents, {
+      root: true,
+      loadTarget: this.#window.webContents,
+      activate: () => this.#activate(this.#profilesManager.getLegacyProfile()?.id),
+    });
     // Seed the cached root profile id; afterwards the add/remove handlers
     // keep it current, so resolution never touches the settings store
     // (electron-store re-reads its JSON file on every access — too costly
@@ -329,6 +354,7 @@ class ProfileViewManager {
     }
     this.#registry.clear();
     this.#viewMeta.clear();
+    this.#descendants.clear();
     this.#initialized = false;
   }
 
@@ -336,12 +362,11 @@ class ProfileViewManager {
 
   /**
    * Resolve a webContents to the id of the profile that owns it: a profile
-   * view's id, or the root window's Profile 0. Returns null for any
-   * unattributed sender: the switcher pill, dialog windows, the root window
-   * while Profile 0 does not exist (pre-bootstrap, or after its removal) —
-   * and, for now, child windows / webview guests spawned by a profile view
-   * (see the KNOWN GAP note in senderProfileMap.js). Null means
-   * "unattributed", never "safe to ignore".
+   * view, the root window's Profile 0, or any popup / webview guest either
+   * of them spawned (tracked recursively). Returns null for unattributed
+   * senders: the switcher pill, dialog windows, and the root window or its
+   * descendants while Profile 0 does not exist (pre-bootstrap, or after its
+   * removal). Null means "unattributed", never "safe to ignore".
    * @param {Electron.WebContents} webContents
    * @returns {string|null}
    */
@@ -424,6 +449,9 @@ class ProfileViewManager {
     // `setDisplayMediaRequestHandler` is per-session and the root window's
     // binding does not carry across to profile partitions (#2529).
     this.#bindDisplayMediaHandler(view.webContents.session);
+    this.#bindWindowOpenHandler(view.webContents, view.webContents, () =>
+      this.#activate(profileId)
+    );
 
     const wcId = view.webContents.id;
     const profileId = profile.id;
@@ -440,6 +468,16 @@ class ProfileViewManager {
     view.webContents.once("destroyed", () => {
       this.#views.delete(profileId);
       this.#registry.unregister(wcId);
+      this.#teardownDescendants(profileId);
+    });
+    // Attribute anything this view spawns to its profile. A popup genuinely
+    // shares the view's partition and preload (window.open inherits them from
+    // the opener); a <webview> guest has its own, but it lives inside this
+    // profile's surface, so its IPC still belongs to this profile.
+    this.#watchDescendants(view.webContents, {
+      profileId,
+      loadTarget: view.webContents,
+      activate: () => this.#activate(profileId),
     });
     this.#applyBounds(view);
 
@@ -447,6 +485,84 @@ class ProfileViewManager {
     view.webContents.loadURL(url, {
       userAgent: this.#config.chromeUserAgent,
     });
+  }
+
+  // Make `profileId` the visible profile (no-op if it already is, or if it
+  // no longer exists). Used when a deep link loads into a profile view that
+  // may currently be in the background.
+  #activate(profileId) {
+    if (!profileId) return;
+    if (this.#profilesManager.getActive()?.id === profileId) return;
+    try {
+      this.#profilesManager.switch(profileId);
+    } catch (error) {
+      console.warn("[ProfileViewManager] activate after deep link failed", {
+        message: error.message,
+      });
+    }
+  }
+
+  // Listen for popups and webview guests spawned by `webContents` and
+  // attribute them to the same owner. `owner` is { profileId } for a profile
+  // view or { root: true } for the root window (Profile 0, whose id is
+  // mutable so descendants resolve through the map's root profile id).
+  #watchDescendants(webContents, owner) {
+    webContents.on("did-create-window", (child) =>
+      this.#trackDescendant(child?.webContents, owner)
+    );
+    webContents.on("did-attach-webview", (_event, guest) =>
+      this.#trackDescendant(guest, owner)
+    );
+  }
+
+  // Attribute a child window / webview guest to its owner for its lifetime,
+  // give it the same window-open policy (deep links still load into the
+  // ORIGINATING view, not the popup), and recurse so grandchildren are
+  // covered — `setWindowOpenHandler` and these events are per-webContents,
+  // not inherited. Id captured up front — same reasoning as the view itself.
+  #trackDescendant(webContents, owner) {
+    if (!webContents || typeof webContents.id !== "number") return;
+    const id = webContents.id;
+    if (owner.root) {
+      this.#registry.registerRootDescendant(id);
+      webContents.once("destroyed", () =>
+        this.#registry.unregisterRootDescendant(id)
+      );
+    } else {
+      this.#registry.register(id, owner.profileId);
+      let siblings = this.#descendants.get(owner.profileId);
+      if (!siblings) {
+        siblings = new Map();
+        this.#descendants.set(owner.profileId, siblings);
+      }
+      siblings.set(id, webContents);
+      webContents.once("destroyed", () => {
+        this.#registry.unregister(id);
+        this.#descendants.get(owner.profileId)?.delete(id);
+      });
+    }
+    this.#bindWindowOpenHandler(webContents, owner.loadTarget, owner.activate);
+    this.#watchDescendants(webContents, owner);
+  }
+
+  // Remove a profile's descendants from attribution and close any that are
+  // still alive: a popup left running after its profile is removed would keep
+  // an authenticated surface for a deleted account (and its partition is
+  // about to be cleared underneath it).
+  #teardownDescendants(profileId) {
+    const siblings = this.#descendants.get(profileId);
+    if (!siblings) return;
+    this.#descendants.delete(profileId);
+    for (const [id, wc] of siblings) {
+      this.#registry.unregister(id);
+      if (wc && !wc.isDestroyed?.()) {
+        try {
+          wc.close();
+        } catch {
+          // Already going away; ignore.
+        }
+      }
+    }
   }
 
   #destroyView(profileId) {
@@ -459,6 +575,7 @@ class ProfileViewManager {
     this.#viewMeta.delete(profileId);
     if (!view && !meta) return;
     if (meta) this.#registry.unregister(meta.wcId);
+    this.#teardownDescendants(profileId);
 
     if (view) {
       try {

--- a/app/mainAppWindow/profileWindowOpenPolicy.js
+++ b/app/mainAppWindow/profileWindowOpenPolicy.js
@@ -1,0 +1,79 @@
+/**
+ * Window-open policy for profile `WebContentsView`s and their descendants
+ * (ADR-020 Phase 2).
+ *
+ * Profile views historically installed NO `setWindowOpenHandler` at all — only
+ * the root window has one (`onNewWindow` in mainAppWindow/index.js) — so every
+ * `window.open()` from a profile view took Electron's default path: a bare new
+ * BrowserWindow inheriting the view's partition and preload. This policy ports
+ * the ONE part of the root behaviour that is provably safe per view:
+ *
+ *   - Teams deep links matching `meetupJoinRegEx` (meeting joins, but the
+ *     default pattern also covers `/l/chat/`, `/l/channel/`, `/l/team/`, …):
+ *     denied as a popup and, when `onNewWindowOpenMeetupJoinUrlInApp` is set,
+ *     loaded IN THE ORIGINATING PROFILE VIEW — never in the root window, which
+ *     is a different profile (#2867's window.open shape).
+ *
+ * Everything else stays on Electron's default `allow` — i.e. exactly what
+ * profile views do today. The root window's remaining handling (ordinary
+ * links → external browser with a Ctrl+click in-app override, auth popups →
+ * deny + recovery) is NOT ported yet, deliberately: the Ctrl override reads
+ * input state tracked only on the root window, the auth classifier is a
+ * 3-host recovery-intercept list that misses sovereign clouds and federated
+ * IdPs, and the deny path is coupled to root-only auth recovery. Porting any
+ * of that piecemeal regresses profile views (links that open in-app today
+ * would go external with no in-app escape hatch, stranding sign-in). It lands
+ * together with per-profile auth recovery (tracked on #2495 with #2867).
+ *
+ * Pure (no Electron imports): `loadInView` is injected so the branch is
+ * unit-testable; `installProfileWindowOpenHandler` is the thin binder that
+ * targets a real webContents.
+ */
+function createProfileWindowOpenHandler({ config, loadInView }) {
+  return (details) => {
+    const url = typeof details?.url === "string" ? details.url : "";
+    if (config.meetupJoinRegEx && new RegExp(config.meetupJoinRegEx).test(url)) {
+      if (config.onNewWindowOpenMeetupJoinUrlInApp) {
+        loadInView(url);
+      }
+      return { action: "deny" };
+    }
+    return { action: "allow" };
+  };
+}
+
+/**
+ * Install the policy on `targetWebContents`. Deep links always load into
+ * `loadTargetWebContents` — the ORIGINATING PROFILE VIEW — even when the
+ * target is one of its descendants (a popup or webview guest), so a meeting
+ * link clicked inside an auth popup lands in the profile, not in the popup.
+ * `activate` is then called so that profile becomes the visible one: the link
+ * may have come from a popup belonging to a BACKGROUND profile, and silently
+ * navigating a hidden view would leave the user staring at the wrong tenant.
+ *
+ * @param {Electron.WebContents} targetWebContents
+ * @param {{ config: object, loadTargetWebContents?: Electron.WebContents,
+ *           activate?: () => void }} deps
+ */
+function installProfileWindowOpenHandler(
+  targetWebContents,
+  { config, loadTargetWebContents = targetWebContents, activate }
+) {
+  targetWebContents.setWindowOpenHandler(
+    createProfileWindowOpenHandler({
+      config,
+      loadInView: (url) => {
+        if (loadTargetWebContents.isDestroyed?.()) return;
+        loadTargetWebContents.loadURL(url, {
+          userAgent: config.chromeUserAgent,
+        });
+        activate?.();
+      },
+    })
+  );
+}
+
+module.exports = {
+  createProfileWindowOpenHandler,
+  installProfileWindowOpenHandler,
+};

--- a/app/mainAppWindow/profileWindowOpenPolicy.js
+++ b/app/mainAppWindow/profileWindowOpenPolicy.js
@@ -70,6 +70,22 @@ function createProfileWindowOpenHandler({ config, loadInView }) {
  * @param {{ config: object, loadTargetWebContents?: Electron.WebContents,
  *           activate?: () => void }} deps
  */
+// Fire-and-forget navigation into the originating profile view. The SPA
+// taking over the route rejects the load with ERR_ABORTED in normal use
+// (#2950), and the process-wide unhandledRejection handler exits on anything
+// it cannot classify — so the failure is handled HERE and the function never
+// rejects; callers do not await it.
+async function navigateDeepLink(webContents, url, userAgent) {
+  try {
+    await webContents.loadURL(url, { userAgent });
+  } catch (error) {
+    console.debug(
+      "[ProfileWindowOpenPolicy] Deep-link navigation interrupted",
+      { code: error?.code ?? error?.errno }
+    );
+  }
+}
+
 function installProfileWindowOpenHandler(
   targetWebContents,
   { config, loadTargetWebContents = targetWebContents, activate }
@@ -79,19 +95,9 @@ function installProfileWindowOpenHandler(
       config,
       loadInView: (url) => {
         if (loadTargetWebContents.isDestroyed?.()) return;
-        // Not awaited: the SPA taking over the navigation rejects this with
-        // ERR_ABORTED in normal use (#2950), and the process-wide
-        // unhandledRejection handler exits on anything it cannot classify —
-        // so the rejection must be caught, and activation must not depend on
-        // the promise resolving.
-        loadTargetWebContents
-          .loadURL(url, { userAgent: config.chromeUserAgent })
-          .catch((error) => {
-            console.debug(
-              "[ProfileWindowOpenPolicy] Deep-link navigation interrupted",
-              { code: error?.code ?? error?.errno }
-            );
-          });
+        // Deliberately not awaited: the window-open handler is synchronous,
+        // and activation must not depend on the navigation resolving.
+        navigateDeepLink(loadTargetWebContents, url, config.chromeUserAgent);
         activate?.();
       },
     })

--- a/app/mainAppWindow/profileWindowOpenPolicy.js
+++ b/app/mainAppWindow/profileWindowOpenPolicy.js
@@ -30,9 +30,24 @@
  * targets a real webContents.
  */
 function createProfileWindowOpenHandler({ config, loadInView }) {
+  // Compiled once, not per window.open. `meetupJoinRegEx` is user-configurable
+  // and the config validator only checks it is a string — a malformed pattern
+  // must degrade to "no deep-link interception" (the pre-policy default),
+  // never throw inside the window-open handler (an uncaught main-process
+  // exception is fatal, app/index.js).
+  let deepLinkRe = null;
+  if (config.meetupJoinRegEx) {
+    try {
+      deepLinkRe = new RegExp(config.meetupJoinRegEx);
+    } catch {
+      console.warn(
+        "[ProfileWindowOpenPolicy] Invalid meetupJoinRegEx; deep-link interception disabled for profile views"
+      );
+    }
+  }
   return (details) => {
     const url = typeof details?.url === "string" ? details.url : "";
-    if (config.meetupJoinRegEx && new RegExp(config.meetupJoinRegEx).test(url)) {
+    if (deepLinkRe?.test(url)) {
       if (config.onNewWindowOpenMeetupJoinUrlInApp) {
         loadInView(url);
       }
@@ -64,9 +79,19 @@ function installProfileWindowOpenHandler(
       config,
       loadInView: (url) => {
         if (loadTargetWebContents.isDestroyed?.()) return;
-        loadTargetWebContents.loadURL(url, {
-          userAgent: config.chromeUserAgent,
-        });
+        // Not awaited: the SPA taking over the navigation rejects this with
+        // ERR_ABORTED in normal use (#2950), and the process-wide
+        // unhandledRejection handler exits on anything it cannot classify —
+        // so the rejection must be caught, and activation must not depend on
+        // the promise resolving.
+        loadTargetWebContents
+          .loadURL(url, { userAgent: config.chromeUserAgent })
+          .catch((error) => {
+            console.debug(
+              "[ProfileWindowOpenPolicy] Deep-link navigation interrupted",
+              { code: error?.code ?? error?.errno }
+            );
+          });
         activate?.();
       },
     })

--- a/app/mainAppWindow/senderProfileMap.js
+++ b/app/mainAppWindow/senderProfileMap.js
@@ -15,12 +15,16 @@
  * because the settings store re-reads its JSON file on every access and
  * resolution sits on the per-badge-tick hot path once aggregation consumes it.
  *
- * KNOWN GAP (correct before relying on "null ⇒ not a profile"): child
- * surfaces spawned BY a profile view — `window.open()` popups and `<webview>`
- * guests inherit the view's partition and preload but are not registered
- * here, so they currently resolve to null. The consuming PR registers
- * descendants (`did-create-window` / `did-attach-webview`); until it lands,
- * null means "unattributed", never "safe to ignore".
+ * Descendants: surfaces spawned BY a profile surface — `window.open()` popups
+ * (which inherit its partition and preload) and `<webview>` guests (own
+ * partition, but embedded inside that profile's surface) — are registered by
+ * ProfileViewManager (recursively, via `did-create-window` /
+ * `did-attach-webview`) to the same profile for their lifetime. Descendants of
+ * the ROOT window are kept in their own set and resolve through the current
+ * root profile id, since that id is mutable (bootstrap / removal). Null
+ * therefore means: the switcher pill, a dialog window, or the root window and
+ * its descendants while Profile 0 does not exist — "unattributed", never
+ * "safe to ignore".
  *
  * Pure module (no Electron imports) so the mapping logic is unit-testable
  * directly under `node --test`.
@@ -32,6 +36,8 @@ class SenderProfileMap {
   #rootWebContentsId = null;
   /** @type {string|null} Profile 0's id once bootstrapped, else null. */
   #rootProfileId = null;
+  /** @type {Set<number>} webContents ids of popups/guests spawned by the root window. */
+  #rootDescendants = new Set();
   #profilesManager;
 
   /**
@@ -64,8 +70,18 @@ class SenderProfileMap {
     this.#byWebContentsId.delete(webContentsId);
   }
 
+  /** A popup / webview guest spawned by the root window (Profile 0). */
+  registerRootDescendant(webContentsId) {
+    this.#rootDescendants.add(webContentsId);
+  }
+
+  unregisterRootDescendant(webContentsId) {
+    this.#rootDescendants.delete(webContentsId);
+  }
+
   clear() {
     this.#byWebContentsId.clear();
+    this.#rootDescendants.clear();
     this.#rootWebContentsId = null;
     this.#rootProfileId = null;
   }
@@ -74,16 +90,16 @@ class SenderProfileMap {
    * Pure map lookup — no I/O.
    * @param {number} webContentsId
    * @returns {string|null} The owning profile's id, or null when the sender
-   *   is unattributed: the switcher pill, a dialog window, the root window
-   *   before Profile 0 is bootstrapped — or (see KNOWN GAP above) a child
-   *   window / webview guest spawned by a profile view.
+   *   is unattributed: the switcher pill, a dialog window, or the root
+   *   window / its descendants while Profile 0 does not exist.
    */
   resolveProfileId(webContentsId) {
     const direct = this.#byWebContentsId.get(webContentsId);
     if (direct !== undefined) return direct;
     if (
-      this.#rootWebContentsId !== null &&
-      webContentsId === this.#rootWebContentsId
+      (this.#rootWebContentsId !== null &&
+        webContentsId === this.#rootWebContentsId) ||
+      this.#rootDescendants.has(webContentsId)
     ) {
       return this.#rootProfileId;
     }

--- a/tests/unit/profileViewManager.test.js
+++ b/tests/unit/profileViewManager.test.js
@@ -23,20 +23,33 @@ class FakeWebContents {
     this.id = nextWcId++;
     this.session = { clearStorageData: async () => {} };
     this._once = {};
+    this._on = {};
     this._destroyed = false;
   }
   loadURL() {}
   async loadFile() {}
-  on() {}
+  on(event, cb) {
+    (this._on[event] ||= []).push(cb);
+  }
+  emit(event, ...args) {
+    for (const cb of this._on[event] || []) cb(...args);
+  }
   once(event, cb) {
     (this._once[event] ||= []).push(cb);
+  }
+  emitOnce(event) {
+    if (event === 'destroyed') this._destroyed = true;
+    for (const cb of this._once[event] || []) cb();
+    this._once[event] = [];
   }
   removeListener() {}
   send() {}
   isDestroyed() {
     return this._destroyed;
   }
-  close() {}
+  close() {
+    this.closed = true;
+  }
 }
 
 class FakeWebContentsView {
@@ -53,9 +66,7 @@ class FakeWebContentsView {
   // in the real app.
   destroyWebContents() {
     const wc = this.webContents;
-    wc._destroyed = true;
-    for (const cb of wc._once['destroyed'] || []) cb();
-    wc._once['destroyed'] = [];
+    wc.emitOnce('destroyed');
     this.webContents = undefined;
     return wc;
   }
@@ -102,6 +113,7 @@ function fakeWindow() {
 
 const LEGACY = { id: 'profile-0', partition: 'persist:teams-4-linux', name: 'My account' };
 const PROFILE_A = { id: 'profile-a', partition: 'persist:teams-profile-a', name: 'A' };
+const PROFILE_B = { id: 'profile-b', partition: 'persist:teams-profile-b', name: 'B' };
 
 function fakeProfilesManager(profiles) {
   const handlers = {};
@@ -114,7 +126,14 @@ function fakeProfilesManager(profiles) {
       for (const h of handlers[event] || []) h(payload);
     },
     list: () => profiles,
-    getActive: () => profiles[0] ?? null,
+    activeId: profiles[0]?.id ?? null,
+    getActive() {
+      return profiles.find((p) => p.id === this.activeId) ?? null;
+    },
+    switch(id) {
+      this.activeId = id;
+      this.emit('switch', profiles.find((p) => p.id === id));
+    },
     getLegacyProfile: () =>
       profiles.find((p) => p.partition === LEGACY.partition) ?? null,
   };
@@ -138,10 +157,16 @@ afterEach(() => {
   delete require.cache[electronPath];
 });
 
-function build(profiles) {
+function build(profiles, bindWindowOpenHandler) {
   const win = fakeWindow();
   const pm = fakeProfilesManager(profiles);
-  const pvm = new ProfileViewManager(win, pm, { url: 'https://teams.cloud.microsoft' }, () => {});
+  const pvm = new ProfileViewManager(
+    win,
+    pm,
+    { url: 'https://teams.cloud.microsoft' },
+    () => {},
+    bindWindowOpenHandler
+  );
   pvm.initialize();
   return { win, pm, pvm };
 }
@@ -239,6 +264,125 @@ describe('ProfileViewManager sender attribution wiring', () => {
     const profileView = createdViews[0];
     pm.emit('remove', { removedId: 'profile-a', activeId: 'profile-0' });
     assert.strictEqual(pvm.resolveProfileId(profileView.webContents), null);
+  });
+
+  it('installs the window-open policy on each profile view (not on the pill), loading into itself', () => {
+    const bound = [];
+    build([LEGACY, PROFILE_A, PROFILE_B], (target, loadTarget) =>
+      bound.push([target, loadTarget])
+    );
+    const [viewA, viewB] = createdViews;
+    const pillView = createdViews[createdViews.length - 1];
+    assert.deepStrictEqual(bound, [
+      [viewA.webContents, viewA.webContents],
+      [viewB.webContents, viewB.webContents],
+    ]);
+    assert.ok(!bound.some(([t]) => t === pillView.webContents));
+  });
+
+  it('attributes a child window opened by a profile view to that profile, until it is destroyed', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const child = { webContents: new FakeWebContents() };
+    createdViews[0].webContents.emit('did-create-window', child);
+    assert.strictEqual(pvm.resolveProfileId(child.webContents), 'profile-a');
+    child.webContents.emitOnce('destroyed');
+    assert.strictEqual(pvm.resolveProfileId(child.webContents), null);
+  });
+
+  it('attributes a <webview> guest attached in a profile view to that profile, until it is destroyed', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const guest = new FakeWebContents();
+    createdViews[0].webContents.emit('did-attach-webview', {}, guest);
+    assert.strictEqual(pvm.resolveProfileId(guest), 'profile-a');
+    guest.emitOnce('destroyed');
+    assert.strictEqual(pvm.resolveProfileId(guest), null);
+  });
+
+  it('attributes grandchildren: a popup of a popup, and a popup of a webview guest', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const child = { webContents: new FakeWebContents() };
+    createdViews[0].webContents.emit('did-create-window', child);
+    const grandchild = { webContents: new FakeWebContents() };
+    child.webContents.emit('did-create-window', grandchild);
+    assert.strictEqual(pvm.resolveProfileId(grandchild.webContents), 'profile-a');
+
+    const guest = new FakeWebContents();
+    createdViews[0].webContents.emit('did-attach-webview', {}, guest);
+    const guestPopup = { webContents: new FakeWebContents() };
+    guest.emit('did-create-window', guestPopup);
+    assert.strictEqual(pvm.resolveProfileId(guestPopup.webContents), 'profile-a');
+  });
+
+  it('installs the window-open policy on descendants with the ORIGINATING view as load target', () => {
+    const bound = [];
+    build([LEGACY, PROFILE_A], (target, loadTarget) => bound.push([target, loadTarget]));
+    const view = createdViews[0];
+    const child = { webContents: new FakeWebContents() };
+    view.webContents.emit('did-create-window', child);
+    const grandchild = { webContents: new FakeWebContents() };
+    child.webContents.emit('did-create-window', grandchild);
+    assert.deepStrictEqual(bound.slice(1), [
+      [child.webContents, view.webContents],
+      [grandchild.webContents, view.webContents],
+    ]);
+  });
+
+  it('a deep link loaded from a background profile activates that profile', () => {
+    let activateFn = null;
+    const { pm } = build([LEGACY, PROFILE_A], (_t, _l, activate) => {
+      activateFn = activate;
+    });
+    assert.strictEqual(pm.getActive().id, 'profile-0');
+    activateFn();
+    assert.strictEqual(pm.getActive().id, 'profile-a');
+    // Idempotent once active.
+    activateFn();
+    assert.strictEqual(pm.getActive().id, 'profile-a');
+  });
+
+  it('removing a profile unregisters AND closes its live descendants (not just on dispose)', () => {
+    const { pm, pvm } = build([LEGACY, PROFILE_A]);
+    const view = createdViews[0];
+    const child = { webContents: new FakeWebContents() };
+    view.webContents.emit('did-create-window', child);
+    const grandchild = { webContents: new FakeWebContents() };
+    child.webContents.emit('did-create-window', grandchild);
+    pm.emit('remove', { removedId: 'profile-a', activeId: 'profile-0' });
+    assert.strictEqual(pvm.resolveProfileId(child.webContents), null);
+    assert.strictEqual(pvm.resolveProfileId(grandchild.webContents), null);
+    assert.strictEqual(child.webContents.closed, true);
+    assert.strictEqual(grandchild.webContents.closed, true);
+  });
+
+  it('a view that destroys itself takes its descendants out of attribution too', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const view = createdViews[0];
+    const child = { webContents: new FakeWebContents() };
+    view.webContents.emit('did-create-window', child);
+    view.destroyWebContents();
+    assert.strictEqual(pvm.resolveProfileId(child.webContents), null);
+    assert.strictEqual(child.webContents.closed, true);
+  });
+
+  it("attributes the root window's descendants to Profile 0 — null pre-bootstrap, the id after", () => {
+    const profiles = [PROFILE_A];
+    const { win, pm, pvm } = build(profiles);
+    const popup = { webContents: new FakeWebContents() };
+    win.webContents.emit('did-create-window', popup);
+    assert.strictEqual(pvm.resolveProfileId(popup.webContents), null);
+    profiles.push(LEGACY);
+    pm.emit('add', LEGACY);
+    assert.strictEqual(pvm.resolveProfileId(popup.webContents), 'profile-0');
+    popup.webContents.emitOnce('destroyed');
+    assert.strictEqual(pvm.resolveProfileId(popup.webContents), null);
+  });
+
+  it('descendant attribution is dropped on dispose', () => {
+    const { pvm } = build([LEGACY, PROFILE_A]);
+    const child = { webContents: new FakeWebContents() };
+    createdViews[0].webContents.emit('did-create-window', child);
+    pvm.dispose();
+    assert.strictEqual(pvm.resolveProfileId(child.webContents), null);
   });
 
   it('dispose clears all attribution including the root window', () => {

--- a/tests/unit/profileWindowOpenPolicy.test.js
+++ b/tests/unit/profileWindowOpenPolicy.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  createProfileWindowOpenHandler,
+  installProfileWindowOpenHandler,
+} = require('../../app/mainAppWindow/profileWindowOpenPolicy');
+const defaults = require('../../app/config/defaults');
+
+// ADR-020 Phase 2: window-open policy for profile views and their
+// descendants. Pure factory + a thin installer, both asserted directly.
+
+const MEETUP_RE = '^https://teams\\.microsoft\\.com/l/meetup-join/';
+
+function build(overrides = {}) {
+  const loads = [];
+  const handler = createProfileWindowOpenHandler({
+    config: {
+      meetupJoinRegEx: MEETUP_RE,
+      onNewWindowOpenMeetupJoinUrlInApp: true,
+      ...overrides.config,
+    },
+    loadInView: (url) => loads.push(url),
+  });
+  return { handler, loads };
+}
+
+describe('createProfileWindowOpenHandler', () => {
+  it('loads a meeting-join link in the originating view and denies the popup', () => {
+    const { handler, loads } = build();
+    const url = 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc';
+    assert.deepStrictEqual(handler({ url }), { action: 'deny' });
+    assert.deepStrictEqual(loads, [url]);
+  });
+
+  it('denies a meeting-join popup without loading when in-app join is off', () => {
+    const { handler, loads } = build({
+      config: { onNewWindowOpenMeetupJoinUrlInApp: false },
+    });
+    const url = 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc';
+    assert.deepStrictEqual(handler({ url }), { action: 'deny' });
+    assert.deepStrictEqual(loads, []);
+  });
+
+  it("leaves everything else on Electron's default allow (ordinary links, about:blank, login popups)", () => {
+    const { handler, loads } = build();
+    for (const url of [
+      'https://example.com/doc',
+      'about:blank',
+      'about:blank#blocked',
+      'https://login.microsoftonline.com/common/oauth2',
+      'https://login.microsoftonline.us/common/oauth2',
+      'https://adfs.example.org/adfs/ls/',
+    ]) {
+      assert.deepStrictEqual(handler({ url }), { action: 'allow' }, url);
+    }
+    assert.deepStrictEqual(loads, []);
+  });
+
+  it('the default meetupJoinRegEx also captures other Teams deep links (chat, channel) — documented blast radius', () => {
+    const { handler, loads } = build({
+      config: { meetupJoinRegEx: defaults.meetupJoinRegEx },
+    });
+    const chat = 'https://teams.microsoft.com/l/chat/0/0?users=someone';
+    assert.deepStrictEqual(handler({ url: chat }), { action: 'deny' });
+    assert.deepStrictEqual(loads, [chat]);
+  });
+
+  it('tolerates a missing meetupJoinRegEx and malformed details', () => {
+    const { handler, loads } = build({ config: { meetupJoinRegEx: '' } });
+    assert.deepStrictEqual(handler({}), { action: 'allow' });
+    assert.deepStrictEqual(handler(null), { action: 'allow' });
+    assert.strictEqual(loads.length, 0);
+  });
+});
+
+describe('installProfileWindowOpenHandler', () => {
+  function fakeWc() {
+    return {
+      loads: [],
+      destroyed: false,
+      handler: null,
+      setWindowOpenHandler(fn) {
+        this.handler = fn;
+      },
+      loadURL(url, opts) {
+        this.loads.push({ url, opts });
+      },
+      isDestroyed() {
+        return this.destroyed;
+      },
+    };
+  }
+  const config = {
+    meetupJoinRegEx: MEETUP_RE,
+    onNewWindowOpenMeetupJoinUrlInApp: true,
+    chromeUserAgent: 'UA/1',
+  };
+  const meeting = 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc';
+
+  it('installs on the target but loads deep links into the ORIGINATING view, then activates it', () => {
+    const popup = fakeWc();
+    const profileView = fakeWc();
+    let activated = 0;
+    installProfileWindowOpenHandler(popup, {
+      config,
+      loadTargetWebContents: profileView,
+      activate: () => activated++,
+    });
+    assert.deepStrictEqual(popup.handler({ url: meeting }), { action: 'deny' });
+    assert.deepStrictEqual(popup.loads, []);
+    assert.deepStrictEqual(profileView.loads, [
+      { url: meeting, opts: { userAgent: 'UA/1' } },
+    ]);
+    assert.strictEqual(activated, 1);
+  });
+
+  it('defaults the load target to the target itself', () => {
+    const view = fakeWc();
+    installProfileWindowOpenHandler(view, { config });
+    view.handler({ url: meeting });
+    assert.strictEqual(view.loads.length, 1);
+  });
+
+  it('does not load into (or activate for) a destroyed originating view', () => {
+    const popup = fakeWc();
+    const profileView = fakeWc();
+    profileView.destroyed = true;
+    let activated = 0;
+    installProfileWindowOpenHandler(popup, {
+      config,
+      loadTargetWebContents: profileView,
+      activate: () => activated++,
+    });
+    assert.deepStrictEqual(popup.handler({ url: meeting }), { action: 'deny' });
+    assert.deepStrictEqual(profileView.loads, []);
+    assert.strictEqual(activated, 0);
+  });
+});

--- a/tests/unit/profileWindowOpenPolicy.test.js
+++ b/tests/unit/profileWindowOpenPolicy.test.js
@@ -67,6 +67,18 @@ describe('createProfileWindowOpenHandler', () => {
     assert.deepStrictEqual(loads, [chat]);
   });
 
+  it('degrades a malformed meetupJoinRegEx to no interception instead of throwing (user-configurable value)', () => {
+    const { handler, loads } = build({ config: { meetupJoinRegEx: '[' } });
+    // Before this policy existed, profile views had no handler at all — a
+    // bad pattern must reproduce that default (allow), never throw inside
+    // the window-open handler (an uncaught main-process exception is fatal).
+    assert.deepStrictEqual(
+      handler({ url: 'https://teams.microsoft.com/l/meetup-join/x' }),
+      { action: 'allow' }
+    );
+    assert.deepStrictEqual(loads, []);
+  });
+
   it('tolerates a missing meetupJoinRegEx and malformed details', () => {
     const { handler, loads } = build({ config: { meetupJoinRegEx: '' } });
     assert.deepStrictEqual(handler({}), { action: 'allow' });
@@ -86,6 +98,7 @@ describe('installProfileWindowOpenHandler', () => {
       },
       loadURL(url, opts) {
         this.loads.push({ url, opts });
+        return Promise.resolve(); // real Electron loadURL returns a promise
       },
       isDestroyed() {
         return this.destroyed;
@@ -121,6 +134,32 @@ describe('installProfileWindowOpenHandler', () => {
     installProfileWindowOpenHandler(view, { config });
     view.handler({ url: meeting });
     assert.strictEqual(view.loads.length, 1);
+  });
+
+  it('catches a rejecting loadURL (ERR_ABORTED is normal use) and still activates', async () => {
+    const popup = fakeWc();
+    const profileView = fakeWc();
+    let rejected;
+    profileView.loadURL = () => {
+      rejected = Promise.reject(
+        Object.assign(new Error('ERR_ABORTED (-3) loading url'), {
+          code: 'ERR_ABORTED',
+        })
+      );
+      return rejected;
+    };
+    let activated = 0;
+    installProfileWindowOpenHandler(popup, {
+      config,
+      loadTargetWebContents: profileView,
+      activate: () => activated++,
+    });
+    popup.handler({ url: meeting });
+    assert.strictEqual(activated, 1);
+    // Give the microtask queue a turn: if the rejection were unhandled, the
+    // node:test runner would fail this file with an unhandledRejection.
+    await new Promise((resolve) => setImmediate(resolve));
+    await rejected.catch(() => {});
   });
 
   it('does not load into (or activate for) a destroyed originating view', () => {


### PR DESCRIPTION
## What

The follow-up promised in the #2865 review: close the descendant-attribution gap, and give profile views a window-open policy (they had **none** — only the root window's `onNewWindow` exists).

### Descendant attribution
- Popups (`did-create-window`) and `<webview>` guests (`did-attach-webview`) spawned by a profile view attribute to that profile — **recursively** (neither the events nor `setWindowOpenHandler` are inherited by children), and drop out on their own `destroyed`.
- The root window's descendants attribute through whatever Profile 0 is at lookup time (its id is mutable across bootstrap/removal).
- **Removing a profile now unregisters and closes its live descendants.** A popup left running after removal would keep an authenticated surface for a deleted account, on a partition about to be cleared underneath it.

### Window-open policy — the provably-safe subset
A new pure `createProfileWindowOpenHandler` (+ thin installer), bound via a `bindWindowOpenHandler` DI mirroring `bindDisplayMediaHandler`:
- Teams deep links matching `meetupJoinRegEx` → denied as a popup and, with `onNewWindowOpenMeetupJoinUrlInApp`, **loaded in the originating profile view** — never the root window (the `window.open` shape of #2867) — then that profile is activated in case the link came from a *background* profile's popup. Installed on the view and every descendant, with the load target pinned to the originating view.
- **Everything else deliberately stays on Electron's default** (today's behavior). I tried porting the root's ordinary-links-external path and both independent reviewers flagged it as a regression: the Ctrl+click in-app override reads input state tracked only on the root window (dead in profile views), and `isAuthLoginUrl` is a 3-host recovery-intercept list that misses sovereign clouds (`login.microsoftonline.us/.cn`) and federated-IdP first hops — those sign-ins would have gone to the system browser with no escape hatch. That parity lands together with per-profile auth recovery (#2495 / #2867), where it can be done properly.

The module note in `profileWindowOpenPolicy.js` spells out exactly what's ported and what's deferred, so the next PR doesn't inherit a false invariant.

### Flag-off safety
Nothing here runs unless `ProfileViewManager` is constructed (flag on). `multi-account-disabled.spec.js` untouched and green.

## Testing
- `npm run lint` — clean
- `npm run test:unit` — **505 passed** (+18: policy branches incl. the deliberate allow-through and the default pattern's chat/channel breadth; installer loads into the originating view — not the popup — and activates; grandchild + guest-popup attribution; **remove (not just dispose)** unregisters and closes descendants; self-destroyed view drains its descendants; root descendants pre/post bootstrap)
- `npm run test:e2e` — 16 passed
- Manual on Linux: meeting started from a non-default profile stays in that profile; Phase 1 behavior unchanged

## Notes
Rebased onto `main` after #2865 merged (2026-09-10) — the diff now carries only this PR's two commits. Part of #2495. Next in the Phase 2 sequence: the `ProfileUnreadAggregator` (badge = sum, top-3 tooltip).






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59254928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears behaviorally sound, but the explicit async/await repository requirement must be satisfied in the new policy test before merging.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atests%2Funit%2FprofileWindowOpenPolicy.test.js%3A162%0AThe%20new%20test%20handles%20%60rejected%60%20with%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%2C%20which%20violates%20the%20repository%20directive%20to%20use%20async%2Fawait%20instead%20of%20promise%20chains.%20This%20explicit%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20assert.rejects%28rejected%2C%20%7B%20code%3A%20'ERR_ABORTED'%20%7D%29%3B%0A%60%60%60%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ismaelmartinez%2Fteams-for-linux&pr=2916&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Promise Chain Remains** <a href="https://github.com/IsmaelMartinez/teams-for-linux/pull/2916#discussion_r3986134538">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
tests/unit/profileWindowOpenPolicy.test.js:162
The new test handles `rejected` with `.catch(() => {})`, which violates the repository directive to use async/await instead of promise chains. This explicit repository requirement must be satisfied before merging.

```suggestion
    await assert.rejects(rejected, { code: 'ERR_ABORTED' });
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Tracks root and profile-view descendants throughout their lifetimes.
- Applies the window-open policy recursively while pinning navigation to the originating view.
- Activates background profiles after routed deep-link navigation.
- Replaces the previously reviewed production promise chain with an async helper and try/catch.
- Adds unit coverage for attribution, teardown, recursive descendants, malformed patterns, rejected navigation, and activation.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Profile view or root webContents] -->|creates popup or attaches webview| B[Track descendant]
    B --> C[Register sender attribution]
    B --> D[Install window-open handler]
    B --> E[Watch descendant recursively]
    D -->|Teams deep link| F[Deny popup]
    F --> G[Load URL in originating profile view]
    G --> H[Activate originating profile]
    D -->|Other URL| I[Electron default allow]
    C -->|descendant destroyed| J[Unregister attribution]
    C -->|profile removed| K[Unregister and close profile descendants]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["refactor(multi-account): deep-link navig..."](https://github.com/ismaelmartinez/teams-for-linux/commit/a5ec555b13092fe3baca64d07540e23610ac91e6)</sub>

<!-- /greptile_comment -->