### PR TITLE
ci(stale): exempt good first issue and help wanted issues from auto-close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,5 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           days-before-pr-close: -1
+          # Issues kept open on purpose for contributors must not be auto-closed.
+          exempt-issue-labels: "good first issue,help wanted"


### PR DESCRIPTION
The stale bot re-marked #2746 on 2026-09-05 although it is kept open on purpose for contributors, and with no exempt labels it would close it five days after the next 30-day mark. Issues labelled `good first issue` or `help wanted` are now skipped; PR handling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kEXVePs5Ebg91ZK8yvE9r

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the stale-issue workflow so issues intended for contributors are not automatically marked stale or closed.
- Exempts issues labeled `good first issue` or `help wanted`.
- Leaves pull-request stale handling unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The pinned stale action supports the new issue-label exemption syntax, and the setting does not alter pull-request handling.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/stale.yml | Adds a valid issue-only label exemption using the comma-separated syntax supported by the pinned stale action. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(stale): exempt good first issue and h..."](https://github.com/ismaelmartinez/teams-for-linux/commit/7195214f774d683a1d6c426f219b21eaaae5e6a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60774379)</sub>

<!-- /greptile_comment -->