### PR TITLE
fix(network): don't show blank page on network drop, and dont reload on network resume

### DIFF
--- a/app/connectionManager/README.md
+++ b/app/connectionManager/README.md
@@ -1,3 +1,5 @@
 # Connection Manager
 
 This module is responsible for managing the application's network connections and ensuring connectivity to Microsoft Teams services. It handles aspects related to network status, proxy settings, and potential connection issues.
+
+A page that is already loaded is left alone when the network drops or the system resumes from sleep: Teams keeps working from its local cache and shows its own connectivity notice. The page is only reloaded after a main-frame navigation actually failed with a recoverable network error (`did-fail-load`), once connectivity is back.

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -94,7 +94,9 @@ class ConnectionManager {
     return this.window && !this.window.isDestroyed();
   }
 
-  async refresh() {
+  // `force` is for an explicit user reload (menu, Ctrl+R): it bypasses the
+  // healthy-page check below.
+  async refresh(force = false) {
     if (!this.isWindowAvailable()) {
       console.warn("Window is not available. Cannot refresh.");
       return;
@@ -112,11 +114,10 @@ class ConnectionManager {
 
       const currentUrl = this.window?.webContents?.getURL() || "";
       const hasUrl = currentUrl?.startsWith("https://");
-      if (hasUrl && !_ConnectionManager_needsReload.get(this)) {
+      if (hasUrl && !force && !_ConnectionManager_needsReload.get(this)) {
         console.debug("[CONNECTION] Page is loaded and healthy, skipping reload");
         return;
       }
-      _ConnectionManager_needsReload.set(this, false);
       this.window?.setTitle("Waiting for network...");
       console.debug("Waiting for network...");
       const connected = await this.isOnline();
@@ -128,34 +129,36 @@ class ConnectionManager {
         return;
       }
 
-      if (connected) {
-        if (hasUrl) {
-          console.debug("Reloading current page...");
-          try {
-            this.window.reload();
-          } catch (err) {
-            console.error(`[CONNECTION] Failed to reload page: ${err.message}`);
-            _ConnectionManager_needsReload.set(this, true);
-            this.debouncedRefresh();
-          }
-        } else {
-          console.debug("Loading initial URL...");
-          try {
-            await this.window.loadURL(this.currentUrl, {
-              userAgent: this.config.chromeUserAgent,
-            });
-          } catch (err) {
-            console.error(`[CONNECTION] Failed to load URL: ${err.message}`);
-            _ConnectionManager_needsReload.set(this, true);
-            this.debouncedRefresh();
-          }
-        }
-      } else {
+      if (!connected) {
+        // needsReload is left as it was, so a later resume or retry still
+        // reloads a page that failed.
         this.window?.setTitle("No internet connection");
         console.error("No internet connection");
+        return;
       }
+
+      _ConnectionManager_needsReload.set(this, false);
+      await this.load(hasUrl);
     } finally {
       _ConnectionManager_isRefreshing.set(this, false);
+    }
+  }
+
+  async load(hasUrl) {
+    try {
+      if (hasUrl) {
+        console.debug("Reloading current page...");
+        this.window.reload();
+      } else {
+        console.debug("Loading initial URL...");
+        await this.window.loadURL(this.currentUrl, {
+          userAgent: this.config.chromeUserAgent,
+        });
+      }
+    } catch (err) {
+      console.error(`[CONNECTION] Failed to load page: ${err.message}`);
+      _ConnectionManager_needsReload.set(this, true);
+      this.debouncedRefresh();
     }
   }
 

--- a/app/connectionManager/index.js
+++ b/app/connectionManager/index.js
@@ -10,6 +10,11 @@ let _ConnectionManager_isRefreshing = new WeakMap();
 let _ConnectionManager_refreshTimeout = new WeakMap();
 let _ConnectionManager_boundRefresh = new WeakMap();
 let _ConnectionManager_boundDidFailLoad = new WeakMap();
+// Set by a main-frame network failure; cleared when refresh() attempts a load.
+// While unset, a page that is already loaded is left alone: Teams keeps
+// working from its local cache when the network drops, and a suspend/resume
+// no longer replaces a healthy page with a blank one (#2611).
+let _ConnectionManager_needsReload = new WeakMap();
 
 class ConnectionManager {
   get window() {
@@ -34,6 +39,7 @@ class ConnectionManager {
     _ConnectionManager_currentUrl.set(this, url || this.config.url);
     _ConnectionManager_isRefreshing.set(this, false);
     _ConnectionManager_refreshTimeout.set(this, null);
+    _ConnectionManager_needsReload.set(this, false);
 
     // Bind methods to preserve 'this' context
     const boundRefresh = this.debouncedRefresh.bind(this);
@@ -106,6 +112,11 @@ class ConnectionManager {
 
       const currentUrl = this.window?.webContents?.getURL() || "";
       const hasUrl = currentUrl?.startsWith("https://");
+      if (hasUrl && !_ConnectionManager_needsReload.get(this)) {
+        console.debug("[CONNECTION] Page is loaded and healthy, skipping reload");
+        return;
+      }
+      _ConnectionManager_needsReload.set(this, false);
       this.window?.setTitle("Waiting for network...");
       console.debug("Waiting for network...");
       const connected = await this.isOnline();
@@ -124,6 +135,7 @@ class ConnectionManager {
             this.window.reload();
           } catch (err) {
             console.error(`[CONNECTION] Failed to reload page: ${err.message}`);
+            _ConnectionManager_needsReload.set(this, true);
             this.debouncedRefresh();
           }
         } else {
@@ -134,6 +146,7 @@ class ConnectionManager {
             });
           } catch (err) {
             console.error(`[CONNECTION] Failed to load URL: ${err.message}`);
+            _ConnectionManager_needsReload.set(this, true);
             this.debouncedRefresh();
           }
         }
@@ -227,6 +240,7 @@ function assignOnDidFailLoadEventHandler(cm) {
       console.error(`[CONNECTION] Main frame failed to load: ${description} (code: ${code})`);
       if (RECOVERABLE_NETWORK_ERRORS.has(description)) {
         console.debug(`Network error detected: ${description}, scheduling debounced refresh...`);
+        _ConnectionManager_needsReload.set(cm, true);
         cm.debouncedRefresh();
       }
     } else {

--- a/app/menus/index.js
+++ b/app/menus/index.js
@@ -157,7 +157,7 @@ class Menus {
       this.window.show();
     }
 
-    this.connectionManager.refresh();
+    this.connectionManager.refresh(true);
   }
 
   debug() {

--- a/tests/unit/connectionManagerOnlineCheck.test.js
+++ b/tests/unit/connectionManagerOnlineCheck.test.js
@@ -277,9 +277,11 @@ describe('ConnectionManager refresh on a loaded page', () => {
 			config: { url: 'https://teams.cloud.microsoft' },
 		});
 		manager.refresh = realRefresh;
-		manager.isOnline = async () => true;
+		let online = true;
+		manager.isOnline = async () => online;
 		return {
-			refresh: () => manager.refresh(),
+			refresh: (force) => manager.refresh(force),
+			setOnline: (value) => { online = value; },
 			didFailLoad: listeners['did-fail-load'],
 			reloadCount: () => reloads,
 		};
@@ -298,5 +300,22 @@ describe('ConnectionManager refresh on a loaded page', () => {
 		assert.strictEqual(reloadCount(), 1);
 		await refresh();
 		assert.strictEqual(reloadCount(), 1, 'a successful reload must not queue another');
+	});
+
+	it('keeps the reload pending while the network is still down', async () => {
+		const { refresh, setOnline, didFailLoad, reloadCount } = loadedManager();
+		didFailLoad({}, -106, 'ERR_INTERNET_DISCONNECTED', 'https://teams.cloud.microsoft/', true);
+		setOnline(false);
+		await refresh();
+		assert.strictEqual(reloadCount(), 0);
+		setOnline(true);
+		await refresh();
+		assert.strictEqual(reloadCount(), 1, 'the failed page must still be reloaded once online');
+	});
+
+	it('always reloads on an explicit user request', async () => {
+		const { refresh, reloadCount } = loadedManager();
+		await refresh(true);
+		assert.strictEqual(reloadCount(), 1);
 	});
 });

--- a/tests/unit/connectionManagerOnlineCheck.test.js
+++ b/tests/unit/connectionManagerOnlineCheck.test.js
@@ -235,3 +235,68 @@ describe('ConnectionManager did-fail-load retry scheduling', () => {
 		assert.strictEqual(scheduledCount(), 0);
 	});
 });
+
+// A loaded page must survive a network drop or a suspend/resume: Teams keeps
+// working from its local cache, and reloading it while the network is still
+// down is what produced the blank window (#2611). Only a main-frame network
+// failure earns a reload.
+describe('ConnectionManager refresh on a loaded page', () => {
+	before(() => {
+		installElectronMock();
+	});
+
+	after(() => {
+		delete require.cache[electronPath];
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	beforeEach(() => {
+		installElectronMock();
+		delete require.cache[require.resolve('../../app/connectionManager')];
+	});
+
+	function loadedManager() {
+		const ConnectionManager = require('../../app/connectionManager');
+		const manager = new ConnectionManager();
+		const listeners = {};
+		let reloads = 0;
+		const window = {
+			isDestroyed: () => false,
+			setTitle() {},
+			reload() { reloads += 1; },
+			webContents: {
+				on(event, fn) { listeners[event] = fn; },
+				removeListener() {},
+				getURL: () => 'https://teams.cloud.microsoft/v2/',
+			},
+		};
+		const realRefresh = manager.refresh;
+		manager.refresh = () => {};
+		manager.start('https://teams.cloud.microsoft', {
+			window,
+			config: { url: 'https://teams.cloud.microsoft' },
+		});
+		manager.refresh = realRefresh;
+		manager.isOnline = async () => true;
+		return {
+			refresh: () => manager.refresh(),
+			didFailLoad: listeners['did-fail-load'],
+			reloadCount: () => reloads,
+		};
+	}
+
+	it('leaves a healthy page alone (e.g. on resume from sleep)', async () => {
+		const { refresh, reloadCount } = loadedManager();
+		await refresh();
+		assert.strictEqual(reloadCount(), 0);
+	});
+
+	it('reloads once after a main-frame network failure, then leaves it alone again', async () => {
+		const { refresh, didFailLoad, reloadCount } = loadedManager();
+		didFailLoad({}, -106, 'ERR_INTERNET_DISCONNECTED', 'https://teams.cloud.microsoft/', true);
+		await refresh();
+		assert.strictEqual(reloadCount(), 1);
+		await refresh();
+		assert.strictEqual(reloadCount(), 1, 'a successful reload must not queue another');
+	});
+});


### PR DESCRIPTION
Losing the network, or resuming from sleep before it is back, currently reloads the loaded Teams page and leaves a blank white window until connectivity returns. That is annoying: Teams itself keeps working from its local cache and shows its own connectivity notice, so there is no reason to throw the page away.

ConnectionManager now only reloads a loaded page after a main-frame navigation actually failed with a recoverable network error. A resume with a healthy page is a no-op.

Related: #2611, #2246



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61982675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ismaelmartinez/-/pull-requests/ismaelmartinez/teams-for-linux/2969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Tracks whether a recoverable main-frame failure requires reloading.
- Retains pending recovery while connectivity remains unavailable.
- Adds a forced path for explicit user reload actions.
- Adds focused tests for healthy-page, offline-recovery, and explicit-reload behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Event as Resume / Retry / Failure
    participant CM as ConnectionManager
    participant Net as Connectivity Check
    participant Page as Teams Window
    Event->>CM: refresh()
    alt Healthy HTTPS page
        CM-->>Event: Skip reload
    else Main-frame failure pending
        CM->>Net: isOnline()
        alt Offline
            CM-->>Event: Preserve needsReload
        else Online
            CM->>Page: reload()
            CM->>CM: Clear needsReload
        end
    else Explicit user reload
        Event->>CM: refresh(true)
        CM->>Net: isOnline()
        Net-->>CM: Online
        CM->>Page: reload()
    end
```
</details>

<!-- /greptile_comment -->