### PR TITLE
chore(deps): bump js-yaml from 4.3.1 to 4.3.2 in both lockfiles

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -12681,9 +12681,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,9 +3847,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears Dependabot alerts [#234](https://github.com/IsmaelMartinez/teams-for-linux/security/dependabot/234) and [#235](https://github.com/IsmaelMartinez/teams-for-linux/security/dependabot/235) (GHSA-2883-xcg3-v3hh, high) for `js-yaml`.

`js-yaml` is transitive in both the root and `docs-site` manifests and neither pins it, so refreshing the lockfiles reaches the patched 4.3.2. The diff is exactly one line per lockfile — `js-yaml` 4.3.1 → 4.3.2, nothing added or removed, no `package.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6R6CVrzhym49tMAjf98Cm
