### PR TITLE
fix(snap): stop the desktop launcher aborting before Electron starts

### DIFF
--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -45,6 +45,20 @@ When the app feels slow or heavy, seven configuration options are the first-line
     *   Download the latest installer from the official GitHub releases page.
     *   Perform a clean installation.
 
+#### Issue: Snap exits immediately with status 1 and no output
+
+**Description:** `snap run teams-for-linux` returns exit code 1 with completely empty stdout and stderr. No window appears and nothing is written to the journal. Affects snap revisions from 2396 onwards on `core22` ([#2946](https://github.com/IsmaelMartinez/teams-for-linux/issues/2946)).
+
+**Potential Causes:**
+*   The snap launcher runs a desktop-integration script under `set -e` that calls `rmdir` on an XDG user directory. `rmdir` fails on a non-empty directory, its error is discarded, and the launcher aborts before Electron ever starts.
+*   Triggered when `~/.config/user-dirs.locale` is missing, or when an XDG user directory (Documents, Downloads, and so on) points somewhere the snap cannot read, such as a path under `/mnt` that needs the `removable-media` interface.
+
+**Solutions/Workarounds:**
+
+1.  **Update the snap.** Revisions built after this issue was fixed launch normally: `sudo snap refresh teams-for-linux`.
+
+2.  **If you cannot update yet**, either create the missing locale file with `touch ~/.config/user-dirs.locale`, connect the interface your XDG directories need with `sudo snap connect teams-for-linux:removable-media`, or roll back with `sudo snap revert teams-for-linux`.
+
 #### Issue: No History after Electron version update
 
 **Description:** When updating the Electron version, the channel history may sometimes disappear. This issue is typically related to a change in the user agent.

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -3,6 +3,7 @@ const { chmod } = require("node:fs/promises");
 const path = require("node:path");
 const { generateReleaseInfo } = require("./generateReleaseInfo");
 const { generateDebianChangelog } = require("./generateDebianChangelog");
+const { patchSnapDesktopLauncher } = require("./patchSnapDesktopLauncher");
 
 function getAppFileName(context) {
   const productFileName = context.packager.appInfo.productFilename;
@@ -26,6 +27,7 @@ exports.default = async function afterPack(context) {
     // Ensure release info is generated for Linux publishing
     if (context.electronPlatformName === "linux") {
       await generateReleaseInfoForLinux();
+      await patchSnapLauncherIfNeeded(context);
     }
 
     const appPath = `${context.appOutDir}/${getAppFileName(context)}`;
@@ -39,6 +41,15 @@ exports.default = async function afterPack(context) {
     process.exit(1);
   }
 };
+
+// afterPack runs inside doPack, before any target builds, so this is the last
+// point at which the snap's launcher scripts can still be fixed up (#2946).
+async function patchSnapLauncherIfNeeded(context) {
+  if (!context.targets.some((target) => target.name === "snap")) {
+    return;
+  }
+  await patchSnapDesktopLauncher(context.arch);
+}
 
 async function generateReleaseInfoForLinux() {
   try {

--- a/scripts/patchSnapDesktopLauncher.js
+++ b/scripts/patchSnapDesktopLauncher.js
@@ -1,0 +1,211 @@
+"use strict";
+
+/**
+ * Build-time workaround for the silent snap launch failure in issue #2946.
+ *
+ * With `build.snap.base = "core22"`, electron-builder 26.15.7 packs snaps through
+ * `app-builder-lib/out/targets/snap/coreLegacy.js`, which unconditionally makes
+ * `command.sh` run the snapcraft desktop-helper chain:
+ *
+ *   #!/bin/bash -e
+ *   exec "$SNAP/desktop-init.sh" "$SNAP/desktop-common.sh" \
+ *        "$SNAP/desktop-gnome-specific.sh" "$SNAP/teams-for-linux" ...
+ *
+ * `desktop-common.sh` also starts with `#!/bin/bash -e` and contains:
+ *
+ *   if [ -d "$HOME/$b" ]; then
+ *     rmdir "$HOME/$b" 2> /dev/null
+ *   fi
+ *
+ * `rmdir` returns 1 on a non-empty directory, `2> /dev/null` throws the message
+ * away, and `set -e` then kills the launcher before Electron is ever exec'd. The
+ * snap exits 1 with completely empty output — exactly what #2946 reports.
+ *
+ * `$b` is computed with `realpath --relative-to="$HOME"` against the snap's
+ * private `$HOME`, so an XDG user directory living outside it (for example on
+ * `/mnt`) yields `../../../..`, and `"$HOME/$b"` resolves straight back out to
+ * the user's *real* directory. The `rmdir` plus the `ln -s` that follows it can
+ * therefore replace a real user directory with a self-referential symlink, so
+ * this patch also skips entries whose relative path escapes `$HOME`.
+ *
+ * Why patch at build time rather than fixing it upstream or in config:
+ *
+ *   - `desktop-common.sh` is not ours. For arm64 it comes from
+ *     `app-builder-lib/templates/snap/`; for x64 and armv7l it comes from the
+ *     `snap-template-electron-4.0-*` tarball that electron-builder downloads
+ *     from electron-builder-binaries. That tarball is a frozen 2019 release, so
+ *     an electron-builder upgrade would not fix x64/armv7l anyway.
+ *   - electron-builder is deliberately frozen at 26.15.7 (see
+ *     `.github/dependabot.yml`, refs #2756, #2684, #2905) and the core24
+ *     migration that would take a different code path was reverted in #2906.
+ *   - `useTemplateApp: false` does not avoid the chain — `buildWithoutTemplate`
+ *     copies the same three scripts into the snap.
+ *
+ * Because electron-builder is pinned, the internal module paths and template
+ * checksums referenced below are stable; `assertTemplateStillMatches` fails the
+ * build loudly if they ever stop matching.
+ */
+
+const { readFile, writeFile, chmod } = require("node:fs/promises");
+const path = require("node:path");
+const { Arch } = require("builder-util");
+
+const APP_BUILDER_LIB_DIR = path.dirname(require.resolve("app-builder-lib/package.json"));
+const CORE_LEGACY_PATH = path.join(APP_BUILDER_LIB_DIR, "out", "targets", "snap", "coreLegacy.js");
+const BUNDLED_TEMPLATE_SCRIPT = path.join(APP_BUILDER_LIB_DIR, "templates", "snap", "desktop-common.sh");
+
+// Mirrors SNAP_TEMPLATES in coreLegacy.js. Kept in step by assertTemplateStillMatches().
+const SNAP_TEMPLATES = {
+  amd64: {
+    releaseName: "snap-template-4.0-2",
+    filenameWithExt: "snap-template-electron-4.0-2-amd64.tar.7z",
+    checksum: "5e3ab4e09364ac06f0072b1c2dab9138318c933f6b2c7374f893b5ec44d19e6f",
+  },
+  armhf: {
+    releaseName: "snap-template-4.0-1",
+    filenameWithExt: "snap-template-electron-4.0-1-armhf.tar.7z",
+    checksum: "6f7553e904f4e043bc3019f0899d05e01a283b00b61fec22e932296490e3be6b",
+  },
+};
+
+// Only these two arches take the downloaded-template path (coreLegacy.js:59).
+// arm64 is packed by snapcraft from the scripts bundled in app-builder-lib.
+const TEMPLATE_ARCH_BY_ARCH = {
+  [Arch.x64]: "amd64",
+  [Arch.armv7l]: "armhf",
+};
+
+const PATCH_MARKER = "teams-for-linux #2946";
+
+// The exact block shipped by both copies of desktop-common.sh. Matched literally
+// (indexOf, no regex) so a changed upstream script fails loudly instead of
+// being silently half-patched.
+const ORIGINAL_BLOCK = [
+  '    b="$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")"',
+  '    if [ -e "$REALHOME/$b" ]; then',
+  '      if [ -d "$HOME/$b" ]; then',
+  '        rmdir "$HOME/$b" 2> /dev/null',
+  "      fi",
+].join("\n");
+
+const PATCHED_BLOCK = [
+  '    b="$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")"',
+  "    # " + PATCH_MARKER + ': $b is relative to the snap private $HOME, so an XDG',
+  '    # user dir outside it yields "../..", and "$HOME/$b" escapes back to the real',
+  "    # directory the rmdir/ln pair below would then clobber. Skip those entries.",
+  '    if [ "$b" = ".." ] || [ "${b#../}" != "$b" ]; then',
+  "      continue",
+  "    fi",
+  '    if [ -e "$REALHOME/$b" ]; then',
+  '      if [ -d "$HOME/$b" ]; then',
+  "        # " + PATCH_MARKER + ": rmdir exits 1 on a non-empty directory and this",
+  "        # script runs under `set -e`, which killed the launcher before Electron",
+  "        # was exec'd — the snap exited 1 with no output at all.",
+  '        rmdir "$HOME/$b" 2> /dev/null || true',
+  "      fi",
+].join("\n");
+
+/**
+ * Rewrites the XDG-links block in one desktop-common.sh. Idempotent: a file that
+ * already carries the marker is left alone. Throws if the expected block is
+ * absent, so an upstream change can never turn this into a silent no-op.
+ */
+async function patchScript(scriptPath) {
+  let source;
+  try {
+    source = await readFile(scriptPath, "utf8");
+  } catch (error) {
+    throw new Error(`#2946 snap launcher patch: cannot read ${scriptPath}: ${error.message}`, { cause: error });
+  }
+
+  if (source.includes(PATCH_MARKER)) {
+    console.log(`   already patched: ${scriptPath}`);
+    return false;
+  }
+
+  const at = source.indexOf(ORIGINAL_BLOCK);
+  if (at < 0) {
+    throw new Error(
+      `#2946 snap launcher patch: the expected rmdir block was not found in ${scriptPath}. ` +
+        "electron-builder's snap launcher changed — re-check the workaround before building.",
+    );
+  }
+  if (source.indexOf(ORIGINAL_BLOCK, at + ORIGINAL_BLOCK.length) >= 0) {
+    throw new Error(`#2946 snap launcher patch: the rmdir block appears more than once in ${scriptPath}.`);
+  }
+
+  const patched = source.slice(0, at) + PATCHED_BLOCK + source.slice(at + ORIGINAL_BLOCK.length);
+  await writeFile(scriptPath, patched, "utf8");
+  await chmod(scriptPath, 0o755);
+  console.log(`   patched: ${scriptPath}`);
+  return true;
+}
+
+/**
+ * Fails the build if coreLegacy.js no longer declares the template release and
+ * checksum this script hard-codes, which would mean we are patching a cache
+ * directory electron-builder does not use.
+ */
+async function assertTemplateStillMatches(template) {
+  const source = await readFile(CORE_LEGACY_PATH, "utf8");
+  for (const literal of [template.releaseName, template.filenameWithExt, template.checksum]) {
+    if (!source.includes(literal)) {
+      throw new Error(
+        `#2946 snap launcher patch: "${literal}" is no longer declared in ${CORE_LEGACY_PATH}. ` +
+          "The snap template moved — update SNAP_TEMPLATES in this script.",
+      );
+    }
+  }
+}
+
+/**
+ * Materialises the snap template into electron-builder's own cache (the same
+ * call coreLegacy.js makes) and patches the desktop-common.sh inside it. The
+ * cache is validated on file count only, so the patched copy is reused by the
+ * build that follows.
+ */
+async function patchDownloadedTemplate(templateArch) {
+  const template = SNAP_TEMPLATES[templateArch];
+  await assertTemplateStillMatches(template);
+
+  // Required lazily so unit tests can exercise patchScript() without pulling in
+  // electron-builder's internals.
+  const { downloadBuilderToolset } = require("app-builder-lib/out/util/electronGet");
+  const templateDir = await downloadBuilderToolset({
+    releaseName: template.releaseName,
+    filenameWithExt: template.filenameWithExt,
+    checksums: { [template.filenameWithExt]: template.checksum },
+    githubOrgRepo: "electron-userland/electron-builder-binaries",
+  });
+
+  await patchScript(path.join(templateDir, "desktop-common.sh"));
+}
+
+/**
+ * Patches every desktop-common.sh the snap build for `arch` can consume.
+ *
+ * @param {number} arch electron-builder Arch enum value.
+ */
+async function patchSnapDesktopLauncher(arch) {
+  console.log("🔄 Patching snap desktop launcher (#2946)...");
+
+  // Used by the no-template path (arm64, and any build with custom packages).
+  await patchScript(BUNDLED_TEMPLATE_SCRIPT);
+
+  // Used by the template path (x64, armv7l).
+  const templateArch = TEMPLATE_ARCH_BY_ARCH[arch];
+  if (templateArch !== undefined) {
+    await patchDownloadedTemplate(templateArch);
+  }
+
+  console.log("✅ Snap desktop launcher patched");
+}
+
+module.exports = {
+  patchSnapDesktopLauncher,
+  patchScript,
+  BUNDLED_TEMPLATE_SCRIPT,
+  ORIGINAL_BLOCK,
+  PATCHED_BLOCK,
+  PATCH_MARKER,
+};

--- a/scripts/patchSnapDesktopLauncher.js
+++ b/scripts/patchSnapDesktopLauncher.js
@@ -70,10 +70,10 @@ const SNAP_TEMPLATES = {
 
 // Only these two arches take the downloaded-template path (coreLegacy.js:59).
 // arm64 is packed by snapcraft from the scripts bundled in app-builder-lib.
-const TEMPLATE_ARCH_BY_ARCH = {
-  [Arch.x64]: "amd64",
-  [Arch.armv7l]: "armhf",
-};
+const TEMPLATE_ARCH_BY_ARCH = new Map([
+  [Arch.x64, "amd64"],
+  [Arch.armv7l, "armhf"],
+]);
 
 const PATCH_MARKER = "teams-for-linux #2946";
 
@@ -130,7 +130,7 @@ async function patchScript(scriptPath) {
         "electron-builder's snap launcher changed — re-check the workaround before building.",
     );
   }
-  if (source.indexOf(ORIGINAL_BLOCK, at + ORIGINAL_BLOCK.length) >= 0) {
+  if (source.includes(ORIGINAL_BLOCK, at + ORIGINAL_BLOCK.length)) {
     throw new Error(`#2946 snap launcher patch: the rmdir block appears more than once in ${scriptPath}.`);
   }
 
@@ -193,9 +193,8 @@ async function patchSnapDesktopLauncher(arch) {
   await patchScript(BUNDLED_TEMPLATE_SCRIPT);
 
   // Used by the template path (x64, armv7l).
-  const templateArch = TEMPLATE_ARCH_BY_ARCH[arch];
-  if (templateArch !== undefined) {
-    await patchDownloadedTemplate(templateArch);
+  if (TEMPLATE_ARCH_BY_ARCH.has(arch)) {
+    await patchDownloadedTemplate(TEMPLATE_ARCH_BY_ARCH.get(arch));
   }
 
   console.log("✅ Snap desktop launcher patched");

--- a/tests/unit/snapDesktopLauncherPatch.test.js
+++ b/tests/unit/snapDesktopLauncherPatch.test.js
@@ -1,0 +1,234 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const {
+	mkdirSync,
+	mkdtempSync,
+	lstatSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, relative, resolve } = require('node:path');
+
+const {
+	patchScript,
+	BUNDLED_TEMPLATE_SCRIPT,
+	ORIGINAL_BLOCK,
+	PATCHED_BLOCK,
+	PATCH_MARKER,
+} = require('../../scripts/patchSnapDesktopLauncher');
+
+// Regression guard for #2946. electron-builder's core22 snap launcher runs
+// desktop-common.sh under `set -e` with an unguarded `rmdir`, so the snap exits
+// 1 with completely empty output. scripts/patchSnapDesktopLauncher.js fixes the
+// script at build time; these tests exercise the real launcher, not a fixture.
+
+// A build may already have patched the copy in node_modules, so restore the
+// pristine block first. String replace, first occurrence only, no regex.
+function unpatchedSource() {
+	const source = readFileSync(BUNDLED_TEMPLATE_SCRIPT, 'utf8');
+	return source.includes(PATCH_MARKER) ? source.replace(PATCHED_BLOCK, ORIGINAL_BLOCK) : source;
+}
+
+function makeTempDir() {
+	return mkdtempSync(join(tmpdir(), 'snap-launcher-'));
+}
+
+function writeScript(dir, source) {
+	const file = join(dir, 'desktop-common.sh');
+	writeFileSync(file, source, { mode: 0o755 });
+	return file;
+}
+
+// The launcher calls `realpath --relative-to`, which is GNU-only. Shim it with
+// node so the fragment behaves identically on every developer machine and in CI.
+function writeRealpathShim(dir) {
+	const binDir = join(dir, 'bin');
+	mkdirSync(binDir);
+	const shim = [
+		'#!/bin/sh',
+		'exec node -e \'const p=require("path");const a=process.argv.slice(1);' +
+			'let rel=null;const paths=[];' +
+			'for(const x of a){if(x.startsWith("--relative-to="))rel=x.slice(14);else paths.push(x);}' +
+			'const t=p.resolve(paths[0]);console.log(rel?p.relative(p.resolve(rel),t):t);\' "$@"',
+		'',
+	].join('\n');
+	writeFileSync(join(binDir, 'realpath'), shim, { mode: 0o755 });
+	return binDir;
+}
+
+// Slice the whole "Create links for user-dirs.dirs" section out of the launcher
+// with two literal lookups, then run it exactly as the snap does: bash -e.
+function extractXdgLinksBlock(source) {
+	const start = source.indexOf('# Create links for user-dirs.dirs');
+	assert.ok(start >= 0, 'launcher no longer has the user-dirs section');
+	const end = source.indexOf('\n# If detect wayland server socket', start);
+	assert.ok(end > start, 'launcher no longer has the wayland section after it');
+	return source.slice(start, end);
+}
+
+/**
+ * Runs the XDG-links block under `bash -e` against a throwaway home.
+ *
+ * @param {object} options
+ * @param {string} options.scriptPath desktop-common.sh to take the block from.
+ * @param {"inside"|"escape"} options.placement where the XDG user dir lives.
+ * @param {boolean} options.emptyXdgDir leave the XDG dir empty (rmdir succeeds).
+ */
+function runXdgLinksBlock({ scriptPath, placement, emptyXdgDir = false }) {
+	const root = makeTempDir();
+	try {
+		const realHome = join(root, 'fs', 'home', 'user');
+		const snapHome = join(realHome, 'snap', 'teams-for-linux', '2396');
+		mkdirSync(snapHome, { recursive: true });
+
+		const xdgDir =
+			placement === 'escape'
+				? join(root, 'fs', 'mnt', 'hdd', 'documents')
+				: join(snapHome, 'Documents');
+		mkdirSync(xdgDir, { recursive: true });
+		if (!emptyXdgDir) {
+			writeFileSync(join(xdgDir, 'keepme'), 'x');
+		}
+
+		if (placement === 'escape') {
+			// `[ -e "$REALHOME/$b" ]` overshoots the common ancestor; on the
+			// reporter's box it clamped at /. Create what it resolves to so the
+			// guard passes, reproducing their trace.
+			mkdirSync(resolve(realHome, relative(snapHome, xdgDir)), { recursive: true });
+		} else {
+			mkdirSync(join(realHome, 'Documents'), { recursive: true });
+		}
+
+		const fragment = join(root, 'fragment.sh');
+		writeFileSync(
+			fragment,
+			[
+				'#!/bin/bash -e',
+				`HOME="${snapHome}"`,
+				`REALHOME="${realHome}"`,
+				'needs_xdg_links=true',
+				`XDG_SPECIAL_DIRS_PATHS=("${xdgDir}")`,
+				'XDG_SPECIAL_DIRS=(XDG_DOCUMENTS_DIR)',
+				`XDG_SPECIAL_DIRS_INITIAL_PATHS=("${xdgDir}")`,
+				extractXdgLinksBlock(readFileSync(scriptPath, 'utf8')),
+				'echo REACHED_END',
+				'',
+			].join('\n'),
+			{ mode: 0o755 },
+		);
+
+		// -e explicitly: `bash <file>` ignores the shebang's flags, and `set -e`
+		// is the whole point of the reproduction.
+		const result = spawnSync('bash', ['-e', fragment], {
+			encoding: 'utf8',
+			env: { ...process.env, PATH: `${writeRealpathShim(root)}:${process.env.PATH}` },
+		});
+		return {
+			status: result.status,
+			output: `${result.stdout}${result.stderr}`,
+			xdgDirIsRealDirectory: lstatSync(xdgDir, { throwIfNoEntry: false })?.isDirectory() === true,
+		};
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+describe('snap desktop launcher patch (#2946)', () => {
+	it('electron-builder still ships the unguarded rmdir block the patch targets', () => {
+		assert.ok(
+			unpatchedSource().includes(ORIGINAL_BLOCK),
+			'the launcher changed upstream — re-check the #2946 workaround',
+		);
+	});
+
+	it('adds the || true guard and the escaping-path skip', async () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, unpatchedSource());
+			assert.strictEqual(await patchScript(file), true);
+
+			const patched = readFileSync(file, 'utf8');
+			assert.ok(patched.includes('rmdir "$HOME/$b" 2> /dev/null || true'));
+			assert.ok(patched.includes('if [ "$b" = ".." ] || [ "${b#../}" != "$b" ]; then'));
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('is idempotent', async () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, unpatchedSource());
+			await patchScript(file);
+			const afterFirst = readFileSync(file, 'utf8');
+
+			assert.strictEqual(await patchScript(file), false);
+			assert.strictEqual(readFileSync(file, 'utf8'), afterFirst);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('throws instead of silently doing nothing when the block is missing', async () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, '#!/bin/bash -e\necho nothing to patch here\n');
+			await assert.rejects(() => patchScript(file), /expected rmdir block was not found/);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('unpatched: a failing rmdir kills the launcher with status 1 and no output', () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, unpatchedSource());
+			const run = runXdgLinksBlock({ scriptPath: file, placement: 'inside' });
+			assert.strictEqual(run.status, 1);
+			assert.strictEqual(run.output, '');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('patched: a failing rmdir no longer stops the launcher', async () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, unpatchedSource());
+			await patchScript(file);
+
+			for (const placement of ['inside', 'escape']) {
+				const run = runXdgLinksBlock({ scriptPath: file, placement });
+				assert.strictEqual(run.status, 0, `${placement} exited ${run.status}`);
+				assert.match(run.output, /REACHED_END/);
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('patched: an empty XDG dir outside the snap home is left alone', async () => {
+		const dir = makeTempDir();
+		try {
+			const file = writeScript(dir, unpatchedSource());
+
+			const before = runXdgLinksBlock({
+				scriptPath: file,
+				placement: 'escape',
+				emptyXdgDir: true,
+			});
+			assert.strictEqual(before.xdgDirIsRealDirectory, false, 'expected the unguarded script to replace it');
+
+			await patchScript(file);
+			const after = runXdgLinksBlock({ scriptPath: file, placement: 'escape', emptyXdgDir: true });
+			assert.strictEqual(after.xdgDirIsRealDirectory, true);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/snapDesktopLauncherPatch.test.js
+++ b/tests/unit/snapDesktopLauncherPatch.test.js
@@ -12,7 +12,7 @@ const {
 	writeFileSync,
 } = require('node:fs');
 const { tmpdir } = require('node:os');
-const { join, relative, resolve } = require('node:path');
+const { join, relative, resolve, sep } = require('node:path');
 
 const {
 	patchScript,
@@ -82,13 +82,19 @@ function extractXdgLinksBlock(source) {
 function runXdgLinksBlock({ scriptPath, placement, emptyXdgDir = false }) {
 	const root = makeTempDir();
 	try {
-		const realHome = join(root, 'fs', 'home', 'user');
+		// `[ -e "$REALHOME/$b" ]` climbs three levels past the common ancestor,
+		// because $b is relative to the snap home three directories deeper. Pad
+		// the fake filesystem so that overshoot stays inside the temp root
+		// instead of reaching into the real one (on a shallow /tmp it lands on
+		// /mnt).
+		const fsRoot = join(root, 'pad-1', 'pad-2', 'pad-3', 'fs');
+		const realHome = join(fsRoot, 'home', 'user');
 		const snapHome = join(realHome, 'snap', 'teams-for-linux', '2396');
 		mkdirSync(snapHome, { recursive: true });
 
 		const xdgDir =
 			placement === 'escape'
-				? join(root, 'fs', 'mnt', 'hdd', 'documents')
+				? join(fsRoot, 'mnt', 'hdd', 'documents')
 				: join(snapHome, 'Documents');
 		mkdirSync(xdgDir, { recursive: true });
 		if (!emptyXdgDir) {
@@ -96,10 +102,11 @@ function runXdgLinksBlock({ scriptPath, placement, emptyXdgDir = false }) {
 		}
 
 		if (placement === 'escape') {
-			// `[ -e "$REALHOME/$b" ]` overshoots the common ancestor; on the
-			// reporter's box it clamped at /. Create what it resolves to so the
-			// guard passes, reproducing their trace.
-			mkdirSync(resolve(realHome, relative(snapHome, xdgDir)), { recursive: true });
+			// Create what the overshooting test resolves to, so the guard passes
+			// and we reproduce the reporter's trace (theirs clamped at /).
+			const decoy = resolve(realHome, relative(snapHome, xdgDir));
+			assert.ok(decoy.startsWith(root + sep), `decoy ${decoy} escaped the sandbox`);
+			mkdirSync(decoy, { recursive: true });
 		} else {
 			mkdirSync(join(realHome, 'Documents'), { recursive: true });
 		}

--- a/tests/unit/snapDesktopLauncherPatch.test.js
+++ b/tests/unit/snapDesktopLauncherPatch.test.js
@@ -14,8 +14,10 @@ const {
 const { tmpdir } = require('node:os');
 const { join, relative, resolve, sep } = require('node:path');
 
+const { Arch } = require('builder-util');
 const {
 	patchScript,
+	patchSnapDesktopLauncher,
 	BUNDLED_TEMPLATE_SCRIPT,
 	ORIGINAL_BLOCK,
 	PATCHED_BLOCK,
@@ -216,6 +218,27 @@ describe('snap desktop launcher patch (#2946)', () => {
 			}
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	// arm64 takes the no-template path: it must patch the bundled script and
+	// never reach for the downloaded snap template, which would need the network.
+	// electronGet is required lazily inside patchDownloadedTemplate, so its
+	// absence from the module cache proves that branch was skipped.
+	it('arm64 patches only the bundled launcher, never the downloaded template', async () => {
+		const electronGet = require.resolve('app-builder-lib/out/util/electronGet');
+		const original = readFileSync(BUNDLED_TEMPLATE_SCRIPT, 'utf8');
+		delete require.cache[electronGet];
+		try {
+			await patchSnapDesktopLauncher(Arch.arm64);
+
+			assert.ok(
+				!(electronGet in require.cache),
+				'arm64 must not load the downloaded-template code path',
+			);
+			assert.ok(readFileSync(BUNDLED_TEMPLATE_SCRIPT, 'utf8').includes(PATCH_MARKER));
+		} finally {
+			writeFileSync(BUNDLED_TEMPLATE_SCRIPT, original, { mode: 0o755 });
 		}
 	});
 


### PR DESCRIPTION
The core22 snap launcher runs `desktop-common.sh` under `set -e` with an unguarded `rmdir "$HOME/$b" 2> /dev/null`, so a non-empty XDG directory kills it before Electron is exec'd and the snap exits 1 with completely empty output. This patches that block at build time from `afterPack`, in both copies of the script: the one bundled in `app-builder-lib` (arm64) and the one in the downloaded `snap-template` tarball (x64, armv7l). It also skips XDG entries whose relative path escapes `$HOME`, which could otherwise replace a real user directory with a symlink.

No electron-builder bump and no core24 change: the template tarballs are frozen 2019 releases, so a bump would not have fixed x64 or armv7l anyway.

x64 and armv7l were built and verified locally by extracting `desktop-common.sh` back out of the resulting `.snap` and running it under `bash -e`. arm64 is unverified because `snapcraft` does not run on macOS, so CI is what proves that arch.

2.19.0 is currently sitting in snap candidate at revisions 2431, 2432 and 2430 and would ship the same dead launcher if promoted before this lands.

closes #2946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KKxYdPzT9nYmdMQdAgsf1


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a build-time workaround for electron-builder’s core22 snap launcher bug and documents the affected startup failure.

- Hooks snap builds during `afterPack` and patches both bundled and downloaded launcher templates.
- Makes a failed removal of a non-empty XDG directory non-fatal.
- Skips canonical relative paths that escape the snap-private home.
- Adds regression tests covering launcher continuation, path escaping, idempotency, and arm64 template selection.
- Documents upgrade and temporary workaround options for affected users.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The patch is narrowly gated to snap targets, validates the launcher source before rewriting it, safely preserves non-empty directories, blocks canonical paths escaping the private home, and includes focused regression coverage for the affected launcher behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/afterpack.js | Adds a snap-target-specific afterPack hook that invokes the launcher patch before target packaging. |
| scripts/patchSnapDesktopLauncher.js | Implements guarded, idempotent patching of bundled and downloaded core22 launcher templates with metadata drift checks. |
| tests/unit/snapDesktopLauncherPatch.test.js | Exercises the actual launcher section under `bash -e`, including the original abort, corrected continuation, escape protection, and arm64 path. |
| docs-site/docs/troubleshooting.md | Documents the silent snap startup failure, its cause, and upgrade or temporary workaround options. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Electron Builder afterPack] --> B{Snap target?}
    B -- No --> C[Continue packaging]
    B -- Yes --> D[Patch bundled desktop-common.sh]
    D --> E{Architecture uses downloaded template?}
    E -- x64 or armv7l --> F[Materialize and patch cached template]
    E -- arm64 --> G[Use bundled template]
    F --> H[Build snap]
    G --> H
    H --> I[Launcher evaluates XDG paths]
    I --> J{Path escapes private HOME?}
    J -- Yes --> K[Skip entry]
    J -- No --> L[Attempt rmdir with nonfatal failure]
    K --> M[Continue launcher]
    L --> M
    M --> N[Start Electron]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(snap): look the template arch u..."](https://github.com/ismaelmartinez/teams-for-linux/commit/05e2785634b9093b3362be5a3150c011e370709f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59943356)</sub>

<!-- /greptile_comment -->