### PR TITLE
fix(flatpak): keep the background portal from deleting autostart entries

### DIFF
--- a/app/backgroundPortal/README.md
+++ b/app/backgroundPortal/README.md
@@ -21,6 +21,15 @@ What this does and does not change:
 - Native, deb, AppImage and snap installs are unaffected: the portal's
   background monitor only tracks Flatpak instances and `SetStatus` rejects
   host callers.
+- Autostart is left exactly as the user set it. `RequestBackground` conflates
+  background permission with autostart management, and the portal reads a
+  missing `autostart` option as an explicit `false`, so it unlinked
+  `~/.config/autostart/<app-id>.desktop` on every launch
+  ([#2936](https://github.com/IsmaelMartinez/teams-for-linux/issues/2936)).
+  There is no way to opt out of that, so the module reads the user's current
+  entry and sends the same state back, passing `commandline` from the existing
+  `Exec` so a customised launch command survives the portal's rewrite. The app
+  has no autostart feature of its own and does not enable it for anyone.
 
 Diagnostic log lines (no PII): portal version, `RequestBackground`
 response code (0 granted, 1 dismissed, 2 error), and status-set confirmation.

--- a/app/backgroundPortal/README.md
+++ b/app/backgroundPortal/README.md
@@ -26,10 +26,14 @@ What this does and does not change:
   missing `autostart` option as an explicit `false`, so it unlinked
   `~/.config/autostart/<app-id>.desktop` on every launch
   ([#2936](https://github.com/IsmaelMartinez/teams-for-linux/issues/2936)).
-  There is no way to opt out of that, so the module reads the user's current
-  entry and sends the same state back, passing `commandline` from the existing
-  `Exec` so a customised launch command survives the portal's rewrite. The app
-  has no autostart feature of its own and does not enable it for anyone.
+  There is no way to opt out of that, so the module reads whether the user has
+  autostart on, counting `Hidden=true` and `X-GNOME-Autostart-enabled=false` as
+  off, and sends the same state back. No `commandline` goes with it: the
+  portal's `rewrite_commandline` always prepends `flatpak run` and turns the
+  first element into `--command=`, so echoing back an `Exec` the portal wrote
+  double-wraps it, and `enable_autostart_sync` rebuilds the file from scratch
+  on every call regardless. The app has no autostart feature of its own and
+  does not enable it for anyone.
 
 Diagnostic log lines (no PII): portal version, `RequestBackground`
 response code (0 granted, 1 dismissed, 2 error), and status-set confirmation.

--- a/app/backgroundPortal/README.md
+++ b/app/backgroundPortal/README.md
@@ -21,14 +21,17 @@ What this does and does not change:
 - Native, deb, AppImage and snap installs are unaffected: the portal's
   background monitor only tracks Flatpak instances and `SetStatus` rejects
   host callers.
-- Autostart is left exactly as the user set it. `RequestBackground` conflates
-  background permission with autostart management, and the portal reads a
-  missing `autostart` option as an explicit `false`, so it unlinked
+- Autostart is never switched on or off behind the user's back.
+  `RequestBackground` conflates background permission with autostart
+  management, and the portal reads a missing `autostart` option as an
+  explicit `false`, so it unlinked
   `~/.config/autostart/<app-id>.desktop` on every launch
   ([#2936](https://github.com/IsmaelMartinez/teams-for-linux/issues/2936)).
   There is no way to opt out of that, so the module reads whether the user has
   autostart on, counting `Hidden=true` and `X-GNOME-Autostart-enabled=false` as
-  off, and sends the same state back. No `commandline` goes with it: the
+  off, and sends the same state back. An entry that is present but disabled is
+  still removed, because the option is a boolean and the only way to keep the
+  file would be to switch autostart back on. No `commandline` goes with it: the
   portal's `rewrite_commandline` always prepends `flatpak run` and turns the
   first element into `--command=`, so echoing back an `Exec` the portal wrote
   double-wraps it, and `enable_autostart_sync` rebuilds the file from scratch

--- a/app/backgroundPortal/index.js
+++ b/app/backgroundPortal/index.js
@@ -36,10 +36,12 @@ const STATUS_MESSAGE = "Running in background";
 // The response may sit behind a user-facing permission dialog, so the wait is
 // generous. After the timeout we only stop listening; nothing is aborted.
 const RESPONSE_TIMEOUT_MS = 30000;
-// Desktop-entry Exec line, and the field codes the spec allows inside it which
-// are not part of the command itself.
-const EXEC_LINE = /^Exec=(.*)$/m;
-const DESKTOP_FIELD_CODES = /%[uUfFickdDnNvm]/g;
+// An autostart entry is switched off in place rather than deleted: GNOME
+// writes X-GNOME-Autostart-enabled=false, and the spec's Hidden=true means the
+// same thing. Reading either as "on" would re-enable autostart for someone who
+// deliberately turned it off.
+const HIDDEN_LINE = /^Hidden\s*=\s*(\S*)/m;
+const GNOME_AUTOSTART_LINE = /^X-GNOME-Autostart-enabled\s*=\s*(\S*)/m;
 
 /**
  * Request the background permission and, when granted on a v2+ portal, set
@@ -120,7 +122,7 @@ function getPortalVersion(sessionBus, callback) {
 }
 
 /**
- * Read the user's current autostart entry, if any.
+ * Whether the user currently has autostart switched on.
  *
  * The portal treats a missing `autostart` option as an explicit false: its
  * `autostart_requested` flag is initialised to FALSE and `g_variant_lookup`
@@ -130,9 +132,16 @@ function getPortalVersion(sessionBus, callback) {
  * autostart intent, so we read whatever the user already has and hand the same
  * state back (#2936).
  *
- * @returns {{commandline: string[]}|null} null when autostart is not enabled
+ * No `commandline` is sent with it. The portal's `rewrite_commandline` always
+ * prepends `flatpak run` and turns the first element into `--command=`, so
+ * handing back an Exec the portal itself wrote double-wraps it. Left out, the
+ * portal writes its own correct `flatpak run <app-id>`, and since
+ * `enable_autostart_sync` rebuilds the file from scratch on every call a
+ * hand-edited Exec never survived regardless.
+ *
+ * @returns {boolean}
  */
-function readAutostartEntry() {
+function isAutostartEnabled() {
   const fs = require("node:fs");
   const os = require("node:os");
   const path = require("node:path");
@@ -149,17 +158,14 @@ function readAutostartEntry() {
     contents = fs.readFileSync(file, "utf8");
   } catch {
     // No entry is the ordinary case, and means autostart is already off.
-    return null;
+    return false;
   }
 
-  // Granting autostart makes the portal rewrite the file from `commandline`,
-  // so carry the existing Exec across or flags such as --minimized are lost.
-  const exec = EXEC_LINE.exec(contents)?.[1] ?? "";
-  const commandline = exec
-    .replace(DESKTOP_FIELD_CODES, " ")
-    .split(/\s+/)
-    .filter(Boolean);
-  return { commandline };
+  // The portal writes a single [Desktop Entry] group, so scanning the whole
+  // file for these two keys is enough.
+  if (HIDDEN_LINE.exec(contents)?.[1] === "true") return false;
+  if (GNOME_AUTOSTART_LINE.exec(contents)?.[1] === "false") return false;
+  return true;
 }
 
 /**
@@ -170,16 +176,12 @@ function readAutostartEntry() {
  */
 function requestBackground(sessionBus, callback) {
   const token = `tfl${Date.now().toString(36)}`;
-  const autostart = readAutostartEntry();
   const options = [
     ["handle_token", ["s", token]],
     ["reason", ["s", REQUEST_REASON]],
     // Always sent. Leaving it out is what deleted the entry (#2936).
-    ["autostart", ["b", autostart !== null]],
+    ["autostart", ["b", isAutostartEnabled()]],
   ];
-  if (autostart?.commandline.length) {
-    options.push(["commandline", ["as", autostart.commandline]]);
-  }
   const matchRule = `type='signal',interface='${REQUEST_INTERFACE}',member='Response'`;
   let done = false;
 

--- a/app/backgroundPortal/index.js
+++ b/app/backgroundPortal/index.js
@@ -36,6 +36,10 @@ const STATUS_MESSAGE = "Running in background";
 // The response may sit behind a user-facing permission dialog, so the wait is
 // generous. After the timeout we only stop listening; nothing is aborted.
 const RESPONSE_TIMEOUT_MS = 30000;
+// Desktop-entry Exec line, and the field codes the spec allows inside it which
+// are not part of the command itself.
+const EXEC_LINE = /^Exec=(.*)$/m;
+const DESKTOP_FIELD_CODES = /%[uUfFickdDnNvm]/g;
 
 /**
  * Request the background permission and, when granted on a v2+ portal, set
@@ -116,6 +120,49 @@ function getPortalVersion(sessionBus, callback) {
 }
 
 /**
+ * Read the user's current autostart entry, if any.
+ *
+ * The portal treats a missing `autostart` option as an explicit false: its
+ * `autostart_requested` flag is initialised to FALSE and `g_variant_lookup`
+ * leaves it untouched when the key is absent, after which
+ * `enable_autostart_sync` runs on every granted request and unlinks the entry.
+ * There is no way to ask for background permission without also declaring an
+ * autostart intent, so we read whatever the user already has and hand the same
+ * state back (#2936).
+ *
+ * @returns {{commandline: string[]}|null} null when autostart is not enabled
+ */
+function readAutostartEntry() {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+
+  const file = path.join(
+    os.homedir(),
+    ".config",
+    "autostart",
+    `${process.env.FLATPAK_ID}.desktop`
+  );
+
+  let contents;
+  try {
+    contents = fs.readFileSync(file, "utf8");
+  } catch {
+    // No entry is the ordinary case, and means autostart is already off.
+    return null;
+  }
+
+  // Granting autostart makes the portal rewrite the file from `commandline`,
+  // so carry the existing Exec across or flags such as --minimized are lost.
+  const exec = EXEC_LINE.exec(contents)?.[1] ?? "";
+  const commandline = exec
+    .replace(DESKTOP_FIELD_CODES, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  return { commandline };
+}
+
+/**
  * Call RequestBackground and wait for the portal's asynchronous Response
  * signal. The signal arrives on a Request object path ending in our
  * handle_token, which is how the reply is matched without computing the
@@ -123,6 +170,16 @@ function getPortalVersion(sessionBus, callback) {
  */
 function requestBackground(sessionBus, callback) {
   const token = `tfl${Date.now().toString(36)}`;
+  const autostart = readAutostartEntry();
+  const options = [
+    ["handle_token", ["s", token]],
+    ["reason", ["s", REQUEST_REASON]],
+    // Always sent. Leaving it out is what deleted the entry (#2936).
+    ["autostart", ["b", autostart !== null]],
+  ];
+  if (autostart?.commandline.length) {
+    options.push(["commandline", ["as", autostart.commandline]]);
+  }
   const matchRule = `type='signal',interface='${REQUEST_INTERFACE}',member='Response'`;
   let done = false;
 
@@ -178,10 +235,7 @@ function requestBackground(sessionBus, callback) {
             // Empty parent window: the request is not anchored to a window,
             // which the portal accepts.
             "",
-            [
-              ["handle_token", ["s", token]],
-              ["reason", ["s", REQUEST_REASON]],
-            ],
+            options,
           ],
         },
         (error) => {

--- a/tests/unit/backgroundPortal.test.js
+++ b/tests/unit/backgroundPortal.test.js
@@ -93,12 +93,18 @@ describe('backgroundPortal', () => {
 		} else {
 			process.env.HOME = originalHome;
 		}
+		while (tempHomes.length) {
+			fs.rmSync(tempHomes.pop(), { recursive: true, force: true });
+		}
 	});
+
+	const tempHomes = [];
 
 	// os.homedir() reads $HOME on POSIX, so pointing it at a temp tree is
 	// enough to stand in for the user's real autostart directory.
 	function withTempHome(entryContents) {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tfl-autostart-'));
+		tempHomes.push(dir);
 		if (entryContents !== null) {
 			const autostartDir = path.join(dir, '.config', 'autostart');
 			fs.mkdirSync(autostartDir, { recursive: true });
@@ -185,7 +191,7 @@ describe('backgroundPortal', () => {
 		assert.ok(!options.some(([key]) => key === 'commandline'));
 	});
 
-	it('reports autostart on, with the existing Exec, when the user has an entry', async () => {
+	it('reports autostart on when the user has an entry', async () => {
 		pretendFlatpakOnLinux();
 		withTempHome(
 			'[Desktop Entry]\nType=Application\n' +
@@ -201,20 +207,47 @@ describe('backgroundPortal', () => {
 			options.find(([key]) => key === 'autostart'),
 			['autostart', ['b', true]]
 		);
-		assert.deepStrictEqual(
-			options.find(([key]) => key === 'commandline'),
-			[
-				'commandline',
-				[
-					'as',
-					[
-						'flatpak',
-						'run',
-						'com.github.IsmaelMartinez.teams_for_linux',
-						'--minimized',
-					],
-				],
-			]
-		);
 	});
+
+	// The portal's rewrite_commandline prepends `flatpak run` and turns the
+	// first element into `--command=`, so echoing back an Exec it wrote itself
+	// double-wraps it. Leaving the key out makes the portal write its own.
+	it('never sends a commandline alongside an enabled entry', async () => {
+		pretendFlatpakOnLinux();
+		withTempHome(
+			'[Desktop Entry]\nType=Application\n' +
+				'Exec=flatpak run com.github.IsmaelMartinez.teams_for_linux --minimized %U\n'
+		);
+		const bus = makeFakeBus({ portalVersion: 2, responseCode: 0 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+		assert.ok(!optionsOf(bus).some(([key]) => key === 'commandline'));
+	});
+
+	// An entry the user switched off is still on disk. Reading it as "on" would
+	// hand the portal a true and turn autostart back on behind their back.
+	for (const [label, disablingLine] of [
+		['X-GNOME-Autostart-enabled=false', 'X-GNOME-Autostart-enabled=false'],
+		['Hidden=true', 'Hidden=true'],
+	]) {
+		it(`reports autostart off for an entry disabled with ${label}`, async () => {
+			pretendFlatpakOnLinux();
+			withTempHome(
+				'[Desktop Entry]\nType=Application\n' +
+					'Exec=flatpak run com.github.IsmaelMartinez.teams_for_linux\n' +
+					`${disablingLine}\n`
+			);
+			const bus = makeFakeBus({ portalVersion: 2, responseCode: 0 });
+			assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+			await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+			assert.deepStrictEqual(
+				optionsOf(bus).find(([key]) => key === 'autostart'),
+				['autostart', ['b', false]]
+			);
+		});
+	}
 });

--- a/tests/unit/backgroundPortal.test.js
+++ b/tests/unit/backgroundPortal.test.js
@@ -1,6 +1,9 @@
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const MODULE_PATH = require.resolve('../../app/backgroundPortal');
 const DBUS_PATH = require.resolve('@homebridge/dbus-native');
@@ -68,6 +71,7 @@ async function waitFor(predicate) {
 
 describe('backgroundPortal', () => {
 	const originalFlatpakId = process.env.FLATPAK_ID;
+	const originalHome = process.env.HOME;
 	const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 	beforeEach(() => {
@@ -84,7 +88,31 @@ describe('backgroundPortal', () => {
 		} else {
 			process.env.FLATPAK_ID = originalFlatpakId;
 		}
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
 	});
+
+	// os.homedir() reads $HOME on POSIX, so pointing it at a temp tree is
+	// enough to stand in for the user's real autostart directory.
+	function withTempHome(entryContents) {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tfl-autostart-'));
+		if (entryContents !== null) {
+			const autostartDir = path.join(dir, '.config', 'autostart');
+			fs.mkdirSync(autostartDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(autostartDir, 'com.github.IsmaelMartinez.teams_for_linux.desktop'),
+				entryContents
+			);
+		}
+		process.env.HOME = dir;
+	}
+
+	function optionsOf(bus) {
+		return bus.calls.find((c) => c.member === 'RequestBackground').body[1];
+	}
 
 	function pretendFlatpakOnLinux() {
 		Object.defineProperty(process, 'platform', {
@@ -137,5 +165,56 @@ describe('backgroundPortal', () => {
 		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
 
 		assert.ok(!bus.calls.some((c) => c.member === 'SetStatus'));
+	});
+
+	// #2936: the portal reads a missing `autostart` as false and unlinks the
+	// user's entry on every granted request, so the key must always be sent.
+	it('always sends an explicit autostart option', async () => {
+		pretendFlatpakOnLinux();
+		withTempHome(null);
+		const bus = makeFakeBus({ portalVersion: 2, responseCode: 0 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+		const options = optionsOf(bus);
+		assert.deepStrictEqual(
+			options.find(([key]) => key === 'autostart'),
+			['autostart', ['b', false]]
+		);
+		assert.ok(!options.some(([key]) => key === 'commandline'));
+	});
+
+	it('reports autostart on, with the existing Exec, when the user has an entry', async () => {
+		pretendFlatpakOnLinux();
+		withTempHome(
+			'[Desktop Entry]\nType=Application\n' +
+				'Exec=flatpak run com.github.IsmaelMartinez.teams_for_linux --minimized %U\n'
+		);
+		const bus = makeFakeBus({ portalVersion: 2, responseCode: 0 });
+		assert.strictEqual(loadWithFakeBus(bus).init(), true);
+
+		await waitFor(() => bus.calls.some((c) => c.member === 'removeMatch'));
+
+		const options = optionsOf(bus);
+		assert.deepStrictEqual(
+			options.find(([key]) => key === 'autostart'),
+			['autostart', ['b', true]]
+		);
+		assert.deepStrictEqual(
+			options.find(([key]) => key === 'commandline'),
+			[
+				'commandline',
+				[
+					'as',
+					[
+						'flatpak',
+						'run',
+						'com.github.IsmaelMartinez.teams_for_linux',
+						'--minimized',
+					],
+				],
+			]
+		);
 	});
 });


### PR DESCRIPTION
The portal reads a missing `autostart` option as an explicit `false` and unlinks `~/.config/autostart/<app-id>.desktop` on every granted request, so asking for background permission has been silently deleting the user's autostart entry on each launch since 2.17.0. There is no way to request background permission without declaring an autostart intent, so this reads whether autostart is actually on, counting `Hidden=true` and `X-GNOME-Autostart-enabled=false` as off, and hands the same state back.

No `commandline` is sent with it. The portal's `rewrite_commandline` always prepends `flatpak run` and turns the first element into `--command=`, so echoing back an `Exec` the portal wrote itself double-wraps the entry. Left out, the portal writes its own correct command, and `enable_autostart_sync` rebuilds the file from scratch on every call regardless, so a hand-edited `Exec` never survived either way.

Verified by restoring the previous implementation underneath the new tests: all three fail without the fix. Lint and the 622-test unit suite are green.

Not verified against a live portal. The module is gated on `FLATPAK_ID` and we do not build Flatpaks on PRs, so the deb and AppImage artifacts here will not exercise this path at all. It needs testing from a Flatpak build before I would trust it.

closes #2936




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59416684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<h3>Summary</h3>

- Reads the application’s desktop entry and treats `Hidden=true` or `X-GNOME-Autostart-enabled=false` as disabled.
- Always sends the resulting boolean as the portal’s `autostart` option.
- Removes `Exec` parsing and avoids sending `commandline`, resolving the previously reported argument-boundary issue.
- Adds unit coverage and documents the portal behavior and limitations.

<sub>Reviews (3) · Last reviewed commit: ["docs(flatpak): say what happens to a dis..."](https://github.com/ismaelmartinez/teams-for-linux/commit/71d5898f7295f96a933158adde3df457ae762b26)</sub>

<!-- /greptile_comment -->