### PR TITLE
fix(auth): keep msal cookie persistence on when a partial auth block omits it

### DIFF
--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -331,9 +331,8 @@ async function cleanExpiredAuthCookies(windowSession, forceCleanAll = false) {
 // Set an expiration date for the cookie to promote it from a session cookie, so it survives restarts
 const MSAL_ENCRYPTION_COOKIE = 'msal.cache.encryption';
 function keepMsalEncryptionCookiePersistent(windowSession) {
-  // Treat undefined as enabled: yargs replaces object options wholesale, so a
-  // partial `auth` block in config.json (e.g. the FIDO2 setup from the docs)
-  // erases this leaf's default and must not silently disable the fix (#2722)
+  // undefined counts as enabled: a partial auth block in config.json replaces
+  // the defaults wholesale and must not silently disable this fix (#2722)
   if (config?.auth?.keepMsalCacheEncryptionCookie?.enabled === false) return;
   windowSession.cookies.on('changed', (_event, cookie, _cause, removed) => {
     if (removed || cookie.name !== MSAL_ENCRYPTION_COOKIE || !cookie.session) {

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -331,7 +331,10 @@ async function cleanExpiredAuthCookies(windowSession, forceCleanAll = false) {
 // Set an expiration date for the cookie to promote it from a session cookie, so it survives restarts
 const MSAL_ENCRYPTION_COOKIE = 'msal.cache.encryption';
 function keepMsalEncryptionCookiePersistent(windowSession) {
-  if(!config?.auth?.keepMsalCacheEncryptionCookie?.enabled) return;
+  // Treat undefined as enabled: yargs replaces object options wholesale, so a
+  // partial `auth` block in config.json (e.g. the FIDO2 setup from the docs)
+  // erases this leaf's default and must not silently disable the fix (#2722)
+  if (config?.auth?.keepMsalCacheEncryptionCookie?.enabled === false) return;
   windowSession.cookies.on('changed', (_event, cookie, _cause, removed) => {
     if (removed || cookie.name !== MSAL_ENCRYPTION_COOKIE || !cookie.session) {
       return;

--- a/tests/unit/msalCookieGuard.test.js
+++ b/tests/unit/msalCookieGuard.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+// Regression guard for issue #2722. yargs v18 replaces object-typed options
+// wholesale instead of deep-merging them, so a config.json carrying a partial
+// `auth` block (for example the FIDO2 snippet from the troubleshooting docs)
+// resolves `auth.keepMsalCacheEncryptionCookie.enabled` to undefined rather
+// than its declared default of true. The guard in
+// `keepMsalEncryptionCookiePersistent` must therefore only bail out on an
+// explicit `false`; a truthiness check silently disables the msal cookie
+// persistence for every partial-auth user and resurrects the #2681
+// lost-settings-on-restart bug.
+//
+// `app/mainAppWindow/index.js` requires the `electron` runtime, so it cannot
+// be `require`d from a plain Node test. Asserting on the source text follows
+// the same pattern as preloadModules.test.js.
+
+const INDEX_PATH = join(__dirname, '..', '..', 'app', 'mainAppWindow', 'index.js');
+
+describe('keepMsalEncryptionCookiePersistent guard', () => {
+	const source = readFileSync(INDEX_PATH, 'utf8');
+
+	it('bails out only on an explicit enabled === false', () => {
+		const explicitFalseGuard =
+			/config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled\s*===\s*false\)\s*return/;
+		assert.match(
+			source,
+			explicitFalseGuard,
+			'expected the guard to compare enabled === false so an undefined value (partial auth block, #2722) keeps the cookie persistence on',
+		);
+	});
+
+	it('does not use a truthiness guard that treats undefined as disabled', () => {
+		const truthinessGuard =
+			/!\s*config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled/;
+		assert.doesNotMatch(
+			source,
+			truthinessGuard,
+			'a truthiness guard turns the feature off for any config.json with a partial auth block (#2722)',
+		);
+	});
+});

--- a/tests/unit/msalCookieGuard.test.js
+++ b/tests/unit/msalCookieGuard.test.js
@@ -5,19 +5,10 @@ const assert = require('node:assert');
 const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 
-// Regression guard for issue #2722. yargs v18 replaces object-typed options
-// wholesale instead of deep-merging them, so a config.json carrying a partial
-// `auth` block (for example the FIDO2 snippet from the troubleshooting docs)
-// resolves `auth.keepMsalCacheEncryptionCookie.enabled` to undefined rather
-// than its declared default of true. The guard in
-// `keepMsalEncryptionCookiePersistent` must therefore only bail out on an
-// explicit `false`; a truthiness check silently disables the msal cookie
-// persistence for every partial-auth user and resurrects the #2681
-// lost-settings-on-restart bug.
-//
-// `app/mainAppWindow/index.js` requires the `electron` runtime, so it cannot
-// be `require`d from a plain Node test. Asserting on the source text follows
-// the same pattern as preloadModules.test.js.
+// Regression guard for #2722: a partial auth block in config.json resolves
+// keepMsalCacheEncryptionCookie.enabled to undefined, so the guard must only
+// bail out on an explicit false. Source-text assertion because
+// app/mainAppWindow/index.js requires the electron runtime.
 
 const INDEX_PATH = join(__dirname, '..', '..', 'app', 'mainAppWindow', 'index.js');
 
@@ -25,22 +16,18 @@ describe('keepMsalEncryptionCookiePersistent guard', () => {
 	const source = readFileSync(INDEX_PATH, 'utf8');
 
 	it('bails out only on an explicit enabled === false', () => {
-		const explicitFalseGuard =
-			/config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled\s*===\s*false\)\s*return/;
 		assert.match(
 			source,
-			explicitFalseGuard,
-			'expected the guard to compare enabled === false so an undefined value (partial auth block, #2722) keeps the cookie persistence on',
+			/config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled\s*===\s*false\)\s*return/,
+			'undefined (partial auth block, #2722) must keep the cookie persistence on',
 		);
 	});
 
 	it('does not use a truthiness guard that treats undefined as disabled', () => {
-		const truthinessGuard =
-			/!\s*config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled/;
 		assert.doesNotMatch(
 			source,
-			truthinessGuard,
-			'a truthiness guard turns the feature off for any config.json with a partial auth block (#2722)',
+			/!\s*config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled/,
+			'a truthiness guard disables the feature for any partial auth block (#2722)',
 		);
 	});
 });

--- a/tests/unit/msalCookieGuard.test.js
+++ b/tests/unit/msalCookieGuard.test.js
@@ -18,7 +18,7 @@ describe('keepMsalEncryptionCookiePersistent guard', () => {
 	it('bails out only on an explicit enabled === false', () => {
 		assert.match(
 			source,
-			/config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled\s*===\s*false\)\s*return/,
+			/config\?\.auth\?\.keepMsalCacheEncryptionCookie\?\.enabled\s*===\s*false/,
 			'undefined (partial auth block, #2722) must keep the cookie persistence on',
 		);
 	});


### PR DESCRIPTION
A config.json carrying a partial `auth` block, such as the FIDO2 snippet from the troubleshooting docs, makes yargs replace the whole `auth` object, resolving `keepMsalCacheEncryptionCookie.enabled` to `undefined` and silently disabling the #2681 fix, so all Teams settings reset on every restart. The guard now bails out only on an explicit `false`, verified against the real loader and confirmed by the reporter.

closes #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KKxYdPzT9nYmdMQdAgsf1