### PR TITLE
fix(webauthn): survive the FIDO2 PIN landing on an exited child

### DIFF
--- a/app/webauthn/fido2Backend.js
+++ b/app/webauthn/fido2Backend.js
@@ -107,6 +107,15 @@ function spawnFido2(cmd, args, inputLines, timeoutMs, pin, signal) {
     signal?.addEventListener("abort", onAbort, { once: true });
     const stopListeningForAbort = () => signal?.removeEventListener("abort", onAbort);
 
+    // Writing into a child that is already gone gives EPIPE on the stream.
+    // Without a listener Node promotes that to an uncaught exception, and the
+    // handler in app/index.js does not recognise it as recoverable, so it takes
+    // the whole app down (#2920). The real outcome is decided by 'close' and
+    // 'error' below, so this only has to keep the failed write from throwing.
+    proc.stdin.on("error", (err) => {
+      log.debug("[WEBAUTHN] stdin write failed", { errCode: err.code });
+    });
+
     proc.stdout.on("data", (data) => { stdout += data.toString(); });
 
     proc.stderr.on("data", (data) => {
@@ -114,8 +123,10 @@ function spawnFido2(cmd, args, inputLines, timeoutMs, pin, signal) {
       stderr += chunk;
 
       // Detect the PIN prompt: "Enter PIN for /dev/hidrawN:"
-      // Only when the tool is ready for PIN input do we write it.
-      if (!pinWritten && pin && chunk.includes("Enter PIN for")) {
+      // Only when the tool is ready for PIN input do we write it. A cancel or
+      // timeout has already killed the process group, and a prompt chunk can
+      // still arrive after that, so do not offer the PIN to a dead child.
+      if (!pinWritten && pin && !rejected && !exited && chunk.includes("Enter PIN for")) {
         pinWritten = true;
         log.info("[WEBAUTHN] PIN prompt detected, writing PIN");
         proc.stdin.write(pin.trim() + "\n");

--- a/app/webauthn/fido2Backend.js
+++ b/app/webauthn/fido2Backend.js
@@ -112,8 +112,11 @@ function spawnFido2(cmd, args, inputLines, timeoutMs, pin, signal) {
     // handler in app/index.js does not recognise it as recoverable, so it takes
     // the whole app down (#2920). The real outcome is decided by 'close' and
     // 'error' below, so this only has to keep the failed write from throwing.
+    // Warn rather than debug: log.debug is off unless auth.webauthn.debug is
+    // set, and a failed parameter write means the tool never received its
+    // input, whose only other symptom is the full timeout a minute later.
     proc.stdin.on("error", (err) => {
-      log.debug("[WEBAUTHN] stdin write failed", { errCode: err.code });
+      log.warn("[WEBAUTHN] stdin write failed", { errCode: err.code });
     });
 
     proc.stdout.on("data", (data) => { stdout += data.toString(); });
@@ -123,10 +126,8 @@ function spawnFido2(cmd, args, inputLines, timeoutMs, pin, signal) {
       stderr += chunk;
 
       // Detect the PIN prompt: "Enter PIN for /dev/hidrawN:"
-      // Only when the tool is ready for PIN input do we write it. A cancel or
-      // timeout has already killed the process group, and a prompt chunk can
-      // still arrive after that, so do not offer the PIN to a dead child.
-      if (!pinWritten && pin && !rejected && !exited && chunk.includes("Enter PIN for")) {
+      // Only when the tool is ready for PIN input do we write it.
+      if (!pinWritten && pin && chunk.includes("Enter PIN for")) {
         pinWritten = true;
         log.info("[WEBAUTHN] PIN prompt detected, writing PIN");
         proc.stdin.write(pin.trim() + "\n");

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -717,6 +717,51 @@ describe('Security key cancellation', () => {
 	});
 });
 
+// ─── Writing to a child that has already gone (#2920) ────────────────────────
+
+describe('Security key PIN write against a closed pipe', () => {
+	const fido2Backend = require('../../app/webauthn/fido2Backend');
+
+	it('does not raise an uncaught exception when the PIN lands on a closed stdin', async () => {
+		// The child closes its read end before prompting, so the PIN write hits a
+		// dead pipe. With no listener on stdin that EPIPE becomes an uncaught
+		// exception, and the handler in app/index.js does not classify it as
+		// recoverable, so it calls process.exit(1) and the app disappears.
+		const uncaught = [];
+		const trap = (err) => uncaught.push(err);
+		process.on('uncaughtException', trap);
+
+		try {
+			await assert.rejects(
+				fido2Backend._spawnFido2(
+					process.execPath,
+					[
+						'-e',
+						'require("node:fs").closeSync(0);' +
+							'process.stderr.write("Enter PIN for /dev/hidraw0:");' +
+							'setTimeout(() => process.exit(1), 300);',
+					],
+					[],
+					5000,
+					'1234',
+					null,
+				),
+				/exited with code 1/,
+			);
+			// The write is asynchronous, so give the EPIPE a chance to surface.
+			await new Promise((resolve) => setTimeout(resolve, 250));
+
+			assert.deepStrictEqual(
+				uncaught.map((err) => err.code),
+				[],
+				'writing the PIN to a dead child must not throw out of the promise',
+			);
+		} finally {
+			process.off('uncaughtException', trap);
+		}
+	});
+});
+
 // ─── The allowCredentials retry loop, driven for real ─────────────────────────
 //
 // getAssertion() walks the credentials the server allowed until one is on the

--- a/tests/unit/webauthn.test.js
+++ b/tests/unit/webauthn.test.js
@@ -719,14 +719,14 @@ describe('Security key cancellation', () => {
 
 // ─── Writing to a child that has already gone (#2920) ────────────────────────
 
-describe('Security key PIN write against a closed pipe', () => {
+describe('Security key stdin writes against a closed pipe', () => {
 	const fido2Backend = require('../../app/webauthn/fido2Backend');
 
-	it('does not raise an uncaught exception when the PIN lands on a closed stdin', async () => {
-		// The child closes its read end before prompting, so the PIN write hits a
-		// dead pipe. With no listener on stdin that EPIPE becomes an uncaught
-		// exception, and the handler in app/index.js does not classify it as
-		// recoverable, so it calls process.exit(1) and the app disappears.
+	it('does not raise an uncaught exception when a write lands on a closed stdin', async () => {
+		// The child closes its read end before prompting, so both the parameter
+		// write and the PIN write hit a dead pipe. With no listener on stdin that
+		// EPIPE becomes an uncaught exception, and the handler in app/index.js
+		// does not classify it as recoverable, so it calls process.exit(1).
 		const uncaught = [];
 		const trap = (err) => uncaught.push(err);
 		process.on('uncaughtException', trap);


### PR DESCRIPTION
## Summary

`spawnFido2` writes to the child's stdin with no `error` listener on that stream. When the child's read end is already closed the write raises `EPIPE` as an uncaught exception, and `isNetworkError` in `app/index.js` only recognises Chromium `ERR_*` strings, so it falls through to `process.exit(1)` and the app disappears.

The fix is one `error` listener on `proc.stdin`, registered before either write. It logs at `warn` and swallows; the real outcome is still decided by the existing `close` and `error` handlers. `warn` rather than `debug` because `log.debug` is off unless `auth.webauthn.debug` is set, and the case that matters most is a failed *parameter* write, where the tool never receives its input and the only other symptom is the full timeout a minute later.

## Testing

- [x] `npm run lint`
- [x] `npm run test:unit` (558 pass, one new)

The new test drives the real `spawnFido2` against a child that closes fd 0 before prompting, and asserts no uncaught exception escapes. Reverting `app/webauthn/fido2Backend.js` to `main` with the test in place fails exactly that test and nothing else.

## Documentation

- [x] No IPC changes
- [x] No new PII in logs (the added line carries `err.code` only)

## Notes for reviewers

The robust trigger is a child that closes its stdin read end before we write. A cancel can also reach it, but only inside the window before Node tears the stdio streams down: killing the process group and writing ~150ms later gives `ERR_STREAM_DESTROYED` delivered to the write callback, with no uncaught exception. An earlier revision of this PR also guarded the PIN write on `!rejected && !exited`; that is dropped, because the listener alone fixes the crash, no test detected the guard's absence, and in the reported failure the child had closed stdin without exiting, so the guard would never have fired.

Known and deliberately not addressed here: `proc.stdout` and `proc.stderr` register only `data` handlers, so an error on either would take the same route. Probing could not construct one, so widening the fix would be speculative.

Found while reviewing #2917, which is not the cause but adds a second PIN-carrying spawn per discoverable sign-in and so widens the window.

closes #2920
