### PR TITLE
perf(deeplink): route deep links in page instead of reloading

### DIFF
--- a/app/mainAppWindow/README.md
+++ b/app/mainAppWindow/README.md
@@ -6,6 +6,7 @@ Manages the primary BrowserWindow that hosts the Teams web interface.
 
 - **[index.js](index.js)**: Entry point and window lifecycle management
 - **[browserWindowManager.js](browserWindowManager.js)**: Window creation, configuration, and event handling
+- **[deepLinkRouter.js](deepLinkRouter.js)**: In-page routing for Teams deep links
 
 ## Responsibilities
 
@@ -13,3 +14,13 @@ Manages the primary BrowserWindow that hosts the Teams web interface.
 - Web contents configuration and security settings
 - Integration with Teams web interface
 - Call event handling and screen sharing coordination
+- Deep link handling for `msteams:` protocol links and HTTPS Teams links
+
+## Deep Link Routing
+
+`onAppSecondInstance` navigates the window to a resolved deep link, which
+replaces the document and cold-boots the SPA. Launcher links avoid that:
+`deepLinkRouter` assigns the equivalent `#/l/...` route to the main frame
+instead, guarded by an origin check. The SPA rewrites the fragment when it
+handles the route, and anything left unconsumed falls back to the full
+navigation.

--- a/app/mainAppWindow/deepLinkRouter.js
+++ b/app/mainAppWindow/deepLinkRouter.js
@@ -1,0 +1,150 @@
+/**
+ * In-page routing for Teams deep links.
+ *
+ * A full `loadURL` replaces the document and cold-boots the SPA. Assigning the
+ * equivalent client-side route to `location.hash` reaches the target with no
+ * navigation. Every failure mode returns false so the caller falls back to the
+ * full navigation.
+ *
+ * Never log the route: `users` carries an email address and `context` carries
+ * meeting identifiers.
+ */
+
+// Any `/l/<segment>/...` launcher route, such as `/l/chat/...`,
+// `/l/meetup-join/...` or `/l/channel/...`. The set is deliberately open: the
+// SPA decides which routes it resolves, and whatever it declines reaches the
+// target through the full navigation instead.
+const LAUNCHER_ROUTE = /^(\/l\/[^/?#]+\/[^?#]+?)\/?(\?.*)?$/;
+
+// A chat launcher without recipients has nothing to resolve, and the SPA lands
+// on an empty chat surface rather than declining the route.
+const CHAT_ROUTE_PREFIX = "/l/chat/";
+
+/**
+ * Converts a Teams deep link into the equivalent client-side route.
+ *
+ * The query is carried through untouched so the SPA resolves the target
+ * exactly as it would after a full navigation, including group chat links and
+ * the `context` blob on meeting links.
+ *
+ * @param {string} url - Absolute URL produced from the launch argument
+ * @returns {string|null} Fragment such as `#/l/chat/0/0?users=a@b.com`
+ */
+function toHashRoute(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const candidate = parsed.hash.startsWith("#/")
+    ? parsed.hash.slice(1)
+    : parsed.pathname + parsed.search;
+
+  const match = LAUNCHER_ROUTE.exec(candidate);
+  if (!match) {
+    return null;
+  }
+
+  const [, route, query = ""] = match;
+  if (route.startsWith(CHAT_ROUTE_PREFIX) && !/[?&]users=[^&]/.test(query)) {
+    return null;
+  }
+
+  return `#${route}${query}`;
+}
+
+function isSameOrigin(frameUrl, origin) {
+  try {
+    return new URL(frameUrl).origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+// The SPA occupies the main frame. The origin check keeps the fragment off
+// unrelated content, such as the login origin mid-auth.
+function findRouterFrame(mainFrame, teamsOrigin) {
+  return isSameOrigin(mainFrame.url, teamsOrigin) ? mainFrame : null;
+}
+
+// The SPA rewrote the fragment within 26ms when measured. This budget is only
+// ever spent when it declines the route, delaying the fallback reload.
+const ROUTE_CONSUMED_TIMEOUT_MS = 750;
+
+/**
+ * Attempts to reach a deep link through the loaded SPA's router.
+ *
+ * @param {Electron.BrowserWindow} window - Main application window
+ * @param {string} url - Deep link URL resolved from the launch argument
+ * @param {string} teamsUrl - Configured Teams URL, used for the origin check
+ * @returns {Promise<boolean>} True when the SPA consumed the route; false
+ *   means the caller should fall back to a full navigation
+ */
+async function navigateInPage(window, url, teamsUrl) {
+  const route = toHashRoute(url);
+  if (!route) {
+    return false;
+  }
+
+  let teamsOrigin;
+  try {
+    teamsOrigin = new URL(teamsUrl).origin;
+  } catch {
+    return false;
+  }
+
+  // Electron throws "Object has been destroyed" rather than returning
+  // undefined when the window is torn down mid-flight, so this reaches the
+  // fallback instead of rejecting out of the module.
+  let frame;
+  try {
+    frame = findRouterFrame(window.webContents.mainFrame, teamsOrigin);
+  } catch {
+    return false;
+  }
+  if (!frame) {
+    return false;
+  }
+
+  try {
+    // Assigning the fragment always sticks, so the assignment proves nothing.
+    // The SPA signals that it handled the route by rewriting the fragment, and
+    // a fragment still holding the assigned value was never consumed. The
+    // previous fragment goes back before giving up, so an aborted fallback
+    // navigation does not strand the page on a route nothing answered.
+    return await frame.executeJavaScript(
+      `new Promise((resolve) => {
+         let timer;
+         const target = ${JSON.stringify(route)};
+         const previous = location.hash;
+         // Re-assigning an identical fragment fires no \`hashchange\`, so the
+         // wait below would time out and reload a page already on the route.
+         if (previous === target) { resolve(true); return; }
+         location.hash = target;
+         const assigned = location.hash;
+         const settle = (consumed) => {
+           clearTimeout(timer);
+           removeEventListener("hashchange", onHashChange);
+           if (!consumed) {
+             history.replaceState(null, "", previous || location.pathname + location.search);
+           }
+           resolve(consumed);
+         };
+         const onHashChange = () => {
+           if (location.hash !== assigned) settle(true);
+         };
+         // \`hashchange\` is queued as a task, so it cannot dispatch until this
+         // block returns: registering after the assignment misses nothing.
+         addEventListener("hashchange", onHashChange);
+         timer = setTimeout(() => settle(false), ${ROUTE_CONSUMED_TIMEOUT_MS});
+       })`
+    );
+  } catch {
+    console.debug("[DEEPLINK] in-page routing rejected");
+    return false;
+  }
+}
+
+module.exports = { toHashRoute, findRouterFrame, navigateInPage };

--- a/app/mainAppWindow/index.js
+++ b/app/mainAppWindow/index.js
@@ -20,6 +20,7 @@ require("../appConfiguration");
 const ConnectionManager = require("../connectionManager");
 const ssoPasswordPrefill = require("../ssoPasswordPrefill");
 const BrowserWindowManager = require("../mainAppWindow/browserWindowManager");
+const deepLinkRouter = require("./deepLinkRouter");
 const os = require("node:os");
 const path = require("node:path");
 
@@ -866,7 +867,7 @@ exports.setQuickChatManager = function (quickChatManager) {
 
 exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
   console.debug("second-instance started");
-  if (window) {
+  if (window && !window.isDestroyed()) {
     event.preventDefault();
     const url = processArgs(args);
     if (url && allowFurtherRequests) {
@@ -874,12 +875,39 @@ exports.onAppSecondInstance = function onAppSecondInstance(event, args) {
       setTimeout(() => {
         allowFurtherRequests = true;
       }, 5000);
-      window.loadURL(url, { userAgent: config.chromeUserAgent });
+      // `loadURL` rejects with ERR_ABORTED whenever Teams redirects the
+      // navigation it started, and the main process exits on
+      // unhandledRejection. The error is dropped rather than logged because it
+      // carries the deep link, and with it the recipient or meeting.
+      openDeepLink(url).catch(() => {
+        console.debug("[DEEPLINK] navigation failed");
+      });
     }
 
     restoreWindow();
   }
 };
+
+/**
+ * Opens a deep link, preferring in-page routing over a full navigation.
+ *
+ * A full `loadURL` discards the running SPA and cold-boots it, which is the
+ * multi-second delay between activating a link and seeing the target. Launcher
+ * links route through the loaded SPA instead, and anything it does not consume
+ * falls back to the full navigation.
+ *
+ * @param {string} url - Deep link URL resolved from the launch argument
+ */
+async function openDeepLink(url) {
+  const routed = await deepLinkRouter.navigateInPage(window, url, config.url);
+  if (routed) {
+    console.debug("[DEEPLINK] routed in page");
+    return;
+  }
+
+  console.debug("[DEEPLINK] in-page routing unavailable, reloading");
+  await window.loadURL(url, { userAgent: config.chromeUserAgent });
+}
 
 function applyAppConfiguration(config, window) {
   applySpellCheckerConfiguration(config.spellCheckerLanguages, window);

--- a/tests/unit/deepLinkRouter.test.js
+++ b/tests/unit/deepLinkRouter.test.js
@@ -1,0 +1,176 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  toHashRoute,
+  findRouterFrame,
+  navigateInPage,
+} = require("../../app/mainAppWindow/deepLinkRouter");
+
+const TEAMS_URL = "https://teams.cloud.microsoft";
+const DEEP_LINK = "https://teams.cloud.microsoft/l/chat/0/0?users=a@b.com";
+const MEETING_LINK =
+  "https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc%40thread.v2/0?context=%7B%22Tid%22%3A%22t%22%7D";
+
+test("toHashRoute moves a path-form launcher route into the fragment", () => {
+  assert.strictEqual(toHashRoute(DEEP_LINK), "#/l/chat/0/0?users=a@b.com");
+});
+
+test("toHashRoute accepts the fragment form Teams redirects to", () => {
+  assert.strictEqual(
+    toHashRoute("https://teams.cloud.microsoft/#/l/chat/0/0?users=a@b.com"),
+    "#/l/chat/0/0?users=a@b.com"
+  );
+});
+
+test("toHashRoute tolerates a trailing slash", () => {
+  assert.strictEqual(
+    toHashRoute("https://teams.cloud.microsoft/l/chat/0/0/?users=a@b.com"),
+    "#/l/chat/0/0?users=a@b.com"
+  );
+});
+
+test("toHashRoute carries group recipients through untouched", () => {
+  assert.strictEqual(
+    toHashRoute(
+      "https://teams.cloud.microsoft/l/chat/0/0?users=a@b.com,c@d.com"
+    ),
+    "#/l/chat/0/0?users=a@b.com,c@d.com"
+  );
+});
+
+test("toHashRoute routes a meeting link with its context blob", () => {
+  assert.strictEqual(
+    toHashRoute(MEETING_LINK),
+    "#/l/meetup-join/19%3ameeting_abc%40thread.v2/0?context=%7B%22Tid%22%3A%22t%22%7D"
+  );
+});
+
+test("toHashRoute routes a channel link", () => {
+  assert.strictEqual(
+    toHashRoute(
+      "https://teams.microsoft.com/l/channel/19%3aabc/General?groupId=g"
+    ),
+    "#/l/channel/19%3aabc/General?groupId=g"
+  );
+});
+
+test("toHashRoute declines links the SPA route cannot resolve", () => {
+  const declined = [
+    "https://teams.cloud.microsoft/l/chat/0/0",
+    "https://teams.cloud.microsoft/l/chat/0/0?users=",
+    "https://teams.cloud.microsoft/l/chat/0/0?topicName=x",
+    "https://teams.microsoft.com/meet/241?p=secret",
+    "https://teams.cloud.microsoft/l/meetup-join/",
+    "https://teams.cloud.microsoft/",
+    "not-a-url",
+  ];
+
+  for (const url of declined) {
+    assert.strictEqual(toHashRoute(url), null, url);
+  }
+});
+
+test("findRouterFrame returns the main frame when Teams is loaded", () => {
+  const main = { url: "https://teams.cloud.microsoft/" };
+
+  assert.strictEqual(findRouterFrame(main, TEAMS_URL), main);
+});
+
+test("findRouterFrame declines while the window is on another origin", () => {
+  const main = { url: "https://login.microsoftonline.com/common/oauth2/" };
+
+  assert.strictEqual(findRouterFrame(main, TEAMS_URL), null);
+});
+
+function windowWith(frameUrl, executeJavaScript) {
+  return {
+    webContents: { mainFrame: { url: frameUrl, executeJavaScript } },
+  };
+}
+
+test("navigateInPage succeeds when the SPA consumes the fragment", async () => {
+  let script = null;
+  const win = windowWith("https://teams.cloud.microsoft/", async (source) => {
+    script = source;
+    return true;
+  });
+
+  assert.strictEqual(await navigateInPage(win, DEEP_LINK, TEAMS_URL), true);
+  assert.match(script, /const target = "#\/l\/chat\/0\/0\?users=a@b\.com"/);
+  // The injected source is evaluated in the renderer, where a syntax error
+  // would surface only as a rejected promise and a silent fallback.
+  assert.doesNotThrow(() => new Function(`return ${script}`));
+});
+
+test("navigateInPage hands a meeting route to the loaded SPA", async () => {
+  let script = null;
+  const win = windowWith("https://teams.cloud.microsoft/", async (source) => {
+    script = source;
+    return true;
+  });
+
+  assert.strictEqual(await navigateInPage(win, MEETING_LINK, TEAMS_URL), true);
+  assert.match(script, /const target = "#\/l\/meetup-join\//);
+});
+
+test("navigateInPage short-circuits when the fragment already holds the route", async () => {
+  let script = null;
+  const win = windowWith("https://teams.cloud.microsoft/", async (source) => {
+    script = source;
+    return true;
+  });
+
+  assert.strictEqual(await navigateInPage(win, DEEP_LINK, TEAMS_URL), true);
+  // Re-assigning an identical fragment fires no `hashchange`, so without this
+  // guard the wait would time out and reload a page already on the route.
+  assert.match(script, /if \(previous === target\) \{ resolve\(true\); return; \}/);
+});
+
+test("navigateInPage falls back when the fragment is left untouched", async () => {
+  const win = windowWith("https://teams.cloud.microsoft/", async () => false);
+
+  assert.strictEqual(await navigateInPage(win, DEEP_LINK, TEAMS_URL), false);
+});
+
+test("navigateInPage declines when Teams is not the loaded origin", async () => {
+  const win = windowWith("https://login.microsoftonline.com/", async () =>
+    assert.fail("should not execute script")
+  );
+
+  assert.strictEqual(await navigateInPage(win, DEEP_LINK, TEAMS_URL), false);
+});
+
+test("navigateInPage declines when the frame rejects", async () => {
+  const win = windowWith("https://teams.cloud.microsoft/", async () => {
+    throw new Error("frame disposed");
+  });
+
+  assert.strictEqual(await navigateInPage(win, DEEP_LINK, TEAMS_URL), false);
+});
+
+test("navigateInPage declines when the window is torn down mid-flight", async () => {
+  // Electron throws on a destroyed object rather than returning undefined, so
+  // optional chaining would not reach the fallback here.
+  const destroyed = {
+    get webContents() {
+      throw new Error("Object has been destroyed");
+    },
+  };
+
+  assert.strictEqual(
+    await navigateInPage(destroyed, DEEP_LINK, TEAMS_URL),
+    false
+  );
+});
+
+test("navigateInPage declines unsupported link shapes without touching the frame", async () => {
+  const win = windowWith("https://teams.cloud.microsoft/", async () =>
+    assert.fail("should not execute script")
+  );
+
+  assert.strictEqual(
+    await navigateInPage(win, "https://teams.microsoft.com/meet/241", TEAMS_URL),
+    false
+  );
+});


### PR DESCRIPTION
## Motivation

Opening a Teams deep link against a running instance redraws the UI from the
sign-in screen and takes several seconds, rather than switching to the target.

`onAppSecondInstance` navigates every deep link with `window.loadURL`. That
replaces the document and cold-boots the Teams SPA, so bundle parse, silent
token acquisition and chat-list sync all run again before the requested
conversation or meeting appears. ADR 014 notes this as a known negative of the
deep-link approach ("Page refresh occurs when navigating via deep link").

## Change

Launcher routes are the client-side routes the SPA already resolves from the
fragment: `/l/chat/0/0?users=<upn>` and `/l/meetup-join/<thread>/0?context=<blob>`
both redirect to their `#/l/...` form. Assigning that fragment to the running
page reaches the target with no navigation at all.

`app/mainAppWindow/deepLinkRouter.js` applies the fragment to the main frame
behind an origin check, so it never lands on unrelated content such as the login
origin mid-auth. The query is passed through untouched, which covers group chats
and the meeting context blob.

The SPA rewrites the fragment once it handles the route, and that is the success
signal, observed through `hashchange`. A fragment still holding the assigned
value means nothing consumed it: the previous fragment goes back, and the caller
falls back to the original full navigation. Shapes with no client-side
equivalent, such as `teams.microsoft.com/meet/<id>`, take that fallback
directly, so their behaviour is unchanged.

This also stops the deep-link navigation promise escaping unhandled. The main
process exits on `unhandledRejection` (`app/index.js`), and this path rejects
with `ERR_ABORTED` in normal use.

## Validation

Measured against a live signed-in session over the Chrome DevTools Protocol:

- the SPA consumed the chat fragment in **26ms**
- a sentinel set on `window` beforehand **survived**, proving the document was
  never replaced
- `document.title` changed to the target conversation

The routing script itself was then exercised in a real renderer under Electron,
against a stub page that rewrites `#/l/...` the way the SPA does:

- consumed route resolved in **2ms**, `window` sentinel survived
- declined route settled at the **753ms** budget and left the fragment clean
- a pre-existing fragment was **restored** when the route was declined

`npm run lint` and `npm run test:unit` pass, aside from the pre-existing local
`snapDesktopLauncherPatch` failures.














<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes supported Teams deep links through the running SPA and falls back to full navigation when in-page routing is unavailable.
- Adds fragment-based launcher-route conversion, origin validation, consumption detection, and fragment restoration.
- Integrates the router into second-instance handling while containing navigation rejections without logging sensitive link data.
- Adds unit coverage and module documentation for the routing behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/mainAppWindow/deepLinkRouter.js | Adds guarded in-page deep-link conversion, routing, consumption detection, and fallback-state restoration. |
| app/mainAppWindow/index.js | Integrates in-page routing into second-instance handling and replaces sensitive rejection logging with a generic message. |
| tests/unit/deepLinkRouter.test.js | Covers supported and declined route shapes, origin checks, renderer rejection, and destroyed-window handling. |
| app/mainAppWindow/README.md | Documents the new deep-link routing module and fallback behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Second instance
    participant M as Main process
    participant R as Deep-link router
    participant T as Teams SPA
    S->>M: Deep-link launch argument
    M->>R: navigateInPage(window, URL, Teams URL)
    R->>R: Convert supported launcher URL to fragment
    R->>R: Verify loaded frame origin
    R->>T: Assign launcher fragment
    alt SPA rewrites fragment
        T-->>R: hashchange with different fragment
        R-->>M: "routed = true"
    else Unsupported, declined, or rejected
        R->>T: Restore previous fragment when needed
        R-->>M: "routed = false"
        M->>T: loadURL(deep link)
    end
```
</details>

<sub>Reviews (10): Last reviewed commit: ["perf(deeplink): route deep links in page..."](https://github.com/ismaelmartinez/teams-for-linux/commit/82c1c65668a15e87ed6fbb9627ec3ff2989e1860) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60061939)</sub>

<!-- /greptile_comment -->