### PR TITLE
chore(deps-dev): bump electron from 42.9.3 to 43.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@electron/fuses": "^2.1.3",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.62.1",
-        "electron": "42.9.3",
+        "electron": "43.7.0",
         "electron-builder": "26.15.7",
         "eslint": "^10.10.0",
         "globals": "^17.12.0",
@@ -2386,9 +2386,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.9.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.9.3.tgz",
-      "integrity": "sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==",
+      "version": "43.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.7.0.tgz",
+      "integrity": "sha512-m98FUehwnoo6q2D9Mr+n602Natb2CRFeKD81GhTdJlKh/Iyud0R1X8hChjpaMBLSsIX9r2ZEFnz0sdIALiO9ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@electron/fuses": "^2.1.3",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "1.62.1",
-    "electron": "42.9.3",
+    "electron": "43.7.0",
     "electron-builder": "26.15.7",
     "eslint": "^10.10.0",
     "globals": "^17.12.0",


### PR DESCRIPTION
Bumps Electron 42.9.3 to 43.7.0 ahead of 42's 2026-10-20 end of life. 43 is the last series shipping prebuilt armv7l, and 43.5.1 carries the xdg-desktop-portal `desktopName` fix that 42's Chromium branch never got.

Lint clean, 674/674 unit tests green locally. Breaking-change audit and the two cosmetic Linux changes to eyeball are in #2927.

closes #2927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kEXVePs5Ebg91ZK8yvE9r

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63017490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The dependency update appears safe to merge, with no concrete compatibility, lockfile, security, or repository-rule issue identified.

<h3>Summary</h3>

- Preserves the exact-version dependency policy.
- Keeps the manifest and lockfile root dependency synchronized.
- Introduces no application-code or configuration changes.

<sub>Reviews (1) · Last reviewed commit: ["chore(deps-dev): bump electron from 42.9..."](https://github.com/ismaelmartinez/teams-for-linux/commit/817b1f9d0b7d1966716f8463b15dfbe2d037c784)</sub>

<!-- /greptile_comment -->