### PR TITLE
Fix: publish unread count over LauncherEntry with packaging-aware desktop URI (badge)

### DIFF
--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -50,7 +50,7 @@ is intentionally out of scope.
 - `config` - Application configuration (`config.download.*` keys are read)
 - `mainAppWindow` - Main window module exposing `getWindow()` for taskbar progress updates and window-title prefix
 - `jobViewEmitter` (Linux only) - Optional sibling module talking to `org.kde.JobViewServer`
-- `launcherEntryEmitter` (Linux only) - Optional sibling module broadcasting `com.canonical.Unity.LauncherEntry` signals for the dock icon (Ubuntu Dock / Dash-to-Dock). Also reused by `app/index.js` to publish the unread badge count, since Electron's `app.setBadgeCount()` depends on `libunity` and is a silent no-op in every packaging we ship. The desktop URI it emits follows the packaging (`<instance>_<app>.desktop` under snap, `<app-id>.desktop` under Flatpak, `<app>.desktop` otherwise) — a mismatched URI is dropped by the dock without any error.
+- `launcherEntryEmitter` (Linux only) - Optional sibling module broadcasting `com.canonical.Unity.LauncherEntry` signals for the dock icon (Ubuntu Dock / Dash-to-Dock). Also reused by `app/index.js` to publish the unread badge count, since Electron's `app.setBadgeCount()` depends on `libunity` and is a silent no-op in every packaging we ship. The desktop URI it emits follows the packaging (`<instance>_<snap-name>.desktop` under snap, `<app-id>.desktop` under Flatpak, `<app>.desktop` otherwise — only the last one follows a custom `class`, since sandboxed packagings fix the desktop file name at build time) — a mismatched URI is dropped by the dock without any error.
 
 **Usage:**
 ```javascript

--- a/app/downloadManager/README.md
+++ b/app/downloadManager/README.md
@@ -50,6 +50,7 @@ is intentionally out of scope.
 - `config` - Application configuration (`config.download.*` keys are read)
 - `mainAppWindow` - Main window module exposing `getWindow()` for taskbar progress updates and window-title prefix
 - `jobViewEmitter` (Linux only) - Optional sibling module talking to `org.kde.JobViewServer`
+- `launcherEntryEmitter` (Linux only) - Optional sibling module broadcasting `com.canonical.Unity.LauncherEntry` signals for the dock icon (Ubuntu Dock / Dash-to-Dock). Also reused by `app/index.js` to publish the unread badge count, since Electron's `app.setBadgeCount()` depends on `libunity` and is a silent no-op in every packaging we ship. The desktop URI it emits follows the packaging (`<instance>_<app>.desktop` under snap, `<app-id>.desktop` under Flatpak, `<app>.desktop` otherwise) — a mismatched URI is dropped by the dock without any error.
 
 **Usage:**
 ```javascript

--- a/app/downloadManager/launcherEntryEmitter.js
+++ b/app/downloadManager/launcherEntryEmitter.js
@@ -38,11 +38,45 @@
 
 const dbus = require("@homebridge/dbus-native");
 
-const DESKTOP_URI = "application://teams-for-linux.desktop";
-const PATH_ID = simpleHash(DESKTOP_URI);
-const SIGNAL_PATH = `/com/canonical/unity/launcherentry/${PATH_ID}`;
 const INTERFACE = "com.canonical.Unity.LauncherEntry";
 const MEMBER = "Update";
+
+/**
+ * Desktop URI the receivers match the signal against. It must name the
+ * desktop file as the *host* sees it, which depends on the packaging:
+ * snapd exports desktop files as `<instance>_<file>.desktop` and Flatpak
+ * as `<app-id>.desktop`, so the plain app name only matches for deb/rpm/
+ * AppImage installs. A mismatched URI is silently dropped by the dock —
+ * the badge/progress just never shows (#2620 follow-up).
+ *
+ * @param {string} appName
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
+function computeDesktopUri(appName, env) {
+  if (env.SNAP_INSTANCE_NAME) {
+    return `application://${env.SNAP_INSTANCE_NAME}_${appName}.desktop`;
+  }
+  if (env.FLATPAK_ID) {
+    return `application://${env.FLATPAK_ID}.desktop`;
+  }
+  return `application://${appName}.desktop`;
+}
+
+let desktopUri = null;
+let signalPath = null;
+
+function getEntry() {
+  if (!desktopUri) {
+    // Lazy: `app.name` may still change while startup switches are applied
+    // (config `class` calls app.setName()), and this module is only used
+    // after the app is ready.
+    const { app } = require("electron");
+    desktopUri = computeDesktopUri(app.name, process.env);
+    signalPath = `/com/canonical/unity/launcherentry/${simpleHash(desktopUri)}`;
+  }
+  return { desktopUri, signalPath };
+}
 
 let bus = null;
 let busDisabled = false;
@@ -95,8 +129,9 @@ function update(props = {}) {
     // buffers pre-handshake and writes post-handshake. (A previous attempt
     // that set the serial manually crashed with "Missing or invalid serial"
     // when the message was marshalled during the handshake window.)
-    sessionBus.sendSignal(SIGNAL_PATH, INTERFACE, MEMBER, "sa{sv}", [
-      DESKTOP_URI,
+    const entry = getEntry();
+    sessionBus.sendSignal(entry.signalPath, INTERFACE, MEMBER, "sa{sv}", [
+      entry.desktopUri,
       properties,
     ]);
   } catch (error) {
@@ -121,4 +156,4 @@ function simpleHash(input) {
   return h;
 }
 
-module.exports = { update };
+module.exports = { update, computeDesktopUri };

--- a/app/downloadManager/launcherEntryEmitter.js
+++ b/app/downloadManager/launcherEntryEmitter.js
@@ -44,9 +44,9 @@ const MEMBER = "Update";
 /**
  * Desktop URI the receivers match the signal against. It must name the
  * desktop file as the *host* sees it, which depends on the packaging:
- * snapd exports desktop files as `<instance>_<file>.desktop` and Flatpak
- * as `<app-id>.desktop`, so the plain app name only matches for deb/rpm/
- * AppImage installs. A mismatched URI is silently dropped by the dock —
+ * snapd exports desktop files as `<instance>_<snap-name>.desktop` and
+ * Flatpak as `<app-id>.desktop`, so the plain app name only matches for
+ * deb/rpm/AppImage installs. A mismatched URI is silently dropped by the dock —
  * the badge/progress just never shows (#2620 follow-up).
  *
  * @param {string} appName
@@ -55,7 +55,10 @@ const MEMBER = "Update";
  */
 function computeDesktopUri(appName, env) {
   if (env.SNAP_INSTANCE_NAME) {
-    return `application://${env.SNAP_INSTANCE_NAME}_${appName}.desktop`;
+    // The basename is fixed at build time to the snap name; a runtime
+    // app.setName() (config `class`) cannot change the exported file, so
+    // appName must not leak into the snap URI.
+    return `application://${env.SNAP_INSTANCE_NAME}_${env.SNAP_NAME || appName}.desktop`;
   }
   if (env.FLATPAK_ID) {
     return `application://${env.FLATPAK_ID}.desktop`;

--- a/app/index.js
+++ b/app/index.js
@@ -785,6 +785,22 @@ async function userStatusChangedHandler(_event, options) {
 async function setBadgeCountHandler(_event, count) {
   if (!config.disableBadgeCount) {
     app.setBadgeCount(count);
+    // Electron's own Linux badge path loads libunity at runtime, which none
+    // of our packagings ship, so setBadgeCount is a silent no-op there.
+    // Mirror the count over the LauncherEntry broadcast the docks actually
+    // listen to — the same route downloads use for dock progress.
+    if (os.platform() === "linux") {
+      try {
+        require("./downloadManager/launcherEntryEmitter").update({
+          count,
+          countVisible: count > 0,
+        });
+      } catch (error) {
+        console.warn("[Badge] LauncherEntry emit failed", {
+          message: error.message,
+        });
+      }
+    }
   }
 }
 

--- a/tests/unit/launcherEntryEmitter.test.js
+++ b/tests/unit/launcherEntryEmitter.test.js
@@ -18,15 +18,38 @@ describe('launcherEntryEmitter.computeDesktopUri', () => {
 
 	it('prefixes the snap instance name the way snapd exports desktop files', () => {
 		assert.strictEqual(
-			computeDesktopUri('teams-for-linux', { SNAP_INSTANCE_NAME: 'teams-for-linux' }),
+			computeDesktopUri('teams-for-linux', {
+				SNAP_NAME: 'teams-for-linux',
+				SNAP_INSTANCE_NAME: 'teams-for-linux',
+			}),
 			'application://teams-for-linux_teams-for-linux.desktop',
 		);
 	});
 
 	it('keeps parallel snap instances distinct', () => {
 		assert.strictEqual(
-			computeDesktopUri('teams-for-linux', { SNAP_INSTANCE_NAME: 'teams-for-linux_work' }),
+			computeDesktopUri('teams-for-linux', {
+				SNAP_NAME: 'teams-for-linux',
+				SNAP_INSTANCE_NAME: 'teams-for-linux_work',
+			}),
 			'application://teams-for-linux_work_teams-for-linux.desktop',
+		);
+	});
+
+	it('ignores a custom app name under snap, where the desktop basename is fixed at build time', () => {
+		assert.strictEqual(
+			computeDesktopUri('my-teams', {
+				SNAP_NAME: 'teams-for-linux',
+				SNAP_INSTANCE_NAME: 'teams-for-linux',
+			}),
+			'application://teams-for-linux_teams-for-linux.desktop',
+		);
+	});
+
+	it('falls back to the app name when SNAP_NAME is missing', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', { SNAP_INSTANCE_NAME: 'teams-for-linux' }),
+			'application://teams-for-linux_teams-for-linux.desktop',
 		);
 	});
 
@@ -42,6 +65,7 @@ describe('launcherEntryEmitter.computeDesktopUri', () => {
 	it('lets the snap prefix win when both snap and flatpak variables are present', () => {
 		assert.strictEqual(
 			computeDesktopUri('teams-for-linux', {
+				SNAP_NAME: 'teams-for-linux',
 				SNAP_INSTANCE_NAME: 'teams-for-linux',
 				FLATPAK_ID: 'com.example.ignored',
 			}),

--- a/tests/unit/launcherEntryEmitter.test.js
+++ b/tests/unit/launcherEntryEmitter.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { computeDesktopUri } = require('../../app/downloadManager/launcherEntryEmitter');
+
+// Receivers (Ubuntu Dock, Dash-to-Dock) match LauncherEntry signals against
+// the desktop file as exported on the host, so the URI has to follow the
+// packaging. A wrong URI is dropped silently: no badge, no progress.
+describe('launcherEntryEmitter.computeDesktopUri', () => {
+	it('uses the plain app name for deb/rpm/AppImage installs', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', {}),
+			'application://teams-for-linux.desktop',
+		);
+	});
+
+	it('prefixes the snap instance name the way snapd exports desktop files', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', { SNAP_INSTANCE_NAME: 'teams-for-linux' }),
+			'application://teams-for-linux_teams-for-linux.desktop',
+		);
+	});
+
+	it('keeps parallel snap instances distinct', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', { SNAP_INSTANCE_NAME: 'teams-for-linux_work' }),
+			'application://teams-for-linux_work_teams-for-linux.desktop',
+		);
+	});
+
+	it('uses the Flatpak app id as the desktop file name', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', {
+				FLATPAK_ID: 'com.github.IsmaelMartinez.teams_for_linux',
+			}),
+			'application://com.github.IsmaelMartinez.teams_for_linux.desktop',
+		);
+	});
+
+	it('lets the snap prefix win when both snap and flatpak variables are present', () => {
+		assert.strictEqual(
+			computeDesktopUri('teams-for-linux', {
+				SNAP_INSTANCE_NAME: 'teams-for-linux',
+				FLATPAK_ID: 'com.example.ignored',
+			}),
+			'application://teams-for-linux_teams-for-linux.desktop',
+		);
+	});
+
+	it('follows a custom app name (config `class`)', () => {
+		assert.strictEqual(
+			computeDesktopUri('my-teams', {}),
+			'application://my-teams.desktop',
+		);
+	});
+});


### PR DESCRIPTION
## Problem

The unread-count badge never appears on the dock icon when running the snap (Ubuntu 24.04, GNOME 46 on Xorg, Ubuntu Dock). The tray icon counter and the urgency flash work, only the launcher badge is missing. Download progress on the dock icon is affected by the same root cause.

Related: #2620, #2643 (renderer/tray fixes — confirmed working, see evidence).

## Root cause (two stacked issues)

1. **Electron's `app.setBadgeCount()` is a silent no-op on Linux packagings.** Its implementation `dlopen`s `libunity` at runtime, neither the snap, the deb nor the AppImage ship it. With `--enable-logging`, the renderer pipeline from #2643 does its job (`[TRAY_DIAG]` shows `0 → 1 → 0` on mark-unread/read), while `dbus-monitor` captures **zero** `com.canonical.Unity.LauncherEntry.Update` signals from the app.

2. **`launcherEntryEmitter` hardcodes `application://teams-for-linux.desktop`.** snapd exports the desktop file to the host as `teams-for-linux_teams-for-linux.desktop` (Flatpak: `<app-id>.desktop`). Ubuntu Dock / Dash-to-Dock match the signal on that URI and drop anything they cannot resolve, with no error. Emitting both URIs by hand from a test script confirms it: only the snap-style URI paints a badge.

I first tried staging `libunity9` into the snap so Electron's own path would work, it kept pulling further missing pieces (`libunity-protocol-private.so.0` outside the loader path, then `libicui18n.so.70`, which the electron-builder template deliberately excludes). The direct D-Bus route the project already uses for download progress is simpler and packaging-independent.

## Fix

- `launcherEntryEmitter`: derive the desktop URI from `app.name` plus `SNAP_INSTANCE_NAME` / `FLATPAK_ID` (`computeDesktopUri`, unit-tested), computed lazily so a custom `class` (`app.setName`) is honoured.
- `index.js` `set-badge-count` handler: mirror the count over the emitter (`count`, `count-visible`). Electron's `setBadgeCount` call is kept for platforms where it works.
- `downloadManager/README.md`: document the emitter and the URI rule.

## Verification

Locally built snap installed with `--dangerous` on the setup above:
- Marking a chat unread paints the badge, opening it clears it.
- `dbus-monitor` shows the signals with `application://teams-for-linux_teams-for-linux.desktop`, `count=1/visible=true` then `count=0/visible=false`.
- `npm run lint` clean, `npm run test:unit` 641/641 (6 new tests for `computeDesktopUri`).

Not tested: Flatpak (URI derived from `FLATPAK_ID` per the Flatpak desktop-file convention) and KDE Plasma's LauncherEntry consumer.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62650617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<h3>Summary</h3>

- Uses Snap instance and package names for Snap desktop URIs.
- Uses the Flatpak application ID for Flatpak desktop URIs.
- Mirrors unread counts through LauncherEntry on Linux.
- Adds packaging and custom-class URI tests and updates the download-manager documentation.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Unread count or download progress] --> B[LauncherEntry emitter]
  B --> C{Packaging}
  C -->|Snap| D[SNAP_INSTANCE_NAME + SNAP_NAME]
  C -->|Flatpak| E[FLATPAK_ID]
  C -->|Other Linux| F[Electron app name]
  D --> G[Packaging-aware desktop URI]
  E --> G
  F --> G
  G --> H[LauncherEntry D-Bus Update]
  H --> I[Dock badge or progress]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(badge): keep the snap desktop basena..."](https://github.com/ismaelmartinez/teams-for-linux/commit/9206a94acec888ac21dbd8dd01ebdd8ca9891883)</sub>

<!-- /greptile_comment -->